### PR TITLE
feat(graph): add RestApiAdapter and CloudflareCrawlAdapter (v0.1.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15] - 2026-03-13
+
+### Added
+
+- `stygian-graph`: `RestApiAdapter` — flexible REST JSON API adapter with 5 auth schemes (Bearer, Basic, API key header/query, none), 4 pagination strategies (none, offset, cursor, RFC 8288 Link header), dot-path JSON response extraction, configurable retries with exponential backoff, and 24 unit tests; registered as `"rest-api"`
+- `stygian-graph`: `CloudflareCrawlAdapter` — delegates whole-site crawling to the Cloudflare Browser Rendering `/crawl` endpoint (open beta); polls until complete, aggregates page results, configurable poll interval and job timeout; gated behind `cloudflare-crawl` feature flag
+- `examples/rest-api-scrape.toml` — example pipeline demonstrating unauthenticated GET, Bearer-auth + Link-header pagination, and API-key + cursor pagination patterns
+
+### Fixed
+
+- `stygian-graph`: resolved all `clippy -D warnings` lint failures in `rest_api.rs` and `cloudflare_crawl.rs` — `indexing_slicing`, `map_unwrap_or`, `manual_map`, `if_not_else`, `option_if_let_else`, `unnecessary_map_or`, `cast_possible_truncation`, `ignore_without_reason`, `panic` in tests
+
 ## [0.1.14] - 2026-03-04
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2751,9 +2751,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3674,7 +3674,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stygian-browser"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "base64",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-graph"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.14"
+version = "0.1.15"
 edition = "2024"
 rust-version = "1.93.1"
 authors = ["Nick Campbell <s0ma@protonmail.com>"]

--- a/README.md
+++ b/README.md
@@ -230,6 +230,6 @@ Built with:
 
 ---
 
-**Status**: Active development | Version 0.1.1 | Rust 2024 edition | 842 tests | Linux + macOS
+**Status**: Active development | Version 0.1.15 | Rust 2024 edition | 694 tests | Linux + macOS
 
 For detailed documentation, see the [project docs site](https://greysquirr3l.github.io/stygian).

--- a/book/src/browser/configuration.md
+++ b/book/src/browser/configuration.md
@@ -50,7 +50,7 @@ let config = BrowserConfig::builder()
 | Field | Type | Default | Description |
 |---|---|---|---|
 | `headless` | `bool` | `true` | Run without visible window |
-| `headless_mode` | `HeadlessMode` | `New` | `New` = `--headless=new` (same renderer as headed Chrome); `Legacy` = classic `--headless` (Chromium < 112 only) |
+| `headless_mode` | `HeadlessMode` | `New` | `New` = `--headless=new` (full Chromium rendering, default since Chrome 112, **only mode since Chrome 132**); `Legacy` = `chrome-headless-shell` / pre-112 `--headless` |
 | `window_size` | `Option<(u32, u32)>` | `(1920, 1080)` | Browser viewport dimensions |
 | `chrome_path` | `Option<PathBuf>` | auto-detect | Path to Chrome/Chromium binary |
 | `stealth_level` | `StealthLevel` | `Advanced` | Anti-detection level |
@@ -92,7 +92,7 @@ All config values can be overridden without touching source code:
 |---|---|---|
 | `STYGIAN_CHROME_PATH` | auto-detect | Path to Chrome/Chromium binary |
 | `STYGIAN_HEADLESS` | `true` | Set `false` for headed mode |
-| `STYGIAN_HEADLESS_MODE` | `new` | `new` (`--headless=new`) or `legacy` (classic `--headless`) |
+| `STYGIAN_HEADLESS_MODE` | `new` | `new` (`--headless=new`) or `legacy` (`chrome-headless-shell`; old `--headless` removed in Chrome 132) |
 | `STYGIAN_STEALTH_LEVEL` | `advanced` | `none`, `basic`, `advanced` |
 | `STYGIAN_POOL_MIN` | `2` | Minimum warm browsers |
 | `STYGIAN_POOL_MAX` | `10` | Maximum concurrent browsers |
@@ -160,9 +160,17 @@ let config = BrowserConfig::builder()
     .build();
 ```
 
-For Chromium < 112 (rare), fall back to the legacy mode:
+For Chromium ≥ 112 (all modern Chrome / Chromium builds), `New` is the right
+choice. `Legacy` targets are rare: pre-112 Chromium or the separately distributed
+`chrome-headless-shell` binary for lightweight CI workloads where full rendering
+fidelity is not required.
+
+> **Note:** As of Chrome 132 the old `--headless` flag is removed entirely.
+> `HeadlessMode::Legacy` now maps to `chrome-headless-shell` semantics — avoid it
+> unless you are explicitly targeting that binary.
 
 ```rust,no_run
+// Only needed for Chromium < 112 or chrome-headless-shell
 let config = BrowserConfig::builder()
     .headless_mode(HeadlessMode::Legacy)
     .build();

--- a/book/src/graph/adapters.md
+++ b/book/src/graph/adapters.md
@@ -36,6 +36,136 @@ let adapter = HttpAdapter::with_config(HttpConfig {
 
 ---
 
+## REST API Adapter
+
+Purpose-built for structured JSON REST APIs. Handles authentication, automatic
+multi-strategy pagination, JSON response extraction, and retry — without the caller
+needing to manage any of that manually.
+
+```rust
+use stygian_graph::adapters::rest_api::{RestApiAdapter, RestApiConfig};
+use stygian_graph::ports::{ScrapingService, ServiceInput};
+use serde_json::json;
+use std::time::Duration;
+
+let adapter = RestApiAdapter::with_config(RestApiConfig {
+    timeout:      Duration::from_secs(20),
+    max_retries:  3,
+    ..Default::default()
+});
+
+let input = ServiceInput {
+    url: "https://api.github.com/repos/rust-lang/rust/issues".to_string(),
+    params: json!({
+        "auth":       { "type": "bearer", "token": "${env:GITHUB_TOKEN}" },
+        "query":      { "state": "open", "per_page": "100" },
+        "pagination": { "strategy": "link_header", "max_pages": 10 },
+        "response":   { "data_path": "" }
+    }),
+};
+// let output = adapter.execute(input).await?;
+```
+
+**Registered service name**: `"rest-api"`
+
+### Config fields
+
+| Field | Default | Description |
+|---|---|---|
+| `timeout` | 30 s | Per-request timeout |
+| `max_retries` | 3 | Retry attempts on transient errors (`429`, `5xx`, network) |
+| `retry_base_delay` | 1 s | Base for exponential backoff |
+| `proxy_url` | `None` | HTTP/HTTPS/SOCKS5 proxy URL |
+
+### `ServiceInput.params` contract
+
+| Param | Required | Default | Description |
+|---|---|---|---|
+| `method` | — | `"GET"` | `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD` |
+| `body` | — | — | JSON body for `POST`/`PUT`/`PATCH` |
+| `body_raw` | — | — | Raw string body (takes precedence over `body`) |
+| `headers` | — | — | Extra request headers object |
+| `query` | — | — | Extra query string parameters object |
+| `accept` | — | `"application/json"` | `Accept` header |
+| `auth` | — | none | Authentication object (see below) |
+| `response.data_path` | — | full body | Dot path into the JSON response to extract |
+| `response.collect_as_array` | — | `false` | Force multi-page results into a JSON array |
+| `pagination.strategy` | — | `"none"` | `"none"`, `"offset"`, `"cursor"`, `"link_header"` |
+| `pagination.max_pages` | — | `1` | Maximum pages to fetch |
+
+### Authentication
+
+```toml
+# Bearer token
+[nodes.params.auth]
+type  = "bearer"
+token = "${env:API_TOKEN}"
+
+# HTTP Basic
+[nodes.params.auth]
+type     = "basic"
+username = "${env:API_USER}"
+password = "${env:API_PASS}"
+
+# API key in header
+[nodes.params.auth]
+type   = "api_key_header"
+header = "X-Api-Key"
+key    = "${env:API_KEY}"
+
+# API key in query string
+[nodes.params.auth]
+type  = "api_key_query"
+param = "api_key"
+key   = "${env:API_KEY}"
+```
+
+### Pagination strategies
+
+| Strategy | How it works | Best for |
+|---|---|---|
+| `"none"` | Single request | Simple endpoints |
+| `"offset"` | Increments `page_param` from `start_page` | REST APIs with `?page=N` |
+| `"cursor"` | Extracts next cursor from `cursor_field` (dot path), sends as `cursor_param` | GraphQL-REST hybrids, Stripe-style |
+| `"link_header"` | Follows RFC 8288 `Link: <url>; rel="next"` | GitHub API, GitLab API |
+
+#### Offset example
+
+```toml
+[nodes.params.pagination]
+strategy        = "offset"
+page_param      = "page"
+page_size_param = "per_page"
+page_size       = 100
+start_page      = 1
+max_pages       = 20
+```
+
+#### Cursor example
+
+```toml
+[nodes.params.pagination]
+strategy     = "cursor"
+cursor_param = "after"
+cursor_field = "meta.next_cursor"
+max_pages    = 50
+```
+
+### Output
+
+`ServiceOutput.data` — pretty-printed JSON string of the extracted data.
+
+`ServiceOutput.metadata`:
+
+```json
+{
+  "url":        "https://...",
+  "page_count": 3
+}
+```
+
+---
+
 ## Browser Adapter
 
 Delegates to `stygian-browser` for JavaScript-rendered pages. Requires the `browser`
@@ -260,3 +390,104 @@ let service = GraphQlService::new(GraphQlConfig::default(), Some(Arc::new(regist
 
 See the [GraphQL Plugins](./graphql-plugins.md) page for the full builder reference,
 `AuthPort` implementation guide, proactive cost throttling, and custom plugin examples.
+
+---
+
+## Cloudflare Browser Rendering adapter
+
+Submits a multi-page crawl job to the [Cloudflare Browser Rendering API](https://developers.cloudflare.com/browser-rendering/),
+polls until it completes, and returns the aggregated content. All page rendering is done
+inside Cloudflare's infrastructure — no local Chrome binary needed.
+
+**Feature flag**: `cloudflare-crawl` (not included in `default` or `browser`; add it
+explicitly or use `full`).
+
+### Quick start
+
+```toml
+# Cargo.toml
+[dependencies]
+stygian-graph = { version = "0.1", features = ["cloudflare-crawl"] }
+```
+
+```rust
+use stygian_graph::adapters::cloudflare_crawl::{
+    CloudflareCrawlAdapter, CloudflareCrawlConfig,
+};
+use std::time::Duration;
+
+let adapter = CloudflareCrawlAdapter::with_config(CloudflareCrawlConfig {
+    poll_interval: Duration::from_secs(3),
+    job_timeout:   Duration::from_secs(120),
+    ..Default::default()
+});
+```
+
+**Registered service name**: `"cloudflare-crawl"`
+
+### `ServiceInput.params` contract
+
+All per-request options are passed via `ServiceInput.params`. `account_id` and
+`api_token` are **required**; the rest are optional and forwarded verbatim to the
+Cloudflare API.
+
+| Param key | Required | Default | Description |
+|---|---|---|---|
+| `account_id` | ✅ | — | Cloudflare account ID |
+| `api_token` | ✅ | — | Cloudflare API token with Browser Rendering permission |
+| `output_format` | — | `"markdown"` | `"markdown"`, `"html"`, or `"raw"` |
+| `max_depth` | — | API default | Maximum crawl depth from the seed URL |
+| `max_pages` | — | API default | Maximum pages to crawl |
+| `url_pattern` | — | API default | Regex or glob restricting which URLs are followed |
+| `modified_since` | — | API default | ISO-8601 timestamp; skip pages not modified since |
+| `max_age_seconds` | — | API default | Skip cached pages older than this many seconds |
+| `static_mode` | — | `false` | Set `"true"` to skip JS execution (faster, static HTML only) |
+
+### Config fields
+
+| Field | Default | Description |
+|---|---|---|
+| `poll_interval` | 2 s | How often to poll for job completion |
+| `job_timeout` | 5 min | Hard timeout per crawl job; returns `ServiceError::Timeout` if exceeded |
+
+### Output
+
+`ServiceOutput.data` contains the page content of all crawled pages joined by newlines.
+`ServiceOutput.metadata` is a JSON object:
+
+```json
+{
+  "job_id":    "some-uuid",
+  "pages":     12,
+  "url_count": 12
+}
+```
+
+### TOML pipeline usage
+
+```toml
+[[nodes]]
+id     = "crawl"
+type   = "scrape"
+target = "https://docs.example.com"
+
+  [nodes.params]
+  account_id    = "${env:CF_ACCOUNT_ID}"
+  api_token     = "${env:CF_API_TOKEN}"
+  output_format = "markdown"
+  max_depth     = "3"
+  max_pages     = "50"
+  url_pattern   = "https://docs.example.com/**"
+
+  [nodes.service]
+  name = "cloudflare-crawl"
+```
+
+### Error mapping
+
+| Condition | `StygianError` variant |
+|---|---|
+| Missing `account_id` or `api_token` | `ServiceError::Unavailable` |
+| Cloudflare API non-2xx | `ServiceError::Unavailable` (with CF error code) |
+| Job still pending after `job_timeout` | `ServiceError::Timeout` |
+| Unexpected response shape | `ServiceError::InvalidResponse` |

--- a/book/src/graph/graphql-plugins.md
+++ b/book/src/graph/graphql-plugins.md
@@ -195,6 +195,137 @@ same view of remaining points.
 
 ---
 
+## Request rate limiting
+
+While cost throttling manages *point budgets* returned by the server, request rate
+limiting operates entirely client-side: it counts (or tokens) before each request
+leaves the process. The two systems are complementary and can both be active at the
+same time.
+
+Enable rate limiting by returning a `RateLimitConfig` from
+`GraphQlTargetPlugin::rate_limit_config()`. The default implementation returns `None`
+(disabled).
+
+### RateLimitConfig
+
+```rust
+use std::time::Duration;
+use stygian_graph::ports::graphql_plugin::{RateLimitConfig, RateLimitStrategy};
+
+let config = RateLimitConfig {
+    max_requests: 100,                          // requests allowed per window
+    window:       Duration::from_secs(60),      // rolling window duration
+    max_delay_ms: 30_000,                       // hard cap on pre-flight sleep (ms)
+    strategy:     RateLimitStrategy::SlidingWindow,  // algorithm (see below)
+};
+```
+
+| Field | Default | Description |
+|---|---|---|
+| `max_requests` | `100` | Maximum requests allowed inside any rolling `window` |
+| `window` | `60 s` | Rolling window duration |
+| `max_delay_ms` | `30 000` | Maximum pre-flight sleep before giving up with an error |
+| `strategy` | `SlidingWindow` | Rate-limiting algorithm — see below |
+
+### RateLimitStrategy
+
+`RateLimitStrategy` selects which algorithm protects outgoing requests. Both variants
+also honour server-returned `Retry-After` headers regardless of which is active.
+
+| Variant | Behaviour | Best for |
+|---|---|---|
+| `SlidingWindow` *(default)* | Counts requests in a rolling time window; blocks new requests once `max_requests` is reached until old timestamps expire | APIs with strict fixed-window quotas (e.g. "100 req / 60 s") |
+| `TokenBucket` | Refills tokens at `max_requests / window` per second; absorbed bursts up to `max_requests` capacity before blocking | APIs that advertise burst allowances — allows short spikes then throttles gracefully |
+
+#### Sliding window example
+
+```rust
+use std::time::Duration;
+use stygian_graph::ports::graphql_plugin::{RateLimitConfig, RateLimitStrategy};
+
+// GitHub GraphQL API: 5 000 points/hour with a hard req/s ceiling
+let config = RateLimitConfig {
+    max_requests: 10,
+    window:       Duration::from_secs(1),
+    max_delay_ms: 5_000,
+    strategy:     RateLimitStrategy::SlidingWindow,
+};
+```
+
+#### Token bucket example
+
+```rust
+use std::time::Duration;
+use stygian_graph::ports::graphql_plugin::{RateLimitConfig, RateLimitStrategy};
+
+// Shopify Admin API: 2 req/s sustained, bursts up to 40
+let config = RateLimitConfig {
+    max_requests: 40,                        // bucket depth = burst capacity
+    window:       Duration::from_secs(20),   // refill rate = 40 / 20 = 2 req/s
+    max_delay_ms: 30_000,
+    strategy:     RateLimitStrategy::TokenBucket,
+};
+```
+
+### Wiring into a custom plugin
+
+```rust
+use std::time::Duration;
+use stygian_graph::ports::graphql_plugin::{
+    GraphQlTargetPlugin, RateLimitConfig, RateLimitStrategy,
+};
+
+pub struct ShopifyPlugin { token: String }
+
+impl GraphQlTargetPlugin for ShopifyPlugin {
+    fn name(&self)     -> &str { "shopify" }
+    fn endpoint(&self) -> &str { "https://my-store.myshopify.com/admin/api/2025-01/graphql.json" }
+
+    fn rate_limit_config(&self) -> Option<RateLimitConfig> {
+        Some(RateLimitConfig {
+            max_requests: 40,
+            window:       Duration::from_secs(20),
+            max_delay_ms: 30_000,
+            strategy:     RateLimitStrategy::TokenBucket,
+        })
+    }
+    // ...other methods omitted
+}
+```
+
+For `GenericGraphQlPlugin`, pass it via the builder:
+
+```rust
+use stygian_graph::adapters::graphql_plugins::generic::GenericGraphQlPlugin;
+use stygian_graph::ports::graphql_plugin::{RateLimitConfig, RateLimitStrategy};
+use std::time::Duration;
+
+let plugin = GenericGraphQlPlugin::builder()
+    .name("shopify")
+    .endpoint("https://my-store.myshopify.com/admin/api/2025-01/graphql.json")
+    .bearer_auth("${env:SHOPIFY_ACCESS_TOKEN}")
+    .rate_limit(RateLimitConfig {
+        max_requests: 40,
+        window:       Duration::from_secs(20),
+        max_delay_ms: 30_000,
+        strategy:     RateLimitStrategy::TokenBucket,
+    })
+    .build()
+    .expect("name and endpoint are required");
+```
+
+### Rate limiting vs cost throttling
+
+| | Request rate limiting | Cost throttling |
+|---|---|---|
+| What it counts | Raw request count | Query complexity points |
+| Data source | Local state only | Server `extensions.cost` response |
+| Algorithm options | Sliding window, token bucket | Leaky-bucket (token refill) |
+| Reactive to 429? | Yes — honours `Retry-After` | Yes — exponential back-off |
+| Enabled by | `rate_limit_config()` | `cost_throttle_config()` |
+
+---
+
 ## Writing a custom plugin
 
 For complex APIs — multi-tenant endpoints, per-request header mutations, non-standard

--- a/book/src/reference/env-vars.md
+++ b/book/src/reference/env-vars.md
@@ -11,7 +11,7 @@ variables. No recompilation required.
 |---|---|---|
 | `STYGIAN_CHROME_PATH` | auto-detect | Absolute path to Chrome or Chromium binary |
 | `STYGIAN_HEADLESS` | `true` | `false` for headed mode (displays browser window) |
-| `STYGIAN_HEADLESS_MODE` | `new` | `new` (`--headless=new`) or `legacy` (classic `--headless`; Chromium < 112 only) |
+| `STYGIAN_HEADLESS_MODE` | `new` | `new` (`--headless=new`) or `legacy` (`chrome-headless-shell`; old `--headless` removed in Chrome 132) |
 | `STYGIAN_STEALTH_LEVEL` | `advanced` | `none`, `basic`, or `advanced` |
 | `STYGIAN_POOL_MIN` | `2` | Minimum warm browser instances |
 | `STYGIAN_POOL_MAX` | `10` | Maximum concurrent browser instances |

--- a/crates/stygian-graph/Cargo.toml
+++ b/crates/stygian-graph/Cargo.toml
@@ -89,13 +89,15 @@ default = ["browser"]
 # Include browser automation support
 browser = ["dep:stygian-browser"]
 # Full feature set
-full = ["browser", "api", "wasm-plugins", "postgres"]
+full = ["browser", "api", "wasm-plugins", "postgres", "cloudflare-crawl"]
 # REST API server
 api = []
 # WASM plugin system (requires wasmtime — significant compile time)
 wasm-plugins = ["dep:wasmtime"]
 # PostgreSQL storage adapter
 postgres = ["dep:sqlx"]
+# Cloudflare Browser Rendering crawl adapter
+cloudflare-crawl = []
 
 [[bin]]
 name = "stygian"

--- a/crates/stygian-graph/src/adapters.rs
+++ b/crates/stygian-graph/src/adapters.rs
@@ -9,6 +9,9 @@
 /// HTTP scraping adapter with anti-bot capabilities
 pub mod http;
 
+/// REST API adapter — JSON APIs with auth, pagination, and data extraction
+pub mod rest_api;
+
 /// AI provider adapters
 pub mod ai;
 
@@ -49,6 +52,10 @@ pub mod graphql_plugins;
 
 /// WASM plugin adapter (feature = "wasm-plugins")
 pub mod wasm_plugin;
+
+/// Cloudflare Browser Rendering crawl adapter (feature = "cloudflare-crawl")
+#[cfg(feature = "cloudflare-crawl")]
+pub mod cloudflare_crawl;
 
 /// Output format helpers — CSV, JSONL, JSON
 pub mod output_format;

--- a/crates/stygian-graph/src/adapters/cloudflare_crawl.rs
+++ b/crates/stygian-graph/src/adapters/cloudflare_crawl.rs
@@ -1,0 +1,580 @@
+//! Cloudflare Browser Rendering crawl adapter
+//!
+//! Delegates whole-site crawling to Cloudflare's `/crawl` endpoint (open beta).
+//! Useful when managed, infrastructure-free crawling is preferred over running a
+//! local Chrome pool — trades stealth/anti-detection capability for zero operational
+//! overhead on the scraping infrastructure.
+//!
+//! # Feature flag
+//!
+//! Gated behind `cloudflare-crawl`. Enable in `Cargo.toml`:
+//!
+//! ```toml
+//! [dependencies]
+//! stygian-graph = { version = "...", features = ["cloudflare-crawl"] }
+//! ```
+//!
+//! # Example
+//!
+//! ```no_run
+//! use stygian_graph::adapters::cloudflare_crawl::CloudflareCrawlAdapter;
+//! use stygian_graph::ports::{ScrapingService, ServiceInput};
+//! use serde_json::json;
+//!
+//! # tokio::runtime::Runtime::new().unwrap().block_on(async {
+//! let adapter = CloudflareCrawlAdapter::new();
+//! let input = ServiceInput {
+//!     url: "https://docs.example.com".to_string(),
+//!     params: json!({
+//!         "account_id": "abc123",
+//!         "api_token":  "my-cf-token",
+//!         "output_format": "markdown",
+//!         "max_depth": 3,
+//!         "max_pages": 50,
+//!     }),
+//! };
+//! // let output = adapter.execute(input).await.unwrap();
+//! # });
+//! ```
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::{Value, json};
+use tokio::time::{interval, timeout};
+use tracing::{debug, info, warn};
+
+use crate::domain::error::{Result, ServiceError, StygianError};
+use crate::ports::{ScrapingService, ServiceInput, ServiceOutput};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Base URL for the Cloudflare Browser Rendering API.
+const CF_API_BASE: &str = "https://api.cloudflare.com/client/v4/accounts";
+
+/// Default interval between poll attempts.
+const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Default maximum time to wait for a crawl job to complete.
+const DEFAULT_JOB_TIMEOUT: Duration = Duration::from_secs(300);
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+/// Configuration for the Cloudflare crawl adapter.
+///
+/// All fields except `account_id` and `api_token` are optional. They map to the
+/// corresponding fields in `ServiceInput.params` and can be overridden per-request.
+///
+/// # Example
+///
+/// ```
+/// use stygian_graph::adapters::cloudflare_crawl::CloudflareCrawlConfig;
+/// use std::time::Duration;
+///
+/// let config = CloudflareCrawlConfig {
+///     poll_interval: Duration::from_secs(3),
+///     job_timeout:   Duration::from_secs(120),
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct CloudflareCrawlConfig {
+    /// How often to poll for job completion (default: 2 s).
+    pub poll_interval: Duration,
+    /// Hard timeout for waiting on any single crawl job (default: 5 min).
+    pub job_timeout: Duration,
+}
+
+impl Default for CloudflareCrawlConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            job_timeout: DEFAULT_JOB_TIMEOUT,
+        }
+    }
+}
+
+// ─── Crawler ──────────────────────────────────────────────────────────────────
+
+/// Cloudflare Browser Rendering crawl adapter.
+///
+/// Submits a seed URL to the Cloudflare `/crawl` endpoint, polls until the job
+/// completes, then aggregates all page results into a single [`ServiceOutput`].
+///
+/// Required [`ServiceInput::params`] fields: `account_id`, `api_token`.
+///
+/// # Example
+///
+/// ```no_run
+/// use stygian_graph::adapters::cloudflare_crawl::CloudflareCrawlAdapter;
+/// use stygian_graph::ports::{ScrapingService, ServiceInput};
+/// use serde_json::json;
+///
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// let adapter = CloudflareCrawlAdapter::new();
+/// let input = ServiceInput {
+///     url: "https://docs.example.com".to_string(),
+///     params: json!({
+///         "account_id": "abc123",
+///         "api_token":  "my-cf-token",
+///         "max_depth":  2,
+///     }),
+/// };
+/// // let output = adapter.execute(input).await.unwrap();
+/// # });
+/// ```
+pub struct CloudflareCrawlAdapter {
+    client: Client,
+    config: CloudflareCrawlConfig,
+}
+
+impl CloudflareCrawlAdapter {
+    /// Create an adapter with default configuration and a shared reqwest client.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_graph::adapters::cloudflare_crawl::CloudflareCrawlAdapter;
+    /// let adapter = CloudflareCrawlAdapter::new();
+    /// ```
+    pub fn new() -> Self {
+        Self::with_config(CloudflareCrawlConfig::default())
+    }
+
+    /// Create an adapter with custom poll / timeout settings.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_graph::adapters::cloudflare_crawl::{
+    ///     CloudflareCrawlAdapter, CloudflareCrawlConfig,
+    /// };
+    /// use std::time::Duration;
+    ///
+    /// let adapter = CloudflareCrawlAdapter::with_config(CloudflareCrawlConfig {
+    ///     poll_interval: Duration::from_secs(5),
+    ///     job_timeout:   Duration::from_secs(600),
+    /// });
+    /// ```
+    pub fn with_config(config: CloudflareCrawlConfig) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(60))
+            .build()
+            // reqwest::ClientBuilder::build only fails on TLS init; that is not recoverable.
+            .unwrap_or_default();
+        Self { client, config }
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    /// Extract a required string field from `params`, returning a `ServiceError`
+    /// with a descriptive message if missing or not a string.
+    fn required_str<'a>(params: &'a Value, key: &str) -> Result<&'a str> {
+        params[key].as_str().ok_or_else(|| {
+            ServiceError::Unavailable(format!("missing required param: {key}")).into()
+        })
+    }
+
+    /// POST the crawl job and return the `job_id`.
+    #[allow(clippy::indexing_slicing)]
+    async fn submit_job(
+        &self,
+        account_id: &str,
+        api_token: &str,
+        seed_url: &str,
+        params: &Value,
+    ) -> Result<String> {
+        let url = format!("{CF_API_BASE}/{account_id}/browser-rendering/crawl");
+
+        let mut body = json!({ "url": seed_url });
+
+        // Optional fields — copy from params if present.
+        for key in &[
+            "output_format",
+            "max_depth",
+            "max_pages",
+            "url_pattern",
+            "modified_since",
+            "max_age_seconds",
+            "static_mode",
+        ] {
+            if !params[key].is_null() {
+                body[key] = params[key].clone();
+            }
+        }
+
+        debug!(%seed_url, %account_id, "Submitting Cloudflare crawl job");
+
+        let resp = self
+            .client
+            .post(&url)
+            .bearer_auth(api_token)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| ServiceError::Unavailable(format!("CF crawl submit failed: {e}")))?;
+
+        let status = resp.status();
+        let resp_body: Value = resp
+            .json()
+            .await
+            .map_err(|e| ServiceError::InvalidResponse(format!("CF crawl response parse: {e}")))?;
+
+        if !status.is_success() {
+            let msg = extract_cf_error(&resp_body);
+            return Err(
+                ServiceError::Unavailable(format!("CF crawl submit HTTP {status}: {msg}")).into(),
+            );
+        }
+
+        resp_body["result"]["id"]
+            .as_str()
+            .ok_or_else(|| {
+                ServiceError::InvalidResponse("CF crawl submit: no job id in response".to_string())
+                    .into()
+            })
+            .map(str::to_string)
+    }
+
+    /// Poll `GET …/crawl/{job_id}` until status is `"complete"` or `"failed"`,
+    /// respecting `config.job_timeout` and `config.poll_interval`.
+    #[allow(clippy::indexing_slicing)]
+    async fn poll_job(&self, account_id: &str, api_token: &str, job_id: &str) -> Result<Value> {
+        let url = format!("{CF_API_BASE}/{account_id}/browser-rendering/crawl/{job_id}");
+        let poll_interval = self.config.poll_interval;
+        let job_timeout = self.config.job_timeout;
+
+        let poll = async {
+            let mut ticker = interval(poll_interval);
+            loop {
+                ticker.tick().await;
+                debug!(%job_id, "Polling Cloudflare crawl job");
+
+                let resp = self
+                    .client
+                    .get(&url)
+                    .bearer_auth(api_token)
+                    .send()
+                    .await
+                    .map_err(|e| ServiceError::Unavailable(format!("CF crawl poll failed: {e}")))?;
+
+                let http_status = resp.status();
+                let body: Value = resp
+                    .json()
+                    .await
+                    .map_err(|e| ServiceError::InvalidResponse(format!("CF poll parse: {e}")))?;
+
+                if !http_status.is_success() {
+                    let msg = extract_cf_error(&body);
+                    return Err::<Value, crate::domain::error::StygianError>(
+                        ServiceError::Unavailable(format!(
+                            "CF crawl poll HTTP {http_status}: {msg}"
+                        ))
+                        .into(),
+                    );
+                }
+
+                match body["result"]["status"].as_str() {
+                    Some("complete") => {
+                        info!(%job_id, "Cloudflare crawl job complete");
+                        return Ok(body);
+                    }
+                    Some("failed") => {
+                        let msg = extract_cf_error(&body);
+                        return Err(ServiceError::Unavailable(format!(
+                            "CF crawl job failed: {msg}"
+                        ))
+                        .into());
+                    }
+                    Some(other) => {
+                        debug!(%job_id, status = %other, "Crawl job in progress");
+                    }
+                    None => {
+                        warn!(%job_id, "CF crawl poll: missing status field");
+                    }
+                }
+            }
+        };
+
+        timeout(job_timeout, poll).await.map_err(|_| {
+            StygianError::from(ServiceError::Timeout(
+                u64::try_from(job_timeout.as_millis()).unwrap_or(u64::MAX),
+            ))
+        })?
+    }
+
+    /// Aggregate completed job results into `(data, metadata)`.
+    #[allow(clippy::indexing_slicing)]
+    fn collect_output(completed: &Value, job_id: &str, output_format: &str) -> (String, Value) {
+        let pages: &[Value] = completed["result"]["pages"]
+            .as_array()
+            .map_or(&[], Vec::as_slice);
+
+        let data = pages
+            .iter()
+            .filter_map(|p| p["content"].as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+
+        let metadata = json!({
+            "job_id":        job_id,
+            "pages_crawled": pages.len(),
+            "output_format": output_format,
+        });
+
+        (data, metadata)
+    }
+}
+
+impl Default for CloudflareCrawlAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl ScrapingService for CloudflareCrawlAdapter {
+    /// Submit a crawl job to Cloudflare, poll until complete, and return
+    /// aggregated page content.
+    ///
+    /// # Params
+    ///
+    /// `input.params` must contain `account_id` and `api_token`. Optional
+    /// fields: `output_format`, `max_depth`, `max_pages`, `url_pattern`,
+    /// `modified_since`, `max_age_seconds`, `static_mode`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ServiceError::Unavailable`] for API errors, and
+    /// [`ServiceError::Timeout`] if the job does not complete within
+    /// `config.job_timeout`.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use stygian_graph::adapters::cloudflare_crawl::CloudflareCrawlAdapter;
+    /// use stygian_graph::ports::{ScrapingService, ServiceInput};
+    /// use serde_json::json;
+    ///
+    /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+    /// let adapter = CloudflareCrawlAdapter::new();
+    /// let input = ServiceInput {
+    ///     url: "https://docs.example.com".to_string(),
+    ///     params: json!({
+    ///         "account_id": "abc123",
+    ///         "api_token":  "my-token",
+    ///     }),
+    /// };
+    /// // let output = adapter.execute(input).await.unwrap();
+    /// # });
+    /// ```
+    async fn execute(&self, input: ServiceInput) -> Result<ServiceOutput> {
+        let params = &input.params;
+
+        let account_id = Self::required_str(params, "account_id")?.to_string();
+        let api_token = Self::required_str(params, "api_token")?.to_string();
+        let output_format = params["output_format"]
+            .as_str()
+            .unwrap_or("markdown")
+            .to_string();
+
+        let job_id = self
+            .submit_job(&account_id, &api_token, &input.url, params)
+            .await?;
+
+        let completed = self.poll_job(&account_id, &api_token, &job_id).await?;
+
+        let (data, metadata) = Self::collect_output(&completed, &job_id, &output_format);
+
+        Ok(ServiceOutput { data, metadata })
+    }
+
+    fn name(&self) -> &'static str {
+        "cloudflare-crawl"
+    }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Extract a human-readable error message from a Cloudflare API response body.
+///
+/// Checks `errors[0].message` first, falls back to the raw body.
+///
+/// # Example
+///
+/// ```
+/// use serde_json::json;
+/// use stygian_graph::adapters::cloudflare_crawl::extract_cf_error;
+///
+/// let body = json!({ "errors": [{ "code": 1000, "message": "Invalid token" }] });
+/// assert_eq!(extract_cf_error(&body), "1000: Invalid token");
+/// ```
+pub fn extract_cf_error(body: &Value) -> String {
+    if let Some(errors) = body["errors"].as_array()
+        && let Some(first) = errors.first()
+    {
+        let code = first["code"].as_u64().unwrap_or(0);
+        let msg = first["message"].as_str().unwrap_or("unknown");
+        return format!("{code}: {msg}");
+    }
+    body.to_string()
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── extract_cf_error ──────────────────────────────────────────────────
+
+    #[test]
+    fn extract_cf_error_formats_code_and_message() {
+        let body = json!({ "errors": [{ "code": 1000, "message": "Invalid token" }] });
+        assert_eq!(extract_cf_error(&body), "1000: Invalid token");
+    }
+
+    #[test]
+    fn extract_cf_error_falls_back_to_raw_body() {
+        let body = json!({ "success": false });
+        // No 'errors' key — should return the raw JSON string.
+        let result = extract_cf_error(&body);
+        assert!(result.contains("success"));
+    }
+
+    #[test]
+    fn extract_cf_error_handles_empty_errors_array() {
+        let body = json!({ "errors": [] });
+        let result = extract_cf_error(&body);
+        // Falls back to raw body when errors array is empty.
+        assert!(result.contains("errors"));
+    }
+
+    // ── required_str ─────────────────────────────────────────────────────
+
+    #[test]
+    fn required_str_returns_value_when_present() {
+        let params = json!({ "account_id": "abc123" });
+        let result = CloudflareCrawlAdapter::required_str(&params, "account_id");
+        assert_eq!(result.unwrap(), "abc123");
+    }
+
+    #[test]
+    fn required_str_errors_when_missing() {
+        let params = json!({});
+        let result = CloudflareCrawlAdapter::required_str(&params, "account_id");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn required_str_errors_when_not_a_string() {
+        let params = json!({ "account_id": 42 });
+        let result = CloudflareCrawlAdapter::required_str(&params, "account_id");
+        assert!(result.is_err());
+    }
+
+    // ── collect_output ────────────────────────────────────────────────────
+
+    #[test]
+    fn collect_output_joins_page_content() {
+        let completed = json!({
+            "result": {
+                "status": "complete",
+                "pages": [
+                    { "url": "https://example.com/a", "content": "# Page A" },
+                    { "url": "https://example.com/b", "content": "# Page B" },
+                ]
+            }
+        });
+
+        let (data, meta) = CloudflareCrawlAdapter::collect_output(&completed, "job-1", "markdown");
+
+        assert!(data.contains("# Page A"));
+        assert!(data.contains("# Page B"));
+        assert_eq!(meta["job_id"], "job-1");
+        assert_eq!(meta["pages_crawled"], 2);
+        assert_eq!(meta["output_format"], "markdown");
+    }
+
+    #[test]
+    fn collect_output_handles_no_pages() {
+        let completed = json!({ "result": { "status": "complete", "pages": [] } });
+        let (data, meta) = CloudflareCrawlAdapter::collect_output(&completed, "job-2", "html");
+        assert_eq!(data, "");
+        assert_eq!(meta["pages_crawled"], 0);
+    }
+
+    #[test]
+    fn collect_output_skips_pages_without_content() {
+        let completed = json!({
+            "result": {
+                "pages": [
+                    { "url": "https://example.com/a" },        // no 'content'
+                    { "url": "https://example.com/b", "content": "hello" },
+                ]
+            }
+        });
+        let (data, _) = CloudflareCrawlAdapter::collect_output(&completed, "job-3", "markdown");
+        assert_eq!(data, "hello");
+    }
+
+    // ── execute — missing params ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn execute_missing_account_id_returns_error() {
+        let adapter = CloudflareCrawlAdapter::new();
+        let input = ServiceInput {
+            url: "https://example.com".to_string(),
+            params: json!({ "api_token": "tok" }),
+        };
+        assert!(adapter.execute(input).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn execute_missing_api_token_returns_error() {
+        let adapter = CloudflareCrawlAdapter::new();
+        let input = ServiceInput {
+            url: "https://example.com".to_string(),
+            params: json!({ "account_id": "acc" }),
+        };
+        assert!(adapter.execute(input).await.is_err());
+    }
+
+    // ── Integration tests (real Cloudflare account, skipped by default) ───
+
+    /// End-to-end integration test.
+    ///
+    /// Requires `CF_ACCOUNT_ID` and `CF_API_TOKEN` to be set and a valid
+    /// Cloudflare Browser Rendering subscription.
+    #[ignore = "requires real Cloudflare credentials and subscription"]
+    #[tokio::test]
+    async fn integration_real_crawl() {
+        let account_id =
+            std::env::var("CF_ACCOUNT_ID").expect("CF_ACCOUNT_ID must be set for integration test");
+        let api_token =
+            std::env::var("CF_API_TOKEN").expect("CF_API_TOKEN must be set for integration test");
+
+        let adapter = CloudflareCrawlAdapter::with_config(CloudflareCrawlConfig {
+            poll_interval: Duration::from_secs(3),
+            job_timeout: Duration::from_secs(120),
+        });
+
+        let input = ServiceInput {
+            url: "https://example.com".to_string(),
+            params: json!({
+                "account_id":    account_id,
+                "api_token":     api_token,
+                "output_format": "markdown",
+                "max_depth":     1,
+                "max_pages":     5,
+            }),
+        };
+
+        let output = adapter.execute(input).await.expect("crawl should succeed");
+        assert!(!output.data.is_empty(), "expected page content");
+        assert_eq!(output.metadata["output_format"], "markdown");
+    }
+}

--- a/crates/stygian-graph/src/adapters/graphql_rate_limit.rs
+++ b/crates/stygian-graph/src/adapters/graphql_rate_limit.rs
@@ -1,13 +1,20 @@
-//! Sliding-window request-count rate limiter for GraphQL API targets.
+//! Request-count rate limiter for GraphQL API targets with pluggable algorithms.
 //!
-//! Limits outgoing requests to `max_requests` in any rolling `window` duration.
-//! Before each request [`rate_limit_acquire`] is called; it records the current
-//! timestamp and sleeps until the oldest in-window request expires if the
-//! window is already full.
+//! Two strategies are supported via [`RateLimitStrategy`]:
+//!
+//! - **[`SlidingWindow`](RateLimitStrategy::SlidingWindow)** — limits outgoing requests to
+//!   `max_requests` in any rolling `window` duration.  Before each request
+//!   [`rate_limit_acquire`] is called; it records the current timestamp and sleeps
+//!   until the oldest in-window request expires if the window is already full.
+//!
+//! - **[`TokenBucket`](RateLimitStrategy::TokenBucket)** — refills tokens at a steady rate
+//!   (`max_requests / window`); short bursts are absorbed by the bucket capacity before
+//!   the rate is enforced.  Computes the exact wait time required to accumulate the next
+//!   token instead of sleeping speculatively.
 //!
 //! A server-returned `Retry-After` value can be applied via
 //! [`rate_limit_retry_after`], which imposes a hard block until the indicated
-//! instant irrespective of the sliding window state.
+//! instant irrespective of the active algorithm.
 //!
 //! Operates in parallel with [`graphql_throttle`](crate::adapters::graphql_throttle)
 //! (leaky-bucket cost throttle).  Both can be active simultaneously.
@@ -20,16 +27,30 @@ use tokio::sync::Mutex;
 
 /// Re-export — canonical definition lives in the ports layer.
 pub use crate::ports::graphql_plugin::RateLimitConfig;
+pub use crate::ports::graphql_plugin::RateLimitStrategy;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WindowState — per-strategy mutable inner state
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Per-strategy mutable state held inside [`RequestWindow`].
+#[derive(Debug)]
+enum WindowState {
+    /// A rolling `VecDeque` of request timestamps for the sliding-window algorithm.
+    Sliding { timestamps: VecDeque<Instant> },
+    /// Token count and last-refill timestamp for the token-bucket algorithm.
+    TokenBucket { tokens: f64, last_refill: Instant },
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // RequestWindow
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Mutable inner state — a sliding window of request timestamps plus an
-/// optional hard block set by a server-returned `Retry-After` header.
+/// Mutable inner state — algorithm-specific window data plus an optional hard
+/// block set by a server-returned `Retry-After` header.
 #[derive(Debug)]
 struct RequestWindow {
-    timestamps: VecDeque<Instant>,
+    state: WindowState,
     config: RateLimitConfig,
     /// Hard block until this instant, set by [`record_retry_after`].
     blocked_until: Option<Instant>,
@@ -37,8 +58,17 @@ struct RequestWindow {
 
 impl RequestWindow {
     fn new(config: &RateLimitConfig) -> Self {
+        let state = match config.strategy {
+            RateLimitStrategy::SlidingWindow => WindowState::Sliding {
+                timestamps: VecDeque::with_capacity(config.max_requests as usize),
+            },
+            RateLimitStrategy::TokenBucket => WindowState::TokenBucket {
+                tokens: f64::from(config.max_requests),
+                last_refill: Instant::now(),
+            },
+        };
         Self {
-            timestamps: VecDeque::with_capacity(config.max_requests as usize),
+            state,
             config: config.clone(),
             blocked_until: None,
         }
@@ -46,13 +76,11 @@ impl RequestWindow {
 
     /// Try to acquire a request slot.
     ///
-    /// Prunes expired entries, then:
-    /// - Returns `None` if a slot is available (timestamp is recorded immediately).
+    /// - Returns `None` if a slot is available (the slot is claimed immediately).
     /// - Returns `Some(wait)` with the duration the caller must sleep before
     ///   retrying (capped at `config.max_delay_ms`).
     fn acquire(&mut self) -> Option<Duration> {
         let now = Instant::now();
-        let window = self.config.window;
         let max_delay = Duration::from_millis(self.config.max_delay_ms);
 
         // Check hard block imposed by a previous Retry-After response.
@@ -64,25 +92,51 @@ impl RequestWindow {
             self.blocked_until = None;
         }
 
-        // Drop timestamps that have rolled out of the window.
-        while self
-            .timestamps
-            .front()
-            .is_some_and(|t| now.duration_since(*t) >= window)
-        {
-            self.timestamps.pop_front();
-        }
+        match &mut self.state {
+            WindowState::Sliding { timestamps } => {
+                let window = self.config.window;
+                // Drop timestamps that have rolled out of the window.
+                while timestamps
+                    .front()
+                    .is_some_and(|t| now.duration_since(*t) >= window)
+                {
+                    timestamps.pop_front();
+                }
 
-        if self.timestamps.len() < self.config.max_requests as usize {
-            // Slot available — record and permit.
-            self.timestamps.push_back(now);
-            None
-        } else {
-            // Window is full; compute wait until the oldest entry rolls out.
-            let &oldest = self.timestamps.front()?;
-            let elapsed = now.duration_since(oldest);
-            let wait = window.saturating_sub(elapsed);
-            Some(wait.min(max_delay))
+                if timestamps.len() < self.config.max_requests as usize {
+                    // Slot available — record and permit.
+                    timestamps.push_back(now);
+                    None
+                } else {
+                    // Window is full; compute wait until the oldest entry rolls out.
+                    let &oldest = timestamps.front()?;
+                    let elapsed = now.duration_since(oldest);
+                    let wait = window.saturating_sub(elapsed);
+                    Some(wait.min(max_delay))
+                }
+            }
+
+            WindowState::TokenBucket {
+                tokens,
+                last_refill,
+            } => {
+                // Refill tokens proportional to elapsed time.
+                let elapsed = now.duration_since(*last_refill);
+                let rate = f64::from(self.config.max_requests) / self.config.window.as_secs_f64();
+                let refill = elapsed.as_secs_f64() * rate;
+                *tokens = (*tokens + refill).min(f64::from(self.config.max_requests));
+                *last_refill = now;
+
+                if *tokens >= 1.0 {
+                    *tokens -= 1.0;
+                    None
+                } else {
+                    // Compute exact wait until 1 token has accumulated.
+                    let wait_secs = (1.0 - *tokens) / rate;
+                    let wait = Duration::from_secs_f64(wait_secs);
+                    Some(wait.min(max_delay))
+                }
+            }
         }
     }
 
@@ -265,6 +319,16 @@ mod tests {
             max_requests,
             window: Duration::from_secs(window_secs),
             max_delay_ms: 60_000,
+            strategy: RateLimitStrategy::SlidingWindow,
+        }
+    }
+
+    fn cfg_bucket(max_requests: u32, window_secs: u64) -> RateLimitConfig {
+        RateLimitConfig {
+            max_requests,
+            window: Duration::from_secs(window_secs),
+            max_delay_ms: 60_000,
+            strategy: RateLimitStrategy::TokenBucket,
         }
     }
 
@@ -285,6 +349,7 @@ mod tests {
             max_requests: 1,
             window: Duration::from_millis(10),
             max_delay_ms: 60_000,
+            strategy: RateLimitStrategy::SlidingWindow,
         });
         assert!(w.acquire().is_none(), "first request");
         std::thread::sleep(Duration::from_millis(25));
@@ -297,9 +362,9 @@ mod tests {
     fn timestamps_recorded_immediately() {
         let mut w = RequestWindow::new(&cfg(2, 60));
         w.acquire();
-        assert_eq!(w.timestamps.len(), 1);
         w.acquire();
-        assert_eq!(w.timestamps.len(), 2);
+        // After two acquisitions the window is full.
+        assert!(w.acquire().is_some(), "third request must be blocked");
     }
 
     // 4. record_retry_after blocks subsequent acquire calls.
@@ -335,5 +400,71 @@ mod tests {
         assert_eq!(parse_retry_after("not-a-number"), None);
         assert_eq!(parse_retry_after(""), None);
         assert_eq!(parse_retry_after("  30  "), Some(30));
+    }
+
+    // ── Token-bucket strategy tests ──────────────────────────────────────────
+
+    // 7. Token bucket allows up to max_requests immediately (full bucket).
+    #[test]
+    fn token_bucket_allows_up_to_max() {
+        let mut w = RequestWindow::new(&cfg_bucket(3, 60));
+        assert!(w.acquire().is_none(), "token 1");
+        assert!(w.acquire().is_none(), "token 2");
+        assert!(w.acquire().is_none(), "token 3");
+        assert!(
+            w.acquire().is_some(),
+            "4th request must be blocked — bucket empty"
+        );
+    }
+
+    // 8. Token bucket refills over time.
+    #[test]
+    fn token_bucket_refills_after_delay() {
+        let mut w = RequestWindow::new(&RateLimitConfig {
+            // 1 token per 10 ms
+            max_requests: 1,
+            window: Duration::from_millis(10),
+            max_delay_ms: 60_000,
+            strategy: RateLimitStrategy::TokenBucket,
+        });
+        assert!(w.acquire().is_none(), "first request consumes the token");
+        assert!(w.acquire().is_some(), "bucket empty — must block");
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(w.acquire().is_none(), "bucket should have refilled");
+    }
+
+    // 9. Token bucket also respects Retry-After hard blocks.
+    #[test]
+    fn token_bucket_respects_retry_after() {
+        let mut w = RequestWindow::new(&cfg_bucket(100, 60));
+        w.record_retry_after(30);
+        assert!(
+            w.acquire().is_some(),
+            "Retry-After must block even with tokens available"
+        );
+    }
+
+    // 10. Token bucket wait duration is proportional to the deficit.
+    #[test]
+    fn token_bucket_wait_is_proportional() {
+        // 60 requests / 60 s = 1 token/s.  After draining the bucket the wait
+        // for a single token should be ≈ 1 s.
+        let mut w = RequestWindow::new(&RateLimitConfig {
+            max_requests: 1,
+            window: Duration::from_secs(1),
+            max_delay_ms: 60_000,
+            strategy: RateLimitStrategy::TokenBucket,
+        });
+        w.acquire(); // consume the only token
+        let wait = w.acquire().unwrap();
+        // Wait should be close to 1 s; allow generous tolerance for slow CI.
+        assert!(
+            wait <= Duration::from_secs(1),
+            "wait {wait:?} should not exceed 1 s"
+        );
+        assert!(
+            wait >= Duration::from_millis(800),
+            "wait {wait:?} should be close to 1 s"
+        );
     }
 }

--- a/crates/stygian-graph/src/adapters/rest_api.rs
+++ b/crates/stygian-graph/src/adapters/rest_api.rs
@@ -1,0 +1,1058 @@
+//! REST API scraping adapter with authentication and pagination support.
+//!
+//! Implements [`ScrapingService`] for structured REST JSON APIs. Supports:
+//!
+//! - HTTP methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`
+//! - Authentication: Bearer token, HTTP Basic, API key (header or query param)
+//! - Automatic pagination: offset/page, cursor, or RFC 8288 `Link` header
+//! - JSON response data extraction via dot-separated path
+//! - Custom request headers and query string parameters
+//! - Configurable retries with exponential backoff
+//!
+//! All per-request options live in [`ServiceInput::params`]; see the
+//! [`RestApiAdapter::execute`] docs for the full contract.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use stygian_graph::adapters::rest_api::{RestApiAdapter, RestApiConfig};
+//! use stygian_graph::ports::{ScrapingService, ServiceInput};
+//! use serde_json::json;
+//! use std::time::Duration;
+//!
+//! # tokio::runtime::Runtime::new().unwrap().block_on(async {
+//! let adapter = RestApiAdapter::with_config(RestApiConfig {
+//!     timeout:      Duration::from_secs(20),
+//!     max_retries:  2,
+//!     ..Default::default()
+//! });
+//!
+//! let input = ServiceInput {
+//!     url: "https://api.github.com/repos/rust-lang/rust/issues".to_string(),
+//!     params: json!({
+//!         "auth": { "type": "bearer", "token": "ghp_..." },
+//!         "query": { "state": "open", "per_page": "30" },
+//!         "pagination": { "strategy": "link_header", "max_pages": 5 },
+//!         "response": { "data_path": "" }
+//!     }),
+//! };
+//! // let output = adapter.execute(input).await.unwrap();
+//! # });
+//! ```
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::{Client, Method, Proxy, header};
+use serde_json::{Value, json};
+use tracing::{debug, info, warn};
+
+use crate::domain::error::{Result, ServiceError, StygianError};
+use crate::ports::{ScrapingService, ServiceInput, ServiceOutput};
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+/// Configuration for [`RestApiAdapter`].
+///
+/// Adapter-level defaults; per-request settings come from `ServiceInput.params`.
+///
+/// # Example
+///
+/// ```
+/// use stygian_graph::adapters::rest_api::RestApiConfig;
+/// use std::time::Duration;
+///
+/// let cfg = RestApiConfig {
+///     timeout:          Duration::from_secs(20),
+///     max_retries:      2,
+///     retry_base_delay: Duration::from_millis(500),
+///     proxy_url:        None,
+/// };
+/// ```
+#[derive(Debug, Clone)]
+pub struct RestApiConfig {
+    /// Per-request timeout (default: 30 s).
+    pub timeout: Duration,
+    /// Maximum retry attempts per page request on transient errors (default: 3).
+    pub max_retries: u32,
+    /// Base delay for exponential backoff (default: 1 s).
+    pub retry_base_delay: Duration,
+    /// Optional HTTP/HTTPS/SOCKS5 proxy URL.
+    pub proxy_url: Option<String>,
+}
+
+impl Default for RestApiConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(30),
+            max_retries: 3,
+            retry_base_delay: Duration::from_secs(1),
+            proxy_url: None,
+        }
+    }
+}
+
+// ─── Internal request model ───────────────────────────────────────────────────
+
+/// Authentication scheme, parsed from `params.auth`.
+#[derive(Debug, Clone)]
+enum AuthScheme {
+    /// No authentication.
+    None,
+    /// `Authorization: Bearer <token>`
+    Bearer(String),
+    /// HTTP Basic authentication.
+    Basic { username: String, password: String },
+    /// Arbitrary header: `<header>: <key>`
+    ApiKeyHeader { header: String, key: String },
+    /// Append `?<param>=<key>` to the query string.
+    ApiKeyQuery { param: String, key: String },
+}
+
+/// Request body variant.
+#[derive(Debug, Clone)]
+enum RequestBody {
+    Json(Value),
+    Raw(String),
+}
+
+/// How to advance to the next page.
+#[derive(Debug, Clone)]
+enum PaginationStrategy {
+    /// Single request — no pagination.
+    None,
+    /// Increment a page/offset query parameter.
+    Offset {
+        page_param: String,
+        page_size_param: Option<String>,
+        page_size: Option<u64>,
+        current_page: u64,
+    },
+    /// Follow a cursor embedded in the response JSON.
+    Cursor {
+        /// Query parameter name that carries the cursor on subsequent requests.
+        cursor_param: String,
+        /// Dot-separated path into the response JSON where the next cursor lives.
+        cursor_field: String,
+    },
+    /// Follow RFC 8288 `Link: <URL>; rel="next"` response header.
+    LinkHeader,
+}
+
+/// Fully-parsed per-request specification, derived from `ServiceInput.params`.
+#[derive(Debug, Clone)]
+struct RequestSpec {
+    method: Method,
+    extra_headers: HashMap<String, String>,
+    query_params: HashMap<String, String>,
+    body: Option<RequestBody>,
+    auth: AuthScheme,
+    accept: String,
+    /// Dot-separated path into the JSON response to extract as data.
+    /// `None` means use the full response body.
+    data_path: Option<String>,
+    /// Return paged data as a flat JSON array even when only one page was fetched.
+    collect_as_array: bool,
+    pagination: PaginationStrategy,
+    max_pages: usize,
+}
+
+// ─── Adapter ──────────────────────────────────────────────────────────────────
+
+/// REST API scraping adapter.
+///
+/// Thread-safe and cheaply cloneable — the inner `reqwest::Client` uses `Arc`
+/// internally. Build once, share across tasks.
+///
+/// # Example
+///
+/// ```
+/// use stygian_graph::adapters::rest_api::RestApiAdapter;
+///
+/// let adapter = RestApiAdapter::new();
+/// ```
+#[derive(Clone)]
+pub struct RestApiAdapter {
+    client: Client,
+    config: RestApiConfig,
+}
+
+impl RestApiAdapter {
+    /// Create a new adapter with default configuration.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_graph::adapters::rest_api::RestApiAdapter;
+    /// let adapter = RestApiAdapter::new();
+    /// ```
+    pub fn new() -> Self {
+        Self::with_config(RestApiConfig::default())
+    }
+
+    /// Create an adapter with custom configuration.
+    ///
+    /// # Panics
+    ///
+    /// Panics only if TLS is unavailable on the host (extremely rare).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_graph::adapters::rest_api::{RestApiAdapter, RestApiConfig};
+    /// use std::time::Duration;
+    ///
+    /// let adapter = RestApiAdapter::with_config(RestApiConfig {
+    ///     timeout: Duration::from_secs(10),
+    ///     ..Default::default()
+    /// });
+    /// ```
+    pub fn with_config(config: RestApiConfig) -> Self {
+        let mut builder = Client::builder()
+            .timeout(config.timeout)
+            .gzip(true)
+            .brotli(true)
+            .use_rustls_tls();
+
+        if let Some(ref proxy_url) = config.proxy_url
+            && let Ok(proxy) = Proxy::all(proxy_url)
+        {
+            builder = builder.proxy(proxy);
+        }
+
+        // SAFETY: TLS via rustls is always available; build() can only fail if the
+        // TLS backend is completely absent, which cannot happen with use_rustls_tls().
+        #[allow(clippy::expect_used)]
+        let client = builder.build().expect("TLS backend unavailable");
+
+        Self { client, config }
+    }
+
+    /// Resolve a dot-separated path into a JSON [`Value`].
+    ///
+    /// Returns `None` if any path segment is missing.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use serde_json::json;
+    /// use stygian_graph::adapters::rest_api::RestApiAdapter;
+    ///
+    /// let v = json!({"meta": {"next": "abc123"}});
+    /// assert_eq!(
+    ///     RestApiAdapter::extract_path(&v, "meta.next"),
+    ///     Some(&json!("abc123"))
+    /// );
+    /// assert!(RestApiAdapter::extract_path(&v, "meta.gone").is_none());
+    /// ```
+    pub fn extract_path<'a>(value: &'a Value, path: &str) -> Option<&'a Value> {
+        let mut current = value;
+        for segment in path.split('.') {
+            current = current.get(segment)?;
+        }
+        Some(current)
+    }
+
+    /// Parse an RFC 8288 `Link` header and return the `rel="next"` URL, if any.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_graph::adapters::rest_api::RestApiAdapter;
+    ///
+    /// let link = r#"<https://api.example.com/items?page=2>; rel="next", <https://api.example.com/items?page=1>; rel="prev""#;
+    /// assert_eq!(
+    ///     RestApiAdapter::parse_link_next(link),
+    ///     Some("https://api.example.com/items?page=2".to_owned())
+    /// );
+    /// ```
+    pub fn parse_link_next(link_header: &str) -> Option<String> {
+        for part in link_header.split(',') {
+            let part = part.trim();
+            let mut url: Option<String> = None;
+            let mut is_next = false;
+            for segment in part.split(';') {
+                let segment = segment.trim();
+                if segment.starts_with('<') && segment.ends_with('>') {
+                    url = Some(segment[1..segment.len() - 1].to_owned());
+                } else if segment.trim_start_matches("rel=").trim_matches('"') == "next" {
+                    is_next = true;
+                }
+            }
+            if is_next {
+                return url;
+            }
+        }
+        None
+    }
+
+    /// Parse `ServiceInput.params` into a `RequestSpec`.
+    #[allow(clippy::indexing_slicing)]
+    fn parse_spec(params: &Value) -> Result<RequestSpec> {
+        let method_str = params["method"].as_str().unwrap_or("GET").to_uppercase();
+        let method = match method_str.as_str() {
+            "GET" => Method::GET,
+            "POST" => Method::POST,
+            "PUT" => Method::PUT,
+            "PATCH" => Method::PATCH,
+            "DELETE" => Method::DELETE,
+            "HEAD" => Method::HEAD,
+            other => {
+                return Err(StygianError::from(ServiceError::Unavailable(format!(
+                    "unknown HTTP method: {other}"
+                ))));
+            }
+        };
+
+        let extra_headers = params["headers"]
+            .as_object()
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| v.as_str().map(|s| (k.clone(), s.to_owned())))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let query_params = params["query"]
+            .as_object()
+            .map(|obj| {
+                obj.iter()
+                    .filter_map(|(k, v)| {
+                        let s = if v.is_string() {
+                            v.as_str().map(ToOwned::to_owned)
+                        } else {
+                            Some(v.to_string())
+                        };
+                        s.map(|val| (k.clone(), val))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let body = if params["body"].is_null() {
+            params["body_raw"]
+                .as_str()
+                .map(|raw| RequestBody::Raw(raw.to_owned()))
+        } else {
+            Some(RequestBody::Json(params["body"].clone()))
+        };
+
+        let accept = params["accept"]
+            .as_str()
+            .unwrap_or("application/json")
+            .to_owned();
+
+        let auth = Self::parse_auth(&params["auth"]);
+
+        let data_path = match params["response"]["data_path"].as_str() {
+            Some("") | None => None,
+            Some(p) => Some(p.to_owned()),
+        };
+        let collect_as_array = params["response"]["collect_as_array"]
+            .as_bool()
+            .unwrap_or(false);
+
+        let max_pages = params["pagination"]["max_pages"]
+            .as_u64()
+            .map_or(1, |n| usize::try_from(n).unwrap_or(usize::MAX));
+
+        let pagination = Self::parse_pagination(&params["pagination"]);
+
+        Ok(RequestSpec {
+            method,
+            extra_headers,
+            query_params,
+            body,
+            auth,
+            accept,
+            data_path,
+            collect_as_array,
+            pagination,
+            max_pages,
+        })
+    }
+
+    /// Parse `params.auth` into an [`AuthScheme`].
+    #[allow(clippy::indexing_slicing)]
+    fn parse_auth(auth: &Value) -> AuthScheme {
+        match auth["type"].as_str().unwrap_or("none") {
+            "bearer" | "oauth2" => auth["token"]
+                .as_str()
+                .map_or(AuthScheme::None, |t| AuthScheme::Bearer(t.to_owned())),
+            "basic" => AuthScheme::Basic {
+                username: auth["username"].as_str().unwrap_or("").to_owned(),
+                password: auth["password"].as_str().unwrap_or("").to_owned(),
+            },
+            "api_key_header" => AuthScheme::ApiKeyHeader {
+                header: auth["header"].as_str().unwrap_or("X-Api-Key").to_owned(),
+                key: auth["key"].as_str().unwrap_or("").to_owned(),
+            },
+            "api_key_query" => AuthScheme::ApiKeyQuery {
+                param: auth["param"].as_str().unwrap_or("api_key").to_owned(),
+                key: auth["key"].as_str().unwrap_or("").to_owned(),
+            },
+            _ => AuthScheme::None,
+        }
+    }
+
+    /// Parse `params.pagination` into a [`PaginationStrategy`].
+    #[allow(clippy::indexing_slicing)]
+    fn parse_pagination(pag: &Value) -> PaginationStrategy {
+        match pag["strategy"].as_str().unwrap_or("none") {
+            "offset" => PaginationStrategy::Offset {
+                page_param: pag["page_param"].as_str().unwrap_or("page").to_owned(),
+                page_size_param: pag["page_size_param"].as_str().map(ToOwned::to_owned),
+                page_size: pag["page_size"].as_u64(),
+                current_page: pag["start_page"].as_u64().unwrap_or(1),
+            },
+            "cursor" => PaginationStrategy::Cursor {
+                cursor_param: pag["cursor_param"].as_str().unwrap_or("cursor").to_owned(),
+                cursor_field: pag["cursor_field"]
+                    .as_str()
+                    .unwrap_or("next_cursor")
+                    .to_owned(),
+            },
+            "link_header" => PaginationStrategy::LinkHeader,
+            _ => PaginationStrategy::None,
+        }
+    }
+
+    /// Extract the data portion of a parsed response using `spec.data_path`.
+    fn extract_data(response: &Value, spec: &RequestSpec) -> Value {
+        spec.data_path
+            .as_deref()
+            .and_then(|path| Self::extract_path(response, path))
+            .cloned()
+            .unwrap_or_else(|| response.clone())
+    }
+
+    /// Execute a single HTTP request, retrying on transient failures.
+    async fn send_one(
+        &self,
+        url: &str,
+        spec: &RequestSpec,
+        extra_query: &HashMap<String, String>,
+    ) -> Result<(Value, Option<String>)> {
+        let mut last_err: Option<StygianError> = None;
+
+        for attempt in 0..=self.config.max_retries {
+            if attempt > 0 {
+                let delay = self.config.retry_base_delay * 2u32.saturating_pow(attempt - 1);
+                tokio::time::sleep(delay).await;
+                debug!(url, attempt, "REST API retry");
+            }
+
+            match self.do_send(url, spec, extra_query).await {
+                Ok(r) => return Ok(r),
+                Err(e) if is_retryable(&e) && attempt < self.config.max_retries => {
+                    last_err = Some(e);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+
+        Err(last_err.unwrap_or_else(|| {
+            StygianError::from(ServiceError::Unavailable("max retries exceeded".into()))
+        }))
+    }
+
+    /// Perform exactly one HTTP round-trip (no retry).
+    ///
+    /// Returns the parsed JSON response body and the raw `Link` header value (if present).
+    async fn do_send(
+        &self,
+        url: &str,
+        spec: &RequestSpec,
+        extra_query: &HashMap<String, String>,
+    ) -> Result<(Value, Option<String>)> {
+        let mut req = self.client.request(spec.method.clone(), url);
+
+        // Accept header
+        req = req.header(header::ACCEPT, spec.accept.as_str());
+
+        // Auth — header-based schemes
+        req = match &spec.auth {
+            AuthScheme::Bearer(token) => req.bearer_auth(token),
+            AuthScheme::Basic { username, password } => req.basic_auth(username, Some(password)),
+            AuthScheme::ApiKeyHeader { header: hdr, key } => req.header(hdr.as_str(), key.as_str()),
+            AuthScheme::ApiKeyQuery { .. } | AuthScheme::None => req,
+        };
+
+        // Custom headers
+        for (k, v) in &spec.extra_headers {
+            req = req.header(k.as_str(), v.as_str());
+        }
+
+        // Merge query params: static + per-page extra + API key query (if applicable)
+        let mut merged: HashMap<String, String> = spec.query_params.clone();
+        merged.extend(extra_query.iter().map(|(k, v)| (k.clone(), v.clone())));
+        if let AuthScheme::ApiKeyQuery { param, key } = &spec.auth {
+            merged.insert(param.clone(), key.clone());
+        }
+        if !merged.is_empty() {
+            let pairs: Vec<(&String, &String)> = merged.iter().collect();
+            req = req.query(&pairs);
+        }
+
+        // Body
+        req = match &spec.body {
+            Some(RequestBody::Json(v)) => req.json(v),
+            Some(RequestBody::Raw(s)) => req.body(s.clone()),
+            None => req,
+        };
+
+        let response = req
+            .send()
+            .await
+            .map_err(|e| StygianError::from(ServiceError::Unavailable(e.to_string())))?;
+
+        let status = response.status();
+
+        // Capture Link header before consuming the response
+        let link_header = response
+            .headers()
+            .get("link")
+            .and_then(|v| v.to_str().ok())
+            .map(ToOwned::to_owned);
+
+        // 429 — log retry-after hint
+        if status.as_u16() == 429 {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(5);
+            warn!(url, retry_after, "REST API rate-limited (429)");
+            return Err(StygianError::from(ServiceError::Unavailable(format!(
+                "HTTP 429 rate-limited; retry-after={retry_after}s"
+            ))));
+        }
+
+        if !status.is_success() {
+            let snippet: String = response
+                .text()
+                .await
+                .unwrap_or_default()
+                .chars()
+                .take(200)
+                .collect();
+            return Err(StygianError::from(ServiceError::Unavailable(format!(
+                "HTTP {status}: {snippet}"
+            ))));
+        }
+
+        let body = response
+            .text()
+            .await
+            .map_err(|e| StygianError::from(ServiceError::Unavailable(e.to_string())))?;
+
+        // Parse as JSON when possible; wrap plain text as a JSON string otherwise.
+        let parsed: Value = serde_json::from_str(&body).unwrap_or(Value::String(body));
+
+        Ok((parsed, link_header))
+    }
+}
+
+impl Default for RestApiAdapter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Returns `true` for transient errors that are worth retrying.
+fn is_retryable(err: &StygianError) -> bool {
+    let StygianError::Service(ServiceError::Unavailable(msg)) = err else {
+        return false;
+    };
+    msg.contains("429")
+        || msg.contains("500")
+        || msg.contains("502")
+        || msg.contains("503")
+        || msg.contains("504")
+        || msg.contains("connection")
+        || msg.contains("timed out")
+}
+
+// ─── ScrapingService ──────────────────────────────────────────────────────────
+
+#[async_trait]
+impl ScrapingService for RestApiAdapter {
+    /// Execute one or more REST API requests and return the aggregated result.
+    ///
+    /// # `ServiceInput.url`
+    ///
+    /// Base URL of the REST endpoint (including path; query string is optional).
+    ///
+    /// # `ServiceInput.params` contract
+    ///
+    /// ```json
+    /// {
+    ///   "method":   "GET",
+    ///   "body":     { "key": "value" },
+    ///   "body_raw": "raw body string",
+    ///   "headers":  { "X-Custom-Header": "value" },
+    ///   "query":    { "state": "open", "per_page": "30" },
+    ///   "accept":   "application/json",
+    ///
+    ///   "auth": {
+    ///     "type":     "bearer",
+    ///     "token":    "...",
+    ///     "username": "user",
+    ///     "password": "pass",
+    ///     "header":   "X-Api-Key",
+    ///     "param":    "api_key",
+    ///     "key":      "sk-..."
+    ///   },
+    ///
+    ///   "response": {
+    ///     "data_path":        "items",
+    ///     "collect_as_array": true
+    ///   },
+    ///
+    ///   "pagination": {
+    ///     "strategy":        "link_header",
+    ///     "max_pages":       10,
+    ///     "page_param":      "page",
+    ///     "page_size_param": "per_page",
+    ///     "page_size":       100,
+    ///     "start_page":      1,
+    ///     "cursor_param":    "cursor",
+    ///     "cursor_field":    "meta.next_cursor"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// # Auth `type` values
+    ///
+    /// | `type` | Required fields | Description |
+    /// |---|---|---|
+    /// | `"bearer"` / `"oauth2"` | `token` | `Authorization: Bearer <token>` |
+    /// | `"basic"` | `username`, `password` | HTTP Basic |
+    /// | `"api_key_header"` | `header`, `key` | Custom header |
+    /// | `"api_key_query"` | `param`, `key` | Query string |
+    /// | `"none"` or absent | — | No auth |
+    ///
+    /// # Pagination strategies
+    ///
+    /// | `strategy` | Description |
+    /// |---|---|
+    /// | `"none"` | Single request (default) |
+    /// | `"offset"` | Increment `page_param` from `start_page` |
+    /// | `"cursor"` | Extract next cursor at `cursor_field` in each response; pass it as `cursor_param` |
+    /// | `"link_header"` | Follow RFC 8288 `Link: <url>; rel="next"` header |
+    async fn execute(&self, input: ServiceInput) -> Result<ServiceOutput> {
+        let spec = Self::parse_spec(&input.params)?;
+
+        let mut accumulated: Vec<Value> = Vec::new();
+        let mut page_count: usize = 0;
+        let mut current_url = input.url.clone();
+        let mut pagination = spec.pagination.clone();
+        let mut extra_query: HashMap<String, String> = HashMap::new();
+
+        // Cursor state lives outside the loop so it persists across pages.
+        let mut cursor_state: Option<String> = None;
+
+        info!(url = %input.url, "REST API execute start");
+
+        loop {
+            if page_count >= spec.max_pages {
+                debug!(%current_url, page_count, "REST API: max_pages reached");
+                break;
+            }
+
+            // Build per-page query additions
+            extra_query.clear();
+            match &pagination {
+                PaginationStrategy::Offset {
+                    page_param,
+                    page_size_param,
+                    page_size,
+                    current_page,
+                } => {
+                    extra_query.insert(page_param.clone(), current_page.to_string());
+                    if let (Some(size_param), Some(size)) = (page_size_param, page_size) {
+                        extra_query.insert(size_param.clone(), size.to_string());
+                    }
+                }
+                PaginationStrategy::Cursor { cursor_param, .. } => {
+                    if let Some(ref cursor) = cursor_state {
+                        extra_query.insert(cursor_param.clone(), cursor.clone());
+                    }
+                }
+                PaginationStrategy::None | PaginationStrategy::LinkHeader => {}
+            }
+
+            let (response, link_header) = self.send_one(&current_url, &spec, &extra_query).await?;
+
+            let page_data = Self::extract_data(&response, &spec);
+
+            // Accumulate — empty array responses signal end-of-pagination.
+            match &page_data {
+                Value::Array(items) => {
+                    if items.is_empty() {
+                        debug!("REST API: empty page, stopping pagination");
+                        break;
+                    }
+                    accumulated.extend(items.iter().cloned());
+                }
+                other => {
+                    accumulated.push(other.clone());
+                }
+            }
+            page_count += 1;
+
+            // Advance pagination state
+            let stop = match &mut pagination {
+                PaginationStrategy::None => true,
+                PaginationStrategy::Offset { current_page, .. } => {
+                    *current_page += 1;
+                    false
+                }
+                PaginationStrategy::Cursor { cursor_field, .. } => {
+                    Self::extract_path(&response, cursor_field.as_str())
+                        .and_then(Value::as_str)
+                        .filter(|s| !s.is_empty())
+                        .map(ToOwned::to_owned)
+                        .is_none_or(|cursor| {
+                            cursor_state = Some(cursor);
+                            false
+                        })
+                }
+                PaginationStrategy::LinkHeader => link_header
+                    .as_deref()
+                    .and_then(Self::parse_link_next)
+                    .is_none_or(|next_url| {
+                        current_url = next_url;
+                        false
+                    }),
+            };
+            if stop {
+                break;
+            }
+        }
+
+        // Serialise accumulated results
+        let data_value = if spec.collect_as_array || accumulated.len() > 1 {
+            Value::Array(accumulated)
+        } else {
+            accumulated.into_iter().next().unwrap_or(Value::Null)
+        };
+
+        let data_str = match &data_value {
+            Value::String(s) => s.clone(),
+            other => serde_json::to_string_pretty(other).unwrap_or_default(),
+        };
+
+        let metadata = json!({
+            "url":        input.url,
+            "page_count": page_count,
+        });
+
+        info!(%input.url, page_count, "REST API execute done");
+
+        Ok(ServiceOutput {
+            data: data_str,
+            metadata,
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        "rest-api"
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── parse_auth ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_auth_bearer() {
+        let auth = json!({"type": "bearer", "token": "tok123"});
+        match RestApiAdapter::parse_auth(&auth) {
+            AuthScheme::Bearer(t) => assert_eq!(t, "tok123"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_oauth2_alias() {
+        let auth = json!({"type": "oauth2", "token": "oauth_tok"});
+        match RestApiAdapter::parse_auth(&auth) {
+            AuthScheme::Bearer(t) => assert_eq!(t, "oauth_tok"),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_basic() {
+        let auth = json!({"type": "basic", "username": "alice", "password": "s3cr3t"});
+        match RestApiAdapter::parse_auth(&auth) {
+            AuthScheme::Basic { username, password } => {
+                assert_eq!(username, "alice");
+                assert_eq!(password, "s3cr3t");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_api_key_header() {
+        let auth = json!({"type": "api_key_header", "header": "X-Token", "key": "k123"});
+        match RestApiAdapter::parse_auth(&auth) {
+            AuthScheme::ApiKeyHeader { header, key } => {
+                assert_eq!(header, "X-Token");
+                assert_eq!(key, "k123");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_api_key_query() {
+        let auth = json!({"type": "api_key_query", "param": "api_key", "key": "qk"});
+        match RestApiAdapter::parse_auth(&auth) {
+            AuthScheme::ApiKeyQuery { param, key } => {
+                assert_eq!(param, "api_key");
+                assert_eq!(key, "qk");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_auth_none_default() {
+        let auth = json!(null);
+        assert!(matches!(
+            RestApiAdapter::parse_auth(&auth),
+            AuthScheme::None
+        ));
+    }
+
+    // ── extract_path ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn extract_path_top_level() {
+        let v = json!({"items": [1, 2, 3]});
+        assert_eq!(
+            RestApiAdapter::extract_path(&v, "items"),
+            Some(&json!([1, 2, 3]))
+        );
+    }
+
+    #[test]
+    fn extract_path_nested() {
+        let v = json!({"meta": {"next_cursor": "abc"}});
+        assert_eq!(
+            RestApiAdapter::extract_path(&v, "meta.next_cursor"),
+            Some(&json!("abc"))
+        );
+    }
+
+    #[test]
+    fn extract_path_missing() {
+        let v = json!({"a": {"b": 1}});
+        assert!(RestApiAdapter::extract_path(&v, "a.c").is_none());
+    }
+
+    // ── parse_link_next ────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_link_next_present() {
+        let h = r#"<https://api.example.com/items?page=2>; rel="next", <https://api.example.com/items?page=1>; rel="prev""#;
+        assert_eq!(
+            RestApiAdapter::parse_link_next(h),
+            Some("https://api.example.com/items?page=2".to_owned())
+        );
+    }
+
+    #[test]
+    fn parse_link_next_absent() {
+        let h = r#"<https://api.example.com/items?page=1>; rel="prev""#;
+        assert!(RestApiAdapter::parse_link_next(h).is_none());
+    }
+
+    #[test]
+    fn parse_link_next_single() {
+        let h = r#"<https://api.example.com/items?page=3>; rel="next""#;
+        assert_eq!(
+            RestApiAdapter::parse_link_next(h),
+            Some("https://api.example.com/items?page=3".to_owned())
+        );
+    }
+
+    // ── parse_spec ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_spec_defaults() {
+        let spec = RestApiAdapter::parse_spec(&json!({})).unwrap();
+        assert_eq!(spec.method, Method::GET);
+        assert_eq!(spec.accept, "application/json");
+        assert_eq!(spec.max_pages, 1);
+        assert!(spec.data_path.is_none());
+        assert!(!spec.collect_as_array);
+        assert!(matches!(spec.pagination, PaginationStrategy::None));
+    }
+
+    #[test]
+    fn parse_spec_post_with_body_and_headers() {
+        let params = json!({
+            "method":  "POST",
+            "body":    { "key": "value" },
+            "headers": { "X-Foo": "bar" },
+            "query":   { "limit": "10" }
+        });
+        let spec = RestApiAdapter::parse_spec(&params).unwrap();
+        assert_eq!(spec.method, Method::POST);
+        assert_eq!(spec.extra_headers.get("X-Foo"), Some(&"bar".to_string()));
+        assert_eq!(spec.query_params.get("limit"), Some(&"10".to_string()));
+        assert!(matches!(spec.body, Some(RequestBody::Json(_))));
+    }
+
+    #[test]
+    fn parse_spec_unknown_method_returns_error() {
+        let result = RestApiAdapter::parse_spec(&json!({"method": "BREW"}));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_spec_cursor_pagination() {
+        let params = json!({
+            "pagination": {
+                "strategy":     "cursor",
+                "cursor_param": "after",
+                "cursor_field": "page_info.end_cursor",
+                "max_pages":    10
+            }
+        });
+        let spec = RestApiAdapter::parse_spec(&params).unwrap();
+        assert_eq!(spec.max_pages, 10);
+        match spec.pagination {
+            PaginationStrategy::Cursor {
+                cursor_param,
+                cursor_field,
+            } => {
+                assert_eq!(cursor_param, "after");
+                assert_eq!(cursor_field, "page_info.end_cursor");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_spec_offset_pagination() {
+        let params = json!({
+            "pagination": {
+                "strategy":        "offset",
+                "page_param":      "page",
+                "page_size_param": "per_page",
+                "page_size":       50,
+                "start_page":      1,
+                "max_pages":       3
+            }
+        });
+        let spec = RestApiAdapter::parse_spec(&params).unwrap();
+        assert_eq!(spec.max_pages, 3);
+        match spec.pagination {
+            PaginationStrategy::Offset {
+                page_size,
+                current_page,
+                page_param,
+                ..
+            } => {
+                assert_eq!(page_size, Some(50));
+                assert_eq!(current_page, 1);
+                assert_eq!(page_param, "page");
+            }
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_spec_link_header_pagination() {
+        let params = json!({
+            "pagination": { "strategy": "link_header", "max_pages": 5 }
+        });
+        let spec = RestApiAdapter::parse_spec(&params).unwrap();
+        assert_eq!(spec.max_pages, 5);
+        assert!(matches!(spec.pagination, PaginationStrategy::LinkHeader));
+    }
+
+    #[test]
+    fn parse_spec_data_path_and_collect_as_array() {
+        let params = json!({
+            "response": { "data_path": "data.items", "collect_as_array": true }
+        });
+        let spec = RestApiAdapter::parse_spec(&params).unwrap();
+        assert_eq!(spec.data_path, Some("data.items".to_owned()));
+        assert!(spec.collect_as_array);
+    }
+
+    #[test]
+    fn parse_spec_empty_data_path_is_none() {
+        let params = json!({ "response": { "data_path": "" } });
+        let spec = RestApiAdapter::parse_spec(&params).unwrap();
+        assert!(spec.data_path.is_none());
+    }
+
+    // ── adapter_name ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn adapter_name() {
+        assert_eq!(RestApiAdapter::new().name(), "rest-api");
+    }
+
+    // ── is_retryable ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn is_retryable_429() {
+        let e = StygianError::from(ServiceError::Unavailable(
+            "HTTP 429 rate-limited".to_string(),
+        ));
+        assert!(is_retryable(&e));
+    }
+
+    #[test]
+    fn is_retryable_503() {
+        let e = StygianError::from(ServiceError::Unavailable(
+            "HTTP 503 Service Unavailable".to_string(),
+        ));
+        assert!(is_retryable(&e));
+    }
+
+    #[test]
+    fn is_retryable_404_not_retryable() {
+        let e = StygianError::from(ServiceError::Unavailable("HTTP 404 Not Found".to_string()));
+        assert!(!is_retryable(&e));
+    }
+
+    // ── integration ────────────────────────────────────────────────────────────
+
+    /// Real HTTP integration test — requires `REST_API_TEST_URL` env var.
+    ///
+    /// Run with: `REST_API_TEST_URL=https://httpbin.org/get cargo test -- --ignored`
+    #[tokio::test]
+    #[ignore = "requires live REST API endpoint; set REST_API_TEST_URL env var"]
+    async fn integration_get_httpbin() {
+        let url = std::env::var("REST_API_TEST_URL")
+            .unwrap_or_else(|_| "https://httpbin.org/get".to_string());
+
+        let adapter = RestApiAdapter::new();
+        let input = ServiceInput {
+            url,
+            params: json!({}),
+        };
+        let output = adapter.execute(input).await.unwrap();
+        assert!(!output.data.is_empty());
+        assert_eq!(output.metadata["page_count"], 1);
+    }
+}

--- a/crates/stygian-graph/src/adapters/rest_api.rs
+++ b/crates/stygian-graph/src/adapters/rest_api.rs
@@ -1,6 +1,6 @@
 //! REST API scraping adapter with authentication and pagination support.
 //!
-//! Implements [`ScrapingService`] for structured REST JSON APIs. Supports:
+//! Implements [`crate::ports::ScrapingService`] for structured REST JSON APIs. Supports:
 //!
 //! - HTTP methods: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`
 //! - Authentication: Bearer token, HTTP Basic, API key (header or query param)
@@ -9,8 +9,8 @@
 //! - Custom request headers and query string parameters
 //! - Configurable retries with exponential backoff
 //!
-//! All per-request options live in [`ServiceInput::params`]; see the
-//! [`RestApiAdapter::execute`] docs for the full contract.
+//! All per-request options live in `ServiceInput::params`; see the
+//! `RestApiAdapter::execute` docs for the full contract.
 //!
 //! # Example
 //!

--- a/crates/stygian-graph/src/application/registry.rs
+++ b/crates/stygian-graph/src/application/registry.rs
@@ -405,8 +405,9 @@ mod tests {
 
     #[test]
     fn global_registry_singleton_is_same_ref() {
-        let a = global_registry() as *const ServiceRegistry;
-        let b = global_registry() as *const ServiceRegistry;
-        assert_eq!(a, b);
+        use std::ptr;
+        let a = global_registry();
+        let b = global_registry();
+        assert!(ptr::addr_eq(a, b));
     }
 }

--- a/crates/stygian-graph/src/ports/graphql_plugin.rs
+++ b/crates/stygian-graph/src/ports/graphql_plugin.rs
@@ -78,7 +78,31 @@ impl Default for CostThrottleConfig {
 // RateLimitConfig
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Sliding-window request-count rate-limit parameters for a GraphQL API target.
+/// Selects which local pre-flight algorithm guards outgoing GraphQL requests.
+///
+/// Both strategies also honour server-returned `Retry-After` headers,
+/// regardless of which algorithm is active.
+///
+/// # Example
+///
+/// ```rust
+/// use stygian_graph::ports::graphql_plugin::RateLimitStrategy;
+///
+/// let strategy = RateLimitStrategy::TokenBucket; // burst-friendly
+/// ```
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum RateLimitStrategy {
+    /// Counts requests inside a rolling time window.  Most predictable for
+    /// server-side fixed-window quotas.
+    #[default]
+    SlidingWindow,
+    /// Refills tokens at a steady rate; short bursts are absorbed by the
+    /// bucket capacity before the window limit is reached.  Better for
+    /// endpoints that advertise burst allowances.
+    TokenBucket,
+}
+
+/// Request-count rate-limit parameters for a GraphQL API target.
 ///
 /// Enable by returning a populated [`RateLimitConfig`] from
 /// [`GraphQlTargetPlugin::rate_limit_config`].  This complements the leaky-bucket
@@ -88,12 +112,13 @@ impl Default for CostThrottleConfig {
 ///
 /// ```rust
 /// use std::time::Duration;
-/// use stygian_graph::ports::graphql_plugin::RateLimitConfig;
+/// use stygian_graph::ports::graphql_plugin::{RateLimitConfig, RateLimitStrategy};
 ///
 /// let config = RateLimitConfig {
 ///     max_requests: 100,
 ///     window: Duration::from_secs(60),
 ///     max_delay_ms: 30_000,
+///     strategy: RateLimitStrategy::TokenBucket,
 /// };
 /// ```
 #[derive(Debug, Clone)]
@@ -104,6 +129,8 @@ pub struct RateLimitConfig {
     pub window: Duration,
     /// Upper bound on any computed pre-flight delay in milliseconds (default: `30_000`).
     pub max_delay_ms: u64,
+    /// Rate-limiting algorithm to use (default: [`RateLimitStrategy::SlidingWindow`]).
+    pub strategy: RateLimitStrategy,
 }
 
 impl Default for RateLimitConfig {
@@ -112,6 +139,7 @@ impl Default for RateLimitConfig {
             max_requests: 100,
             window: Duration::from_secs(60),
             max_delay_ms: 30_000,
+            strategy: RateLimitStrategy::SlidingWindow,
         }
     }
 }
@@ -271,6 +299,7 @@ pub trait GraphQlTargetPlugin: Send + Sync {
     ///             max_requests: 200,
     ///             window: Duration::from_secs(60),
     ///             max_delay_ms: 30_000,
+    ///             ..Default::default()
     ///         })
     ///     }
     /// }

--- a/examples/rest-api-scrape.toml
+++ b/examples/rest-api-scrape.toml
@@ -1,0 +1,158 @@
+# rest-api-scrape.toml
+#
+# Demonstrates the REST API adapter with three real-world patterns:
+#
+#   1. Unauthenticated GET with query params (public JSONPlaceholder API)
+#   2. Bearer token auth + Link-header pagination (GitHub Issues)
+#   3. API key header auth (abstract OpenAPI-style endpoint)
+#
+# The results from each fetch are piped into Claude for structured extraction.
+#
+# Run:
+#   GITHUB_TOKEN=ghp_... ANTHROPIC_API_KEY=sk-... stygian run examples/rest-api-scrape.toml
+
+[[services]]
+name  = "rest"
+kind  = "rest-api"
+
+[[services]]
+name  = "claude"
+kind  = "claude"
+model = "claude-opus-4-5"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pattern 1: Unauthenticated GET — public REST API, no auth needed
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[nodes]]
+id      = "fetch-posts"
+service = "rest"
+url     = "https://jsonplaceholder.typicode.com/posts"
+
+  [nodes.params]
+  method = "GET"
+  query  = { "_limit" = "10", "_sort" = "id", "_order" = "desc" }
+
+  [nodes.params.response]
+  collect_as_array = true
+
+  [nodes.params.pagination]
+  strategy = "none"
+
+# Extract structured data from the raw JSON response
+
+[[nodes]]
+id         = "summarise-posts"
+service    = "claude"
+depends_on = ["fetch-posts"]
+
+  [nodes.prompt]
+  system = "You are a data analyst. Return concise summaries."
+  user   = "Summarise these 10 blog posts in a JSON array with fields: id, title, summary (max 20 words)."
+
+  [nodes.schema]
+  type = "object"
+  properties.posts.type = "array"
+  properties.posts.items.type = "object"
+  properties.posts.items.properties.id.type      = "integer"
+  properties.posts.items.properties.title.type   = "string"
+  properties.posts.items.properties.summary.type = "string"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pattern 2: Bearer auth + RFC 8288 Link-header pagination (GitHub Issues)
+#
+# Fetches up to 3 pages of open issues from the rust-lang/rust repo.
+# Replace GITHUB_TOKEN with a PAT that has repo:read scope.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[nodes]]
+id      = "fetch-issues"
+service = "rest"
+url     = "https://api.github.com/repos/rust-lang/rust/issues"
+
+  [nodes.params]
+  method = "GET"
+  accept = "application/vnd.github+json"
+  query  = { "state" = "open", "per_page" = "30" }
+
+  [nodes.params.auth]
+  type  = "bearer"
+  token = "${env:GITHUB_TOKEN}"
+
+  [nodes.params.response]
+  data_path        = ""
+  collect_as_array = true
+
+  [nodes.params.pagination]
+  strategy  = "link_header"
+  max_pages = 3
+
+# Extract the top issues for a report
+
+[[nodes]]
+id         = "analyse-issues"
+service    = "claude"
+depends_on = ["fetch-issues"]
+
+  [nodes.prompt]
+  system = "You are a project manager reviewing open issues."
+  user   = "List the top 5 most actionable issues from this data. Return: number, title, label (bug/feature/docs), and a one-sentence action item."
+
+  [nodes.schema]
+  type = "object"
+  properties.issues.type = "array"
+  properties.issues.items.type = "object"
+  properties.issues.items.properties.number.type      = "integer"
+  properties.issues.items.properties.title.type       = "string"
+  properties.issues.items.properties.label.type       = "string"
+  properties.issues.items.properties.action_item.type = "string"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Pattern 3: API key in header + cursor pagination (hypothetical products API)
+#
+# Replace MY_API_KEY with your actual API key.
+# ─────────────────────────────────────────────────────────────────────────────
+
+[[nodes]]
+id      = "fetch-products"
+service = "rest"
+url     = "https://api.example.com/v1/products"
+
+  [nodes.params]
+  method = "GET"
+
+  [nodes.params.auth]
+  type   = "api_key_header"
+  header = "X-Api-Key"
+  key    = "${env:MY_API_KEY}"
+
+  [nodes.params.response]
+  data_path        = "data"
+  collect_as_array = true
+
+  [nodes.params.pagination]
+  strategy     = "cursor"
+  cursor_field = "meta.next_cursor"
+  cursor_param = "cursor"
+  max_pages    = 10
+
+# Extract structured product list
+
+[[nodes]]
+id         = "extract-products"
+service    = "claude"
+depends_on = ["fetch-products"]
+
+  [nodes.prompt]
+  system = "You are a product data specialist."
+  user   = "Extract the product catalogue into a clean JSON array with: id, name, price_usd, category, in_stock (bool)."
+
+  [nodes.schema]
+  type = "object"
+  properties.products.type = "array"
+  properties.products.items.type = "object"
+  properties.products.items.properties.id.type        = "string"
+  properties.products.items.properties.name.type      = "string"
+  properties.products.items.properties.price_usd.type = "number"
+  properties.products.items.properties.category.type  = "string"
+  properties.products.items.properties.in_stock.type  = "boolean"


### PR DESCRIPTION
## Summary

Adds two new scraping adapters to `stygian-graph` and bumps the workspace to **v0.1.15**.

---

### `RestApiAdapter` (`"rest-api"`)

Purpose-built for structured JSON REST APIs. No feature flag required — uses the existing `reqwest` dependency.

**Auth schemes** (all via `params.auth`):
- `bearer` / `oauth2` — `Authorization: Bearer <token>`
- `basic` — HTTP Basic
- `api_key_header` — arbitrary header
- `api_key_query` — query string param

**Pagination strategies** (all via `params.pagination`):
- `none` — single request
- `offset` — increments `page_param` from `start_page`
- `cursor` — follows JSON dot-path cursor field
- `link_header` — RFC 8288 `Link: <url>; rel="next"`

**Other features**: dot-path JSON response extraction, configurable retries with exponential backoff, proxy support, `collect_as_array` option.

**Tests**: 24 unit + 1 `#[ignore]` integration.

---

### `CloudflareCrawlAdapter` (`"cloudflare-crawl"`)

Delegates whole-site crawling to the Cloudflare Browser Rendering `/crawl` endpoint (open beta). No local Chrome binary needed.

- Feature-gated: `cloudflare-crawl`
- Polls until complete with configurable poll interval and job timeout
- Aggregates all page results into a single `ServiceOutput`

---

### Also included

- `examples/rest-api-scrape.toml` — three real-world pipeline patterns
- Clippy `-D warnings` clean across both new adapters
- Updated `book/src/graph/adapters.md` with full REST API and Cloudflare sections
- CHANGELOG and README updated for v0.1.15