### PR TITLE
docs(browser): document PageHandle::url() and status_code() in page-operations

### DIFF
--- a/book/src/browser/page-operations.md
+++ b/book/src/browser/page-operations.md
@@ -191,8 +191,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("{count} products found");
 
     let url = page.url().await?;
-    let status = page.status_code()?.unwrap_or(0);
-    println!("{url} → HTTP {status}");
+    let status = page.status_code()?;
+    match status {
+        Some(code) => println!("{url} → HTTP {code}"),
+        None => println!("{url} → HTTP status unknown"),
+    }
 
     let html = page.content().await?;
     // … pass html to an AI extraction node …

--- a/book/src/browser/page-operations.md
+++ b/book/src/browser/page-operations.md
@@ -47,7 +47,9 @@ let title = page.title().await?;
 // Current URL (may differ from navigated URL after redirects)
 let url   = page.url().await?;
 
-// HTTP status code of the last navigation (None if no navigation yet)
+// HTTP status code of the last navigation, if available
+// (None if no navigation has committed yet, the URL is non-HTTP such as file://,
+//  or network events were not captured)
 if let Some(status) = page.status_code()? {
     println!("HTTP {status}");
 }

--- a/book/src/browser/page-operations.md
+++ b/book/src/browser/page-operations.md
@@ -46,6 +46,11 @@ let title = page.title().await?;
 
 // Current URL (may differ from navigated URL after redirects)
 let url   = page.url().await?;
+
+// HTTP status code of the last navigation (None if no navigation yet)
+if let Some(status) = page.status_code()? {
+    println!("HTTP {status}");
+}
 ```
 
 ---
@@ -182,6 +187,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let count: u32 = page.eval("document.querySelectorAll('.product').length").await?;
     println!("{count} products found");
+
+    let url = page.url().await?;
+    let status = page.status_code()?.unwrap_or(0);
+    println!("{url} → HTTP {status}");
 
     let html = page.content().await?;
     // … pass html to an AI extraction node …


### PR DESCRIPTION
## Summary

Updates the mdBook page-operations doc to cover the two methods added in v0.1.5.

### Changes

- **Reading page content** section: added `status_code()` example alongside the existing `url()` snippet
- **Complete example**: added `url()` + `status_code()` calls to the end-to-end walkthrough