### PR TITLE
security: deny unsafe_code in stygian-browser; fix env-var race in jobber tests

### DIFF
--- a/crates/stygian-browser/src/config.rs
+++ b/crates/stygian-browser/src/config.rs
@@ -978,6 +978,7 @@ mod tests {
 // cleanup to isolate side effects.
 
 #[cfg(test)]
+#[allow(unsafe_code)] // env::set_var / remove_var are unsafe in Rust ≥1.93; guarded by ENV_LOCK
 mod temp_env {
     use std::env;
     use std::ffi::OsStr;

--- a/crates/stygian-browser/src/lib.rs
+++ b/crates/stygian-browser/src/lib.rs
@@ -1,6 +1,7 @@
 //! # stygian-browser
 //!
 #![allow(clippy::multiple_crate_versions)]
+#![deny(unsafe_code)] // All unsafe usage is confined to #[cfg(test)] modules with explicit #[allow]
 //! High-performance, anti-detection browser automation library for Rust.
 //!
 //! Built on Chrome `DevTools` Protocol (CDP) via [`chromiumoxide`](https://github.com/mattsse/chromiumoxide)

--- a/crates/stygian-graph/src/adapters/graphql_plugins/jobber.rs
+++ b/crates/stygian-graph/src/adapters/graphql_plugins/jobber.rs
@@ -92,7 +92,9 @@ mod tests {
     #[test]
     fn default_auth_reads_env() {
         let key = "JOBBER_ACCESS_TOKEN";
-        let _guard = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var(key).ok();
         // SAFETY: ENV_LOCK serialises all env mutations in this module
         unsafe { std::env::set_var(key, "test-token-abc") };
@@ -114,7 +116,9 @@ mod tests {
     #[test]
     fn default_auth_absent_when_no_env() {
         let key = "JOBBER_ACCESS_TOKEN";
-        let _guard = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var(key).ok();
         // SAFETY: ENV_LOCK serialises all env mutations in this module
         unsafe { std::env::remove_var(key) };

--- a/crates/stygian-graph/src/adapters/graphql_plugins/jobber.rs
+++ b/crates/stygian-graph/src/adapters/graphql_plugins/jobber.rs
@@ -62,6 +62,10 @@ impl GraphQlTargetPlugin for JobberPlugin {
 #[allow(unsafe_code, clippy::expect_used)] // set_var/remove_var are unsafe in Rust ≥1.93; scoped to tests only
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serialise env-var mutations so parallel test threads don't race each other.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn plugin_name_is_jobber() {
@@ -88,8 +92,9 @@ mod tests {
     #[test]
     fn default_auth_reads_env() {
         let key = "JOBBER_ACCESS_TOKEN";
+        let _guard = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var(key).ok();
-        // SAFETY: single-threaded test; no concurrent env access
+        // SAFETY: ENV_LOCK serialises all env mutations in this module
         unsafe { std::env::set_var(key, "test-token-abc") };
 
         let auth = JobberPlugin.default_auth();
@@ -109,8 +114,9 @@ mod tests {
     #[test]
     fn default_auth_absent_when_no_env() {
         let key = "JOBBER_ACCESS_TOKEN";
+        let _guard = ENV_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         let prev = std::env::var(key).ok();
-        // SAFETY: single-threaded test; no concurrent env access
+        // SAFETY: ENV_LOCK serialises all env mutations in this module
         unsafe { std::env::remove_var(key) };
 
         assert!(JobberPlugin.default_auth().is_none());


### PR DESCRIPTION
## Security audit findings and fixes

### What was audited

- `cargo audit` — scanned all 542 transitive dependencies for known CVEs
- Checked for `unsafe` code in library source (including injection/code-execution vectors)
- Reviewed JS injection paths in `stealth.rs` (safe — uses `{:?}` debug formatting which escapes all string content)
- Reviewed Chrome launch in `browser.rs` (safe — args passed as `Vec<String>` to tokio process, no shell interpolation)
- Reviewed `page.eval()` (expected API surface — caller controls their own browser process)

### Known CVEs (already tracked in `deny.toml`, no fix available upstream)

| Advisory | Crate | Path | Status |
|---|---|---|---|
| RUSTSEC-2023-0071 | `rsa` | `sqlx-mysql` (pulled in even with only `postgres` feature) | No upstream fix |
| RUSTSEC-2025-0052 | `async-std` | `chromiumoxide` | Discontinued; no CDP library alternative |
| RUSTSEC-2025-0057 | `fxhash` | `scraper → selectors` | Unmaintained; must wait on upstream |
| RUSTSEC-2025-0119 | `number_prefix` | `indicatif` | Unmaintained transitive dep |

### Fixes in this PR

**1. `#![deny(unsafe_code)]` in `stygian-browser`** (`lib.rs`)
- `stygian-graph` already had this; now `stygian-browser` matches.
- All `unsafe` usage in `stygian-browser` is confined to `#[cfg(test)]` modules, each annotated with `#[allow(unsafe_code)]`.
- Added the corresponding `#[allow(unsafe_code)]` to the `temp_env` test helper in `config.rs`.

**2. Thread-safe env mutation in `jobber.rs` tests** (`adapters/graphql_plugins/jobber.rs`)
- The SAFETY comment on `default_auth_reads_env` and `default_auth_absent_when_no_env` claimed "single-threaded test" — incorrect, cargo test runs tests in parallel by default.
- Added `static ENV_LOCK: Mutex<()>` (same pattern as `config.rs`) so the two env-mutating tests serialise correctly.
- Updated SAFETY comments to reflect the actual invariant.