### PR TITLE
feat: close Turnstile fingerprint gaps, add request pacing, and proxy list fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `stygian-proxy`: `ProxyType::Socks4` and `ProxyType::Socks5` enum variants now properly
+  feature-gated behind `#[cfg(feature = "socks")]` in all match expressions; previously they
+  were guarded in the enum definition but unconditionally matched in `url()` and `proxy_type()`
+  methods, causing compile failures when the feature was disabled
+- `stygian-proxy`: `FreeListFetcher::fetch()` now uses true concurrent fetching via
+  `futures::future::join_all()` instead of sequential iteration; previously concurrent
+  sources were fetched sequentially despite comments claiming concurrency
+- `stygian-proxy`: `ProxyType::Https` now correctly maps to `"https"` scheme (was `"http"`)
+- `stygian-proxy`: `FreeListFetcher::new()` now logs warnings on TLS client build failures
+  instead of silently falling back with `unwrap_or_default()`
+- `stygian-browser`: `do_keyactivity()` now logs CDP evaluation failures with context instead
+  of silently discarding them via `.ok()`
+- `stygian-browser`: `fingerprint::font_measurement_intercept()` docstring corrected to match
+  implementation (checks visibility/position only, not font-family); `getBoundingClientRect`
+  now returns `new DOMRect(...)` for proper prototype chain instead of plain object literal
+
 ## [0.8.3] - 2026-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `stygian-browser`: `fingerprint::font_measurement_intercept()` docstring corrected to match
   implementation (checks visibility/position only, not font-family); `getBoundingClientRect`
   now returns `new DOMRect(...)` for proper prototype chain instead of plain object literal
+- `stygian-proxy`: `FreeListFetcher` parsing is now bracket-aware for IPv6 (`[addr]:port`),
+  and invalid entries are rejected earlier (empty host, `[]`, and port `0`)
+- `stygian-proxy`: `FreeListFetcher::fetch()` now returns a clear `ConfigError` when no
+  sources are configured instead of a non-diagnostic fetch failure with empty origin text
+- `stygian-proxy`: `ProxyError` is now marked `#[non_exhaustive]` to support adding variants
+  more safely in future releases
+- `stygian-browser`: `RequestPacer::with_timing()` now normalizes inverted bounds
+  (`min_ms > max_ms`) by swapping them, `with_rate()` docs now explicitly describe the
+  minimum `0.01 rps` clamp, and async throttling behavior is covered by unit tests
+- `stygian-browser`: `navigator.storage.estimate()` spoof now returns a merged object
+  (`Object.assign`) instead of mutating the original result in-place for better compatibility
 
 ## [0.8.3] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `stygian-proxy`: `FreeListFetcher::fetch()` now uses true concurrent fetching via
+  `futures::future::join_all()` instead of sequential iteration; previously concurrent
+  sources were fetched sequentially despite comments claiming concurrency
+- `stygian-browser`: `RequestPacer::with_timing()` now normalizes inverted bounds
+  (`min_ms > max_ms`) by swapping them, `with_rate()` docs now explicitly describe the
+  minimum `0.01 rps` clamp, and async throttling behavior is covered by unit tests
+
 ### Fixed
 
 - `stygian-proxy`: `ProxyType::Socks4` and `ProxyType::Socks5` enum variants now properly
   feature-gated behind `#[cfg(feature = "socks")]` in all match expressions; previously they
   were guarded in the enum definition but unconditionally matched in `url()` and `proxy_type()`
   methods, causing compile failures when the feature was disabled
-- `stygian-proxy`: `FreeListFetcher::fetch()` now uses true concurrent fetching via
-  `futures::future::join_all()` instead of sequential iteration; previously concurrent
-  sources were fetched sequentially despite comments claiming concurrency
 - `stygian-proxy`: `ProxyType::Https` now correctly maps to `"https"` scheme (was `"http"`)
 - `stygian-proxy`: `FreeListFetcher::new()` now logs warnings on TLS client build failures
   instead of silently falling back with `unwrap_or_default()`
@@ -30,11 +36,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sources are configured instead of a non-diagnostic fetch failure with empty origin text
 - `stygian-proxy`: `ProxyError` is now marked `#[non_exhaustive]` to support adding variants
   more safely in future releases
-- `stygian-browser`: `RequestPacer::with_timing()` now normalizes inverted bounds
-  (`min_ms > max_ms`) by swapping them, `with_rate()` docs now explicitly describe the
-  minimum `0.01 rps` clamp, and async throttling behavior is covered by unit tests
 - `stygian-browser`: `navigator.storage.estimate()` spoof now returns a merged object
   (`Object.assign`) instead of mutating the original result in-place for better compatibility
+
+### Breaking changes
+
+- `stygian-proxy`: `ProxyError` is now marked `#[non_exhaustive]`. Downstream crates that
+  exhaustively match on this enum must add a wildcard arm to remain source-compatible.
 
 ## [0.8.3] - 2026-04-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4210,6 +4210,7 @@ name = "stygian-proxy"
 version = "0.8.3"
 dependencies = [
  "async-trait",
+ "futures",
  "rand 0.9.2",
  "reqwest 0.13.2",
  "serde",

--- a/crates/stygian-browser/Cargo.toml
+++ b/crates/stygian-browser/Cargo.toml
@@ -66,7 +66,6 @@ prometheus-client = { workspace = true, optional = true }
 stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.8", optional = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
 proptest = { workspace = true }
 tracing-subscriber = { workspace = true }
 trybuild = "1"

--- a/crates/stygian-browser/Cargo.toml
+++ b/crates/stygian-browser/Cargo.toml
@@ -66,6 +66,7 @@ prometheus-client = { workspace = true, optional = true }
 stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.8", optional = true }
 
 [dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 proptest = { workspace = true }
 tracing-subscriber = { workspace = true }
 trybuild = "1"

--- a/crates/stygian-browser/src/behavior.rs
+++ b/crates/stygian-browser/src/behavior.rs
@@ -943,7 +943,7 @@ impl RequestPacer {
     /// let _pacer = RequestPacer::with_rate(0.5); // ~1 request every 2 s
     /// ```
     pub fn with_rate(requests_per_second: f64) -> Self {
-        let mean_ms = (1_000.0 / requests_per_second.max(0.01)) as u64;
+        let mean_ms = (1_000.0 / requests_per_second.max(0.01)).max(1.0) as u64;
         let std_ms = mean_ms / 4;
         let min_ms = mean_ms / 2;
         let max_ms = mean_ms.saturating_mul(2);
@@ -1248,7 +1248,7 @@ mod tests {
     #[test]
     fn request_pacer_with_rate_clamps_extreme() {
         // Very high rps yields a very small mean delay; mean_ms should still be at least 1 ms
-        let p = RequestPacer::with_rate(1_000.0);
+        let p = RequestPacer::with_rate(10_000.0);
         assert!(p.mean_ms >= 1);
     }
 
@@ -1266,24 +1266,12 @@ mod tests {
         // First call should complete immediately.
         p.throttle().await;
 
-        // Second call should not complete immediately.
-        let handle = tokio::spawn(async move {
-            p.throttle().await;
-        });
-
-        tokio::time::sleep(Duration::from_millis(5)).await;
+        // Second call should enforce a measurable delay.
+        let started = Instant::now();
+        p.throttle().await;
         assert!(
-            !handle.is_finished(),
-            "second throttle unexpectedly finished early"
+            started.elapsed() >= Duration::from_millis(15),
+            "second throttle should wait before returning"
         );
-
-        let joined = tokio::time::timeout(Duration::from_millis(200), handle).await;
-        assert!(
-            joined.is_ok(),
-            "second throttle did not finish within timeout"
-        );
-        if let Ok(join_res) = joined {
-            assert!(join_res.is_ok(), "throttle task join failed");
-        }
     }
 }

--- a/crates/stygian-browser/src/behavior.rs
+++ b/crates/stygian-browser/src/behavior.rs
@@ -881,6 +881,8 @@ impl RequestPacer {
 
     /// Create with explicit timing parameters (all values in milliseconds).
     ///
+    /// If `min_ms > max_ms`, bounds are normalized by swapping them.
+    ///
     /// # Example
     ///
     /// ```
@@ -889,6 +891,11 @@ impl RequestPacer {
     /// let _pacer = RequestPacer::with_timing(500, 150, 200, 1_500);
     /// ```
     pub fn with_timing(mean_ms: u64, std_ms: u64, min_ms: u64, max_ms: u64) -> Self {
+        let (min_ms, max_ms) = if min_ms <= max_ms {
+            (min_ms, max_ms)
+        } else {
+            (max_ms, min_ms)
+        };
         let seed = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs() ^ u64::from(d.subsec_nanos()))
@@ -906,6 +913,9 @@ impl RequestPacer {
     /// Construct from a target requests-per-second rate.
     ///
     /// Mean = `1000 / rps` ms, σ = 25 % of mean, clamped to ±50 % of mean.
+    ///
+    /// `rps` is clamped to a minimum of `0.01` to avoid division by zero and
+    /// extreme near-zero denominators.
     ///
     /// # Example
     ///
@@ -1221,5 +1231,35 @@ mod tests {
         // Very high rps yields a very small mean delay; mean_ms should still be at least 1 ms
         let p = RequestPacer::with_rate(1_000.0);
         assert!(p.mean_ms >= 1);
+    }
+
+    #[test]
+    fn request_pacer_with_timing_swaps_inverted_bounds() {
+        let p = RequestPacer::with_timing(500, 100, 2_000, 200);
+        assert_eq!(p.min_ms, 200);
+        assert_eq!(p.max_ms, 2_000);
+    }
+
+    #[tokio::test]
+    async fn request_pacer_throttle_first_immediate_then_waits() {
+        let mut p = RequestPacer::with_timing(25, 0, 25, 25);
+
+        let start = Instant::now();
+        p.throttle().await;
+        let first_elapsed = start.elapsed();
+        assert!(
+            first_elapsed < Duration::from_millis(10),
+            "first throttle should be immediate, got {:?}",
+            first_elapsed
+        );
+
+        let second_start = Instant::now();
+        p.throttle().await;
+        let second_elapsed = second_start.elapsed();
+        assert!(
+            second_elapsed >= Duration::from_millis(20),
+            "second throttle should wait close to target delay, got {:?}",
+            second_elapsed
+        );
     }
 }

--- a/crates/stygian-browser/src/behavior.rs
+++ b/crates/stygian-browser/src/behavior.rs
@@ -22,6 +22,7 @@ use chromiumoxide::Page;
 use chromiumoxide::cdp::browser_protocol::input::{DispatchKeyEventParams, DispatchKeyEventType};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::time::sleep;
+use tracing::warn;
 
 use crate::error::{BrowserError, Result};
 
@@ -698,7 +699,7 @@ impl InteractionSimulator {
                 .unwrap_or("Tab");
             let down_delay = rand_range(&mut self.rng, 50.0, 120.0) as u64;
             sleep(Duration::from_millis(down_delay)).await;
-            Self::js(
+            if let Err(e) = Self::js(
                 page,
                 format!(
                     "window.dispatchEvent(new KeyboardEvent('keydown',\
@@ -706,10 +707,12 @@ impl InteractionSimulator {
                 ),
             )
             .await
-            .ok();
+            {
+                warn!(key, "Failed to dispatch keydown event: {e}");
+            }
             let hold_ms = rand_range(&mut self.rng, 20.0, 60.0) as u64;
             sleep(Duration::from_millis(hold_ms)).await;
-            Self::js(
+            if let Err(e) = Self::js(
                 page,
                 format!(
                     "window.dispatchEvent(new KeyboardEvent('keyup',\
@@ -717,7 +720,9 @@ impl InteractionSimulator {
                 ),
             )
             .await
-            .ok();
+            {
+                warn!(key, "Failed to dispatch keyup event: {e}");
+            }
         }
         Ok(())
     }
@@ -1213,7 +1218,7 @@ mod tests {
 
     #[test]
     fn request_pacer_with_rate_clamps_extreme() {
-        // Very high rps effectively floors to 0.01 rps minimum
+        // Very high rps yields a very small mean delay; mean_ms should still be at least 1 ms
         let p = RequestPacer::with_rate(1_000.0);
         assert!(p.mean_ms >= 1);
     }

--- a/crates/stygian-browser/src/behavior.rs
+++ b/crates/stygian-browser/src/behavior.rs
@@ -1259,34 +1259,31 @@ mod tests {
         assert_eq!(p.max_ms, 2_000);
     }
 
-    #[tokio::test(start_paused = true)]
-    async fn request_pacer_throttle_first_immediate_then_waits()
-    -> std::result::Result<(), tokio::task::JoinError> {
+    #[tokio::test]
+    async fn request_pacer_throttle_first_immediate_then_waits() {
         let mut p = RequestPacer::with_timing(25, 0, 25, 25);
 
-        // First call should complete immediately even under paused time.
+        // First call should complete immediately.
         p.throttle().await;
 
-        // Second call should block until 25 ms of virtual time has advanced.
+        // Second call should not complete immediately.
         let handle = tokio::spawn(async move {
             p.throttle().await;
         });
 
-        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
         assert!(
             !handle.is_finished(),
             "second throttle unexpectedly finished early"
         );
 
-        tokio::time::advance(Duration::from_millis(24)).await;
-        tokio::task::yield_now().await;
+        let joined = tokio::time::timeout(Duration::from_millis(200), handle).await;
         assert!(
-            !handle.is_finished(),
-            "second throttle finished before target delay"
+            joined.is_ok(),
+            "second throttle did not finish within timeout"
         );
-
-        tokio::time::advance(Duration::from_millis(1)).await;
-        handle.await?;
-        Ok(())
+        if let Ok(join_res) = joined {
+            assert!(join_res.is_ok(), "throttle task join failed");
+        }
     }
 }

--- a/crates/stygian-browser/src/behavior.rs
+++ b/crates/stygian-browser/src/behavior.rs
@@ -20,7 +20,7 @@
 
 use chromiumoxide::Page;
 use chromiumoxide::cdp::browser_protocol::input::{DispatchKeyEventParams, DispatchKeyEventType};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::time::sleep;
 
 use crate::error::{BrowserError, Result};
@@ -681,6 +681,47 @@ impl InteractionSimulator {
         .await
     }
 
+    /// Dispatch synthetic key events to `window` so behavioural-biometric SDKs
+    /// (Cloudflare Turnstile Signal Orchestrator, `OpenAI` Sentinel SO) accumulate
+    /// non-zero keystroke telemetry before a protected action fires.
+    ///
+    /// Events are dispatched at window-level (bubbling) since SO listeners are
+    /// installed there.  Arrow/Tab keys are used — they do not activate UI
+    /// elements but are universally listened for by signal trackers.
+    async fn do_keyactivity(&mut self, page: &Page) -> Result<()> {
+        const KEYS: &[&str] = &["ArrowDown", "Tab", "ArrowRight", "ArrowUp"];
+        let count = 3 + rand_range(&mut self.rng, 0.0, 4.0) as u32;
+        for i in 0..count {
+            let key = KEYS
+                .get((i as usize) % KEYS.len())
+                .copied()
+                .unwrap_or("Tab");
+            let down_delay = rand_range(&mut self.rng, 50.0, 120.0) as u64;
+            sleep(Duration::from_millis(down_delay)).await;
+            Self::js(
+                page,
+                format!(
+                    "window.dispatchEvent(new KeyboardEvent('keydown',\
+                     {{bubbles:true,cancelable:true,key:{key:?},code:{key:?}}}));"
+                ),
+            )
+            .await
+            .ok();
+            let hold_ms = rand_range(&mut self.rng, 20.0, 60.0) as u64;
+            sleep(Duration::from_millis(hold_ms)).await;
+            Self::js(
+                page,
+                format!(
+                    "window.dispatchEvent(new KeyboardEvent('keyup',\
+                     {{bubbles:true,cancelable:true,key:{key:?},code:{key:?}}}));"
+                ),
+            )
+            .await
+            .ok();
+        }
+        Ok(())
+    }
+
     /// Scroll down a random amount, then partially scroll back up.
     async fn do_scroll(&mut self, page: &Page) -> Result<()> {
         let down = rand_range(&mut self.rng, 200.0, 600.0) as i64;
@@ -731,22 +772,32 @@ impl InteractionSimulator {
             }
             InteractionLevel::Medium => {
                 self.do_scroll(page).await?;
-                let p1 = rand_range(&mut self.rng, 1_000.0, 3_000.0) as u64;
+                let p1 = rand_range(&mut self.rng, 800.0, 2_000.0) as u64;
                 sleep(Duration::from_millis(p1)).await;
-                self.do_mouse_wiggle(page, viewport_w, viewport_h).await?;
-                let p2 = rand_range(&mut self.rng, 500.0, 2_000.0) as u64;
+                // Key events populate behavioural-biometric trackers.
+                self.do_keyactivity(page).await?;
+                let p2 = rand_range(&mut self.rng, 500.0, 1_500.0) as u64;
                 sleep(Duration::from_millis(p2)).await;
+                self.do_mouse_wiggle(page, viewport_w, viewport_h).await?;
+                let p3 = rand_range(&mut self.rng, 400.0, 1_500.0) as u64;
+                sleep(Duration::from_millis(p3)).await;
             }
             InteractionLevel::High => {
                 self.do_scroll(page).await?;
                 let p1 = rand_range(&mut self.rng, 1_000.0, 5_000.0) as u64;
                 sleep(Duration::from_millis(p1)).await;
-                self.do_mouse_wiggle(page, viewport_w, viewport_h).await?;
-                let p2 = rand_range(&mut self.rng, 800.0, 3_000.0) as u64;
+                self.do_keyactivity(page).await?;
+                let p2 = rand_range(&mut self.rng, 400.0, 1_200.0) as u64;
                 sleep(Duration::from_millis(p2)).await;
                 self.do_mouse_wiggle(page, viewport_w, viewport_h).await?;
-                let p3 = rand_range(&mut self.rng, 500.0, 2_000.0) as u64;
+                let p3 = rand_range(&mut self.rng, 800.0, 3_000.0) as u64;
                 sleep(Duration::from_millis(p3)).await;
+                self.do_keyactivity(page).await?;
+                let p4 = rand_range(&mut self.rng, 300.0, 800.0) as u64;
+                sleep(Duration::from_millis(p4)).await;
+                self.do_mouse_wiggle(page, viewport_w, viewport_h).await?;
+                let p5 = rand_range(&mut self.rng, 500.0, 2_000.0) as u64;
+                sleep(Duration::from_millis(p5)).await;
                 // Occasional scroll-back (40 % chance).
                 if rand_f64(&mut self.rng) < 0.4 {
                     let up = -(rand_range(&mut self.rng, 50.0, 200.0) as i64);
@@ -756,6 +807,153 @@ impl InteractionSimulator {
             }
         }
         Ok(())
+    }
+}
+
+// ─── RequestPacer ─────────────────────────────────────────────────────────────
+
+/// Paces programmatic HTTP/CDP requests with human-realistic inter-request delays.
+///
+/// Prevents tight-loop request patterns that are trivially detectable by server-side
+/// rate analysers (Cloudflare, Akamai, `DataDome`, AWS WAF).  Delays follow a truncated
+/// Gaussian distribution centred on `mean_ms` with `std_ms` variance, giving natural
+/// bursty-but-not-mechanical timing.
+///
+/// The first call to [`throttle`][RequestPacer::throttle] always returns immediately
+/// (no prior request to pace against).
+///
+/// # Example
+///
+/// ```no_run
+/// use stygian_browser::behavior::RequestPacer;
+///
+/// # async fn run() {
+/// let mut pacer = RequestPacer::new();
+/// for url in &["https://a.example.com", "https://b.example.com"] {
+///     pacer.throttle().await;
+///     // … make request to url …
+/// }
+/// # }
+/// ```
+pub struct RequestPacer {
+    rng: u64,
+    mean_ms: u64,
+    std_ms: u64,
+    min_ms: u64,
+    max_ms: u64,
+    last_request: Option<Instant>,
+}
+
+impl Default for RequestPacer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RequestPacer {
+    /// Default pacer: mean 1 200 ms, σ = 400 ms, clamped 400–4 000 ms.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_browser::behavior::RequestPacer;
+    /// let _pacer = RequestPacer::new();
+    /// ```
+    pub fn new() -> Self {
+        let seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() ^ u64::from(d.subsec_nanos()))
+            .unwrap_or(0xdead_beef_cafe_1337);
+        Self {
+            rng: seed,
+            mean_ms: 1_200,
+            std_ms: 400,
+            min_ms: 400,
+            max_ms: 4_000,
+            last_request: None,
+        }
+    }
+
+    /// Create with explicit timing parameters (all values in milliseconds).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_browser::behavior::RequestPacer;
+    /// // Aggressive: ~500 ms mean, σ = 150 ms, clamped 200–1 500 ms.
+    /// let _pacer = RequestPacer::with_timing(500, 150, 200, 1_500);
+    /// ```
+    pub fn with_timing(mean_ms: u64, std_ms: u64, min_ms: u64, max_ms: u64) -> Self {
+        let seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() ^ u64::from(d.subsec_nanos()))
+            .unwrap_or(0xdead_beef_cafe_1337);
+        Self {
+            rng: seed,
+            mean_ms,
+            std_ms,
+            min_ms,
+            max_ms,
+            last_request: None,
+        }
+    }
+
+    /// Construct from a target requests-per-second rate.
+    ///
+    /// Mean = `1000 / rps` ms, σ = 25 % of mean, clamped to ±50 % of mean.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_browser::behavior::RequestPacer;
+    /// let _pacer = RequestPacer::with_rate(0.5); // ~1 request every 2 s
+    /// ```
+    pub fn with_rate(requests_per_second: f64) -> Self {
+        let mean_ms = (1_000.0 / requests_per_second.max(0.01)) as u64;
+        let std_ms = mean_ms / 4;
+        let min_ms = mean_ms / 2;
+        let max_ms = mean_ms.saturating_mul(2);
+        let seed = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() ^ u64::from(d.subsec_nanos()))
+            .unwrap_or(0xdead_beef_cafe_1337);
+        Self {
+            rng: seed,
+            mean_ms,
+            std_ms,
+            min_ms,
+            max_ms,
+            last_request: None,
+        }
+    }
+
+    /// Wait until the appropriate inter-request delay has elapsed, then return.
+    ///
+    /// The first call returns immediately.  Subsequent calls sleep remaining time
+    /// to match the sampled target delay.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # async fn run() {
+    /// use stygian_browser::behavior::RequestPacer;
+    /// let mut pacer = RequestPacer::new();
+    /// pacer.throttle().await; // first call: immediate
+    /// pacer.throttle().await; // waits ~1.2 s
+    /// # }
+    /// ```
+    pub async fn throttle(&mut self) {
+        let target_ms = rand_normal(&mut self.rng, self.mean_ms as f64, self.std_ms as f64)
+            .max(self.min_ms as f64)
+            .min(self.max_ms as f64) as u64;
+
+        if let Some(last) = self.last_request {
+            let elapsed_ms = last.elapsed().as_millis() as u64;
+            if elapsed_ms < target_ms {
+                sleep(Duration::from_millis(target_ms - elapsed_ms)).await;
+            }
+        }
+        self.last_request = Some(Instant::now());
     }
 }
 
@@ -984,5 +1182,39 @@ mod tests {
     fn interaction_simulator_default_is_none_level() {
         let sim = InteractionSimulator::default();
         assert_eq!(sim.level, InteractionLevel::None);
+    }
+
+    #[test]
+    fn request_pacer_new_has_expected_defaults() {
+        let p = RequestPacer::new();
+        assert_eq!(p.mean_ms, 1_200);
+        assert_eq!(p.min_ms, 400);
+        assert_eq!(p.max_ms, 4_000);
+        assert!(p.last_request.is_none());
+    }
+
+    #[test]
+    fn request_pacer_with_timing_stores_params() {
+        let p = RequestPacer::with_timing(500, 100, 200, 2_000);
+        assert_eq!(p.mean_ms, 500);
+        assert_eq!(p.std_ms, 100);
+        assert_eq!(p.min_ms, 200);
+        assert_eq!(p.max_ms, 2_000);
+    }
+
+    #[test]
+    fn request_pacer_with_rate_computes_mean() {
+        // 0.5 rps → mean = 2 000 ms
+        let p = RequestPacer::with_rate(0.5);
+        assert_eq!(p.mean_ms, 2_000);
+        assert_eq!(p.min_ms, 1_000);
+        assert_eq!(p.max_ms, 4_000);
+    }
+
+    #[test]
+    fn request_pacer_with_rate_clamps_extreme() {
+        // Very high rps effectively floors to 0.01 rps minimum
+        let p = RequestPacer::with_rate(1_000.0);
+        assert!(p.mean_ms >= 1);
     }
 }

--- a/crates/stygian-browser/src/behavior.rs
+++ b/crates/stygian-browser/src/behavior.rs
@@ -692,6 +692,7 @@ impl InteractionSimulator {
     async fn do_keyactivity(&mut self, page: &Page) -> Result<()> {
         const KEYS: &[&str] = &["ArrowDown", "Tab", "ArrowRight", "ArrowUp"];
         let count = 3 + rand_range(&mut self.rng, 0.0, 4.0) as u32;
+        let mut successful_pairs = 0u32;
         for i in 0..count {
             let key = KEYS
                 .get((i as usize) % KEYS.len())
@@ -699,7 +700,7 @@ impl InteractionSimulator {
                 .unwrap_or("Tab");
             let down_delay = rand_range(&mut self.rng, 50.0, 120.0) as u64;
             sleep(Duration::from_millis(down_delay)).await;
-            if let Err(e) = Self::js(
+            let keydown_ok = if let Err(e) = Self::js(
                 page,
                 format!(
                     "window.dispatchEvent(new KeyboardEvent('keydown',\
@@ -709,10 +710,13 @@ impl InteractionSimulator {
             .await
             {
                 warn!(key, "Failed to dispatch keydown event: {e}");
-            }
+                false
+            } else {
+                true
+            };
             let hold_ms = rand_range(&mut self.rng, 20.0, 60.0) as u64;
             sleep(Duration::from_millis(hold_ms)).await;
-            if let Err(e) = Self::js(
+            let keyup_ok = if let Err(e) = Self::js(
                 page,
                 format!(
                     "window.dispatchEvent(new KeyboardEvent('keyup',\
@@ -722,8 +726,23 @@ impl InteractionSimulator {
             .await
             {
                 warn!(key, "Failed to dispatch keyup event: {e}");
+                false
+            } else {
+                true
+            };
+
+            if keydown_ok && keyup_ok {
+                successful_pairs += 1;
             }
         }
+
+        if successful_pairs == 0 {
+            return Err(BrowserError::CdpError {
+                operation: "InteractionSimulator::do_keyactivity".to_string(),
+                message: "all synthetic key event dispatches failed".to_string(),
+            });
+        }
+
         Ok(())
     }
 
@@ -751,8 +770,8 @@ impl InteractionSimulator {
     /// | ---------- | ----------------------------------------------------------- |
     /// | `None`   | No-op                                                     |
     /// | `Low`    | One scroll + short pause (500–1 500 ms)                   |
-    /// | `Medium` | Scroll + mouse wiggle + reading pause (1–3 s)             |
-    /// | `High`   | Medium + second wiggle + optional scroll-back             |
+    /// | `Medium` | Scroll + key activity + mouse wiggle + reading pauses     |
+    /// | `High`   | Medium + extra key activity + extra wiggle + optional up-scroll |
     ///
     /// # Parameters
     ///
@@ -1240,26 +1259,34 @@ mod tests {
         assert_eq!(p.max_ms, 2_000);
     }
 
-    #[tokio::test]
-    async fn request_pacer_throttle_first_immediate_then_waits() {
+    #[tokio::test(start_paused = true)]
+    async fn request_pacer_throttle_first_immediate_then_waits()
+    -> std::result::Result<(), tokio::task::JoinError> {
         let mut p = RequestPacer::with_timing(25, 0, 25, 25);
 
-        let start = Instant::now();
+        // First call should complete immediately even under paused time.
         p.throttle().await;
-        let first_elapsed = start.elapsed();
+
+        // Second call should block until 25 ms of virtual time has advanced.
+        let handle = tokio::spawn(async move {
+            p.throttle().await;
+        });
+
+        tokio::task::yield_now().await;
         assert!(
-            first_elapsed < Duration::from_millis(10),
-            "first throttle should be immediate, got {:?}",
-            first_elapsed
+            !handle.is_finished(),
+            "second throttle unexpectedly finished early"
         );
 
-        let second_start = Instant::now();
-        p.throttle().await;
-        let second_elapsed = second_start.elapsed();
+        tokio::time::advance(Duration::from_millis(24)).await;
+        tokio::task::yield_now().await;
         assert!(
-            second_elapsed >= Duration::from_millis(20),
-            "second throttle should wait close to target delay, got {:?}",
-            second_elapsed
+            !handle.is_finished(),
+            "second throttle finished before target delay"
         );
+
+        tokio::time::advance(Duration::from_millis(1)).await;
+        handle.await?;
+        Ok(())
     }
 }

--- a/crates/stygian-browser/src/fingerprint.rs
+++ b/crates/stygian-browser/src/fingerprint.rs
@@ -1129,9 +1129,10 @@ fn storage_estimate_spoof_script() -> String {
     const usage = (5  + _seed % 10) * 1048576;
     navigator.storage.estimate = function() {
       return _origEstimate().then(function(result) {
-        result.quota = quota;
-        result.usage = usage;
-        return result;
+                return Object.assign({}, result, {
+                    quota: quota,
+                    usage: usage
+                });
       });
     };
   })();"

--- a/crates/stygian-browser/src/fingerprint.rs
+++ b/crates/stygian-browser/src/fingerprint.rs
@@ -1075,14 +1075,14 @@ fn connection_spoof_script() -> String {
 
 /// Intercept `getBoundingClientRect` on hidden font-probe elements.
 ///
-/// Turnstile creates a hidden `<div>`, sets a font family, renders a string,
-/// and measures `getBoundingClientRect` to verify the font physically renders.
-/// A headless browser using our injected font list returns different layout
-/// dimensions than the profile claims because the font may not be installed in
-/// the sandbox.  We intercept `getBoundingClientRect` on any element whose
-/// computed `fontFamily` is a font from our injected list and return plausible
-/// non-zero dimensions drawn from a seeded deterministic jitter so the same
-/// call always returns the same value within a session.
+/// Turnstile creates a hidden `<div>`, renders a string, and measures
+/// `getBoundingClientRect` to verify the font physically renders.  In headless
+/// Chrome the sandbox may not have the font installed, so the browser returns a
+/// zero-size rect.  This intercept detects zero-size rects on elements that are
+/// hidden (`visibility:hidden` or `aria-hidden`) with absolute/fixed positioning
+/// (the canonical font-probe pattern) and returns plausible non-zero dimensions
+/// drawn from a seeded deterministic jitter so the same call always returns the
+/// same value within a session.
 fn font_measurement_intercept_script() -> String {
     r"  // getBoundingClientRect font-probe intercept (Turnstile Layer 1)
   (function() {
@@ -1104,15 +1104,7 @@ fn font_measurement_intercept_script() -> String {
             (pos === 'absolute' || pos === 'fixed')) {
           const w = _jitter(10, 8);
           const h = _jitter(14, 4);
-          return {
-            width: w, height: h,
-            top: 0, left: 0,
-            right: w, bottom: h,
-            x: 0, y: 0,
-            toJSON: function() {
-              return { width: w, height: h, top: 0, left: 0, right: w, bottom: h, x: 0, y: 0 };
-            },
-          };
+          return new DOMRect(0, 0, w, h);
         }
       }
       return rect;

--- a/crates/stygian-browser/src/fingerprint.rs
+++ b/crates/stygian-browser/src/fingerprint.rs
@@ -691,6 +691,8 @@ impl Fingerprint {
 
         parts.push(audio_fingerprint_script());
         parts.push(connection_spoof_script());
+        parts.push(font_measurement_intercept_script());
+        parts.push(storage_estimate_spoof_script());
         parts.push(battery_spoof_script());
         parts.push(plugins_spoof_script());
 
@@ -930,6 +932,9 @@ impl BrowserKind {
 fn screen_script((width, height): (u32, u32)) -> String {
     // availHeight leaves ~40 px for a taskbar / dock.
     let avail_height = height.saturating_sub(40);
+    // availLeft/availTop: on Windows the taskbar is usually at the bottom so
+    // both are 0. Spoofing to 0 matches the most common real-device value and
+    // avoids the headless default which Turnstile checks explicitly.
     format!(
         r"  // Screen dimensions
   const _defineScreen = (prop, val) =>
@@ -938,6 +943,8 @@ fn screen_script((width, height): (u32, u32)) -> String {
   _defineScreen('height',      {height});
   _defineScreen('availWidth',  {width});
   _defineScreen('availHeight', {avail_height});
+  _defineScreen('availLeft',   0);
+  _defineScreen('availTop',    0);
   _defineScreen('colorDepth',  24);
   _defineScreen('pixelDepth',  24);
   // outerWidth/outerHeight: headless Chrome may return 0; spoof to viewport size.
@@ -1062,6 +1069,79 @@ fn connection_spoof_script() -> String {
         configurable: false,
       });
     } catch (_) {}
+  })();"
+        .to_string()
+}
+
+/// Intercept `getBoundingClientRect` on hidden font-probe elements.
+///
+/// Turnstile creates a hidden `<div>`, sets a font family, renders a string,
+/// and measures `getBoundingClientRect` to verify the font physically renders.
+/// A headless browser using our injected font list returns different layout
+/// dimensions than the profile claims because the font may not be installed in
+/// the sandbox.  We intercept `getBoundingClientRect` on any element whose
+/// computed `fontFamily` is a font from our injected list and return plausible
+/// non-zero dimensions drawn from a seeded deterministic jitter so the same
+/// call always returns the same value within a session.
+fn font_measurement_intercept_script() -> String {
+    r"  // getBoundingClientRect font-probe intercept (Turnstile Layer 1)
+  (function() {
+    const _origGBCR = Element.prototype.getBoundingClientRect;
+    const _seed = Math.floor(performance.timeOrigin % 9973);
+    function _jitter(base, range) {
+      return base + ((_seed * 1103515245 + 12345) & 0x7fffffff) % range;
+    }
+    Element.prototype.getBoundingClientRect = function() {
+      const rect = _origGBCR.call(this);
+      // Only intercept zero-size rects on hidden probe elements (the font-
+      // measurement pattern: position absolute/fixed, visibility hidden).
+      if (rect.width === 0 && rect.height === 0) {
+        const st = window.getComputedStyle(this);
+        const vis = st.getPropertyValue('visibility');
+        const pos = st.getPropertyValue('position');
+        const ariaHidden = this.getAttribute('aria-hidden');
+        if ((vis === 'hidden' || ariaHidden === 'true') &&
+            (pos === 'absolute' || pos === 'fixed')) {
+          const w = _jitter(10, 8);
+          const h = _jitter(14, 4);
+          return {
+            width: w, height: h,
+            top: 0, left: 0,
+            right: w, bottom: h,
+            x: 0, y: 0,
+            toJSON: function() {
+              return { width: w, height: h, top: 0, left: 0, right: w, bottom: h, x: 0, y: 0 };
+            },
+          };
+        }
+      }
+      return rect;
+    };
+  })();"
+        .to_string()
+}
+
+/// Spoof `navigator.storage.estimate()` to return realistic quota/usage values.
+///
+/// Headless Chrome returns a very low `quota` (typically 60–120 MB) vs a real
+/// browser profile which accumulates gigabytes of quota.  Turnstile explicitly
+/// reads `quota` and `usage` to compare against expected real-profile ranges.
+fn storage_estimate_spoof_script() -> String {
+    r"  // navigator.storage.estimate() spoof (Turnstile Layer 1 — storage)
+  (function() {
+    if (!navigator.storage || typeof navigator.storage.estimate !== 'function') return;
+    const _origEstimate = navigator.storage.estimate.bind(navigator.storage);
+    const _seed = Math.floor(performance.timeOrigin % 9973);
+    // Realistic Chrome profile: ~250 GB quota, small stable usage.
+    const quota = (240 + _seed % 20) * 1073741824;
+    const usage = (5  + _seed % 10) * 1048576;
+    navigator.storage.estimate = function() {
+      return _origEstimate().then(function(result) {
+        result.quota = quota;
+        result.usage = usage;
+        return result;
+      });
+    };
   })();"
         .to_string()
 }

--- a/crates/stygian-browser/src/lib.rs
+++ b/crates/stygian-browser/src/lib.rs
@@ -137,6 +137,8 @@ pub use stealth::{NavigatorProfile, StealthConfig, StealthProfile};
 #[cfg(feature = "stealth")]
 pub use behavior::InteractionLevel;
 #[cfg(feature = "stealth")]
+pub use behavior::RequestPacer;
+#[cfg(feature = "stealth")]
 pub use fingerprint::{BrowserKind, DeviceProfile};
 
 #[cfg(feature = "stealth")]

--- a/crates/stygian-proxy/Cargo.toml
+++ b/crates/stygian-proxy/Cargo.toml
@@ -34,6 +34,9 @@ async-trait = { workspace = true }
 # reqwest — socks feature is unlocked via the "socks" cargo feature
 reqwest = { workspace = true }
 
+# Async concurrency utilities
+futures = { workspace = true }
+
 # Random strategy
 rand = "0.9"
 

--- a/crates/stygian-proxy/src/error.rs
+++ b/crates/stygian-proxy/src/error.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 /// }
 /// ```
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ProxyError {
     /// The proxy pool has no available proxies to hand out.
     #[error("proxy pool is exhausted")]

--- a/crates/stygian-proxy/src/error.rs
+++ b/crates/stygian-proxy/src/error.rs
@@ -54,6 +54,15 @@ pub enum ProxyError {
     /// A configuration error.
     #[error("configuration error: {0}")]
     ConfigError(String),
+
+    /// A remote proxy list could not be fetched or parsed.
+    #[error("proxy fetch failed from `{origin}`: {message}")]
+    FetchFailed {
+        /// URL or identifier of the remote source.
+        origin: String,
+        /// Human-readable description of the failure.
+        message: String,
+    },
 }
 
 /// Convenience result alias for all stygian-proxy operations.

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -368,7 +368,8 @@ mod tests {
 
     #[test]
     fn free_list_source_url_is_nonempty() {
-        let mut sources = vec![
+        #[cfg(not(feature = "socks"))]
+        let sources = vec![
             FreeListSource::TheSpeedXHttp,
             FreeListSource::ClarketmHttp,
             FreeListSource::OpenProxyListHttp,
@@ -378,10 +379,22 @@ mod tests {
             },
         ];
         #[cfg(feature = "socks")]
-        sources.extend([
-            FreeListSource::TheSpeedXSocks4,
-            FreeListSource::TheSpeedXSocks5,
-        ]);
+        let sources = {
+            let mut s = vec![
+                FreeListSource::TheSpeedXHttp,
+                FreeListSource::ClarketmHttp,
+                FreeListSource::OpenProxyListHttp,
+                FreeListSource::Custom {
+                    url: "https://example.com/proxies.txt".into(),
+                    proxy_type: ProxyType::Http,
+                },
+            ];
+            s.extend([
+                FreeListSource::TheSpeedXSocks4,
+                FreeListSource::TheSpeedXSocks5,
+            ]);
+            s
+        };
         for src in &sources {
             assert!(
                 !src.url().is_empty(),

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -226,6 +226,36 @@ impl FreeListFetcher {
         self
     }
 
+    /// Parse one `host:port` line, including bracketed IPv6 addresses.
+    fn parse_host_port_line(line: &str) -> Option<(String, u16)> {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            return None;
+        }
+
+        let (host, port_str) = if line.starts_with('[') {
+            let end = line.find(']')?;
+            let host = line.get(..=end)?.trim();
+            let remainder = line.get(end + 1..)?.trim();
+            let (_, port_str) = remainder.rsplit_once(':')?;
+            (host, port_str.trim())
+        } else {
+            let (host, port_str) = line.rsplit_once(':')?;
+            (host.trim(), port_str.trim())
+        };
+
+        if host.is_empty() || host == "[]" {
+            return None;
+        }
+
+        let port = port_str.parse::<u16>().ok()?;
+        if port == 0 {
+            return None;
+        }
+
+        Some((host.to_string(), port))
+    }
+
     /// Fetch a single source, returning parsed proxies (empty on failure).
     async fn fetch_source(&self, source: &FreeListSource) -> Vec<Proxy> {
         let url = source.url();
@@ -255,17 +285,7 @@ impl FreeListFetcher {
         let proxies: Vec<Proxy> = body
             .lines()
             .filter_map(|line| {
-                let line = line.trim();
-                if line.is_empty() || line.starts_with('#') {
-                    return None;
-                }
-                // Expect `host:port` — both halves must be present and port numeric.
-                let mut parts = line.splitn(2, ':');
-                let host = parts.next()?.trim();
-                let port_str = parts.next()?.trim();
-                if port_str.parse::<u16>().is_err() {
-                    return None;
-                }
+                let (host, port) = Self::parse_host_port_line(line)?;
                 let scheme = match proxy_type {
                     ProxyType::Http => "http",
                     ProxyType::Https => "https",
@@ -275,7 +295,7 @@ impl FreeListFetcher {
                     ProxyType::Socks5 => "socks5",
                 };
                 Some(Proxy {
-                    url: format!("{scheme}://{host}:{port_str}"),
+                    url: format!("{scheme}://{host}:{port}"),
                     proxy_type,
                     username: None,
                     password: None,
@@ -293,6 +313,12 @@ impl FreeListFetcher {
 #[async_trait]
 impl ProxyFetcher for FreeListFetcher {
     async fn fetch(&self) -> ProxyResult<Vec<Proxy>> {
+        if self.sources.is_empty() {
+            return Err(ProxyError::ConfigError(
+                "no sources configured for FreeListFetcher".into(),
+            ));
+        }
+
         // Drive all source fetches concurrently.
         let results = join_all(self.sources.iter().map(|s| self.fetch_source(s))).await;
         let all: Vec<Proxy> = results.into_iter().flatten().collect();
@@ -423,22 +449,13 @@ mod tests {
     fn free_list_fetcher_parse_valid_lines() {
         let fetcher = FreeListFetcher::new(vec![]);
         // Test the parsing logic directly by calling parse on synthetic text.
-        let text = "1.2.3.4:8080\n# comment\n\nbad-line\n5.6.7.8:3128\n";
+        let text = "1.2.3.4:8080\n# comment\n\nbad-line\n5.6.7.8:3128\n[2001:db8::1]:8081\n";
         let parsed: Vec<Proxy> = text
             .lines()
             .filter_map(|line| {
-                let line = line.trim();
-                if line.is_empty() || line.starts_with('#') {
-                    return None;
-                }
-                let mut parts = line.splitn(2, ':');
-                let host = parts.next()?.trim();
-                let port_str = parts.next()?.trim();
-                if port_str.parse::<u16>().is_err() {
-                    return None;
-                }
+                let (host, port) = FreeListFetcher::parse_host_port_line(line)?;
                 Some(Proxy {
-                    url: format!("http://{host}:{port_str}"),
+                    url: format!("http://{host}:{port}"),
                     proxy_type: ProxyType::Http,
                     username: None,
                     password: None,
@@ -448,9 +465,10 @@ mod tests {
             })
             .collect();
 
-        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed.len(), 3);
         assert_eq!(parsed[0].url, "http://1.2.3.4:8080");
         assert_eq!(parsed[1].url, "http://5.6.7.8:3128");
+        assert_eq!(parsed[2].url, "http://[2001:db8::1]:8081");
     }
 
     #[test]
@@ -462,11 +480,27 @@ mod tests {
 
     #[test]
     fn free_list_fetcher_skips_invalid_port() {
-        let line = "1.2.3.4:notaport";
-        let mut parts = line.splitn(2, ':');
-        let _host = parts.next().unwrap();
-        let port_str = parts.next().unwrap();
-        assert!(port_str.parse::<u16>().is_err());
+        assert!(FreeListFetcher::parse_host_port_line("1.2.3.4:notaport").is_none());
+        assert!(FreeListFetcher::parse_host_port_line("1.2.3.4:0").is_none());
+        assert!(FreeListFetcher::parse_host_port_line(":8080").is_none());
+    }
+
+    #[test]
+    fn free_list_fetcher_empty_sources_is_config_error() {
+        let fetcher = FreeListFetcher::new(vec![]);
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap_or_else(|e| panic!("failed to build runtime for test: {e}"));
+        let err = rt
+            .block_on(fetcher.fetch())
+            .expect_err("empty sources should fail");
+        match err {
+            ProxyError::ConfigError(msg) => {
+                assert!(msg.contains("no sources configured"));
+            }
+            other => panic!("unexpected error variant: {other}"),
+        }
     }
 
     #[test]

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -22,7 +22,6 @@
 //! # async fn run() -> stygian_proxy::error::ProxyResult<()> {
 //! let fetcher = FreeListFetcher::new(vec![
 //!     FreeListSource::TheSpeedXHttp,
-//!     FreeListSource::TheSpeedXSocks5,
 //! ]);
 //!
 //! let manager = ProxyManager::builder()
@@ -37,6 +36,7 @@
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures::future::join_all;
 use reqwest::Client;
 use tracing::{debug, warn};
 
@@ -106,9 +106,11 @@ pub trait ProxyFetcher: Send + Sync {
 pub enum FreeListSource {
     /// HTTP proxies from `TheSpeedX/PROXY-List` (GitHub, plain `host:port`).
     TheSpeedXHttp,
-    /// SOCKS4 proxies from `TheSpeedX/PROXY-List`.
+    #[cfg(feature = "socks")]
+    /// SOCKS4 proxies from `TheSpeedX/PROXY-List` (requires the `socks` feature).
     TheSpeedXSocks4,
-    /// SOCKS5 proxies from `TheSpeedX/PROXY-List`.
+    #[cfg(feature = "socks")]
+    /// SOCKS5 proxies from `TheSpeedX/PROXY-List` (requires the `socks` feature).
     TheSpeedXSocks5,
     /// HTTP proxies from `clarketm/proxy-list` (GitHub, plain `host:port`).
     ClarketmHttp,
@@ -129,9 +131,11 @@ impl FreeListSource {
             Self::TheSpeedXHttp => {
                 "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/http.txt"
             }
+            #[cfg(feature = "socks")]
             Self::TheSpeedXSocks4 => {
                 "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/socks4.txt"
             }
+            #[cfg(feature = "socks")]
             Self::TheSpeedXSocks5 => {
                 "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/socks5.txt"
             }
@@ -146,7 +150,9 @@ impl FreeListSource {
     fn proxy_type(&self) -> ProxyType {
         match self {
             Self::TheSpeedXHttp | Self::ClarketmHttp | Self::OpenProxyListHttp => ProxyType::Http,
+            #[cfg(feature = "socks")]
             Self::TheSpeedXSocks4 => ProxyType::Socks4,
+            #[cfg(feature = "socks")]
             Self::TheSpeedXSocks5 => ProxyType::Socks5,
             Self::Custom { proxy_type, .. } => *proxy_type,
         }
@@ -194,9 +200,10 @@ impl FreeListFetcher {
         let client = Client::builder()
             .timeout(Duration::from_secs(10))
             .build()
-            // Client construction only fails when TLS backend is unavailable,
-            // which is a compile-time configuration issue, not a runtime one.
-            .unwrap_or_default();
+            .unwrap_or_else(|e| {
+                warn!("Failed to build HTTP client with 10 s timeout (TLS backend issue?): {e}; falling back to default client");
+                Client::default()
+            });
         Self {
             sources,
             client,
@@ -260,8 +267,11 @@ impl FreeListFetcher {
                     return None;
                 }
                 let scheme = match proxy_type {
-                    ProxyType::Http | ProxyType::Https => "http",
+                    ProxyType::Http => "http",
+                    ProxyType::Https => "https",
+                    #[cfg(feature = "socks")]
                     ProxyType::Socks4 => "socks4",
+                    #[cfg(feature = "socks")]
                     ProxyType::Socks5 => "socks5",
                 };
                 Some(Proxy {
@@ -283,17 +293,9 @@ impl FreeListFetcher {
 #[async_trait]
 impl ProxyFetcher for FreeListFetcher {
     async fn fetch(&self) -> ProxyResult<Vec<Proxy>> {
-        // Fetch all sources concurrently.
-        let mut handles = Vec::with_capacity(self.sources.len());
-        for source in &self.sources {
-            handles.push(self.fetch_source(source));
-        }
-        // Sequential join — futures are not Send across .join_all without boxing;
-        // sources are typically 3–5 so sequential is fine.
-        let mut all: Vec<Proxy> = Vec::new();
-        for handle in handles {
-            all.extend(handle.await);
-        }
+        // Drive all source fetches concurrently.
+        let results = join_all(self.sources.iter().map(|s| self.fetch_source(s))).await;
+        let all: Vec<Proxy> = results.into_iter().flatten().collect();
 
         if all.is_empty() {
             return Err(ProxyError::FetchFailed {
@@ -366,10 +368,8 @@ mod tests {
 
     #[test]
     fn free_list_source_url_is_nonempty() {
-        let sources = [
+        let mut sources = vec![
             FreeListSource::TheSpeedXHttp,
-            FreeListSource::TheSpeedXSocks4,
-            FreeListSource::TheSpeedXSocks5,
             FreeListSource::ClarketmHttp,
             FreeListSource::OpenProxyListHttp,
             FreeListSource::Custom {
@@ -377,6 +377,8 @@ mod tests {
                 proxy_type: ProxyType::Http,
             },
         ];
+        #[cfg(feature = "socks")]
+        sources.extend([FreeListSource::TheSpeedXSocks4, FreeListSource::TheSpeedXSocks5]);
         for src in &sources {
             assert!(
                 !src.url().is_empty(),
@@ -388,14 +390,10 @@ mod tests {
     #[test]
     fn free_list_source_proxy_types() {
         assert_eq!(FreeListSource::TheSpeedXHttp.proxy_type(), ProxyType::Http);
-        assert_eq!(
-            FreeListSource::TheSpeedXSocks4.proxy_type(),
-            ProxyType::Socks4
-        );
-        assert_eq!(
-            FreeListSource::TheSpeedXSocks5.proxy_type(),
-            ProxyType::Socks5
-        );
+        #[cfg(feature = "socks")]
+        assert_eq!(FreeListSource::TheSpeedXSocks4.proxy_type(), ProxyType::Socks4);
+        #[cfg(feature = "socks")]
+        assert_eq!(FreeListSource::TheSpeedXSocks5.proxy_type(), ProxyType::Socks5);
         assert_eq!(FreeListSource::ClarketmHttp.proxy_type(), ProxyType::Http);
     }
 

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -1,0 +1,461 @@
+//! Proxy list fetching — port trait and free-list HTTP adapter.
+//!
+//! [`ProxyFetcher`] is the port trait.  Implement it to pull proxies from any
+//! source (remote HTTP list, database, commercial API, etc.) and integrate with
+//! [`ProxyManager`][crate::ProxyManager] via [`load_from_fetcher`].
+//!
+//! The built-in [`FreeListFetcher`] downloads plain-text `host:port` proxy
+//! lists from public URLs (e.g. the `TheSpeedX/PROXY-List` feeds on GitHub)
+//! and parses them into [`Proxy`] records.  It is suitable for development,
+//! testing, and low-stakes scraping where proxy quality is less critical.
+//!
+//! ## Example — load from a free list and populate the pool
+//!
+//! ```no_run
+//! use std::sync::Arc;
+//! use stygian_proxy::{
+//!     ProxyManager,
+//!     storage::MemoryProxyStore,
+//!     fetcher::{FreeListFetcher, ProxyFetcher, FreeListSource},
+//! };
+//!
+//! # async fn run() -> stygian_proxy::error::ProxyResult<()> {
+//! let fetcher = FreeListFetcher::new(vec![
+//!     FreeListSource::TheSpeedXHttp,
+//!     FreeListSource::TheSpeedXSocks5,
+//! ]);
+//!
+//! let manager = ProxyManager::builder()
+//!     .storage(Arc::new(MemoryProxyStore::default()))
+//!     .build()?;
+//! let loaded = stygian_proxy::fetcher::load_from_fetcher(&manager, &fetcher).await?;
+//! println!("Loaded {loaded} proxies");
+//! # Ok(())
+//! # }
+//! ```
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use reqwest::Client;
+use tracing::{debug, warn};
+
+use crate::{
+    Proxy, ProxyManager, ProxyType,
+    error::{ProxyError, ProxyResult},
+};
+
+// ─── Port trait ───────────────────────────────────────────────────────────────
+
+/// A source that can produce a list of [`Proxy`] records asynchronously.
+///
+/// Implement this trait to integrate any proxy source (remote HTTP list,
+/// commercial API, database, file) with [`load_from_fetcher`].
+///
+/// # Example
+///
+/// ```
+/// use async_trait::async_trait;
+/// use stygian_proxy::{Proxy, ProxyType};
+/// use stygian_proxy::fetcher::ProxyFetcher;
+/// use stygian_proxy::error::ProxyResult;
+///
+/// struct MyStaticFetcher;
+///
+/// #[async_trait]
+/// impl ProxyFetcher for MyStaticFetcher {
+///     async fn fetch(&self) -> ProxyResult<Vec<Proxy>> {
+///         Ok(vec![Proxy {
+///             url: "http://192.168.1.1:8080".into(),
+///             proxy_type: ProxyType::Http,
+///             username: None,
+///             password: None,
+///             weight: 1,
+///             tags: vec!["static".into()],
+///         }])
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait ProxyFetcher: Send + Sync {
+    /// Fetch the current proxy list.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProxyError::FetchFailed`] if the source is unreachable or
+    /// returns malformed data.
+    async fn fetch(&self) -> ProxyResult<Vec<Proxy>>;
+}
+
+// ─── Free-list sources ────────────────────────────────────────────────────────
+
+/// A well-known free/public proxy list feed.
+///
+/// These lists are community-maintained and quality varies.  They are suitable
+/// for development and testing.  For production use, prefer a commercial
+/// provider adapter.
+///
+/// # Example
+///
+/// ```
+/// use stygian_proxy::fetcher::FreeListSource;
+/// let _src = FreeListSource::TheSpeedXHttp;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FreeListSource {
+    /// HTTP proxies from `TheSpeedX/PROXY-List` (GitHub, plain `host:port`).
+    TheSpeedXHttp,
+    /// SOCKS4 proxies from `TheSpeedX/PROXY-List`.
+    TheSpeedXSocks4,
+    /// SOCKS5 proxies from `TheSpeedX/PROXY-List`.
+    TheSpeedXSocks5,
+    /// HTTP proxies from `clarketm/proxy-list` (GitHub, plain `host:port`).
+    ClarketmHttp,
+    /// Mixed HTTP proxies from `openproxylist.xyz`.
+    OpenProxyListHttp,
+    /// A custom URL.  Content must be one `host:port` entry per line.
+    Custom {
+        /// The URL to fetch.
+        url: String,
+        /// The [`ProxyType`] to assign all parsed entries.
+        proxy_type: ProxyType,
+    },
+}
+
+impl FreeListSource {
+    fn url(&self) -> &str {
+        match self {
+            Self::TheSpeedXHttp => {
+                "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/http.txt"
+            }
+            Self::TheSpeedXSocks4 => {
+                "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/socks4.txt"
+            }
+            Self::TheSpeedXSocks5 => {
+                "https://raw.githubusercontent.com/TheSpeedX/PROXY-List/master/socks5.txt"
+            }
+            Self::ClarketmHttp => {
+                "https://raw.githubusercontent.com/clarketm/proxy-list/master/proxy-list-raw.txt"
+            }
+            Self::OpenProxyListHttp => "https://openproxylist.xyz/http.txt",
+            Self::Custom { url, .. } => url.as_str(),
+        }
+    }
+
+    fn proxy_type(&self) -> ProxyType {
+        match self {
+            Self::TheSpeedXHttp | Self::ClarketmHttp | Self::OpenProxyListHttp => ProxyType::Http,
+            Self::TheSpeedXSocks4 => ProxyType::Socks4,
+            Self::TheSpeedXSocks5 => ProxyType::Socks5,
+            Self::Custom { proxy_type, .. } => *proxy_type,
+        }
+    }
+}
+
+// ─── FreeListFetcher ──────────────────────────────────────────────────────────
+
+/// Fetches plain-text `host:port` proxy lists from one or more public URLs.
+///
+/// Each source is fetched concurrently.  Lines that do not parse as valid
+/// `host:port` entries are silently skipped.  An empty or unreachable source
+/// logs a warning but does not fail the entire fetch — at least one source
+/// must return results for the call to succeed.
+///
+/// # Example
+///
+/// ```no_run
+/// use stygian_proxy::fetcher::{FreeListFetcher, FreeListSource, ProxyFetcher};
+///
+/// # async fn run() -> stygian_proxy::error::ProxyResult<()> {
+/// let fetcher = FreeListFetcher::new(vec![FreeListSource::TheSpeedXHttp]);
+/// let proxies = fetcher.fetch().await?;
+/// println!("Got {} proxies", proxies.len());
+/// # Ok(())
+/// # }
+/// ```
+pub struct FreeListFetcher {
+    sources: Vec<FreeListSource>,
+    client: Client,
+    tags: Vec<String>,
+}
+
+impl FreeListFetcher {
+    /// Create a fetcher for the given sources with default HTTP client settings
+    /// (10 s timeout, TLS enabled).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_proxy::fetcher::{FreeListFetcher, FreeListSource};
+    /// let _f = FreeListFetcher::new(vec![FreeListSource::TheSpeedXHttp]);
+    /// ```
+    pub fn new(sources: Vec<FreeListSource>) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            // Client construction only fails when TLS backend is unavailable,
+            // which is a compile-time configuration issue, not a runtime one.
+            .unwrap_or_default();
+        Self {
+            sources,
+            client,
+            tags: vec!["free-list".into()],
+        }
+    }
+
+    /// Attach extra tags to every proxy produced by this fetcher.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_proxy::fetcher::{FreeListFetcher, FreeListSource};
+    /// let _f = FreeListFetcher::new(vec![FreeListSource::TheSpeedXHttp])
+    ///     .with_tags(vec!["dev".into(), "http".into()]);
+    /// ```
+    #[must_use]
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags.extend(tags);
+        self
+    }
+
+    /// Fetch a single source, returning parsed proxies (empty on failure).
+    async fn fetch_source(&self, source: &FreeListSource) -> Vec<Proxy> {
+        let url = source.url();
+        let proxy_type = source.proxy_type();
+
+        let body = match self.client.get(url).send().await {
+            Ok(resp) if resp.status().is_success() => match resp.text().await {
+                Ok(t) => t,
+                Err(e) => {
+                    warn!("Failed to read body from {url}: {e}");
+                    return vec![];
+                }
+            },
+            Ok(resp) => {
+                warn!(
+                    "Non-success status {} fetching proxy list from {url}",
+                    resp.status()
+                );
+                return vec![];
+            }
+            Err(e) => {
+                warn!("Failed to fetch proxy list from {url}: {e}");
+                return vec![];
+            }
+        };
+
+        let proxies: Vec<Proxy> = body
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    return None;
+                }
+                // Expect `host:port` — both halves must be present and port numeric.
+                let mut parts = line.splitn(2, ':');
+                let host = parts.next()?.trim();
+                let port_str = parts.next()?.trim();
+                if port_str.parse::<u16>().is_err() {
+                    return None;
+                }
+                let scheme = match proxy_type {
+                    ProxyType::Http | ProxyType::Https => "http",
+                    ProxyType::Socks4 => "socks4",
+                    ProxyType::Socks5 => "socks5",
+                };
+                Some(Proxy {
+                    url: format!("{scheme}://{host}:{port_str}"),
+                    proxy_type,
+                    username: None,
+                    password: None,
+                    weight: 1,
+                    tags: self.tags.clone(),
+                })
+            })
+            .collect();
+
+        debug!(source = url, count = proxies.len(), "Fetched proxy list");
+        proxies
+    }
+}
+
+#[async_trait]
+impl ProxyFetcher for FreeListFetcher {
+    async fn fetch(&self) -> ProxyResult<Vec<Proxy>> {
+        // Fetch all sources concurrently.
+        let mut handles = Vec::with_capacity(self.sources.len());
+        for source in &self.sources {
+            handles.push(self.fetch_source(source));
+        }
+        // Sequential join — futures are not Send across .join_all without boxing;
+        // sources are typically 3–5 so sequential is fine.
+        let mut all: Vec<Proxy> = Vec::new();
+        for handle in handles {
+            all.extend(handle.await);
+        }
+
+        if all.is_empty() {
+            return Err(ProxyError::FetchFailed {
+                origin: self
+                    .sources
+                    .iter()
+                    .map(|s| s.url())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+                message: "all sources returned empty or failed".into(),
+            });
+        }
+
+        Ok(all)
+    }
+}
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+/// Fetch proxies from `fetcher` and add them all to `manager`.
+///
+/// Returns the number of proxies successfully added.  Individual `add_proxy`
+/// failures (e.g. duplicate URL) are logged as warnings and do not abort the
+/// load.
+///
+/// # Errors
+///
+/// Returns [`ProxyError::FetchFailed`] if the fetcher itself fails.
+///
+/// # Example
+///
+/// ```no_run
+/// use std::sync::Arc;
+/// use stygian_proxy::{ProxyManager, storage::MemoryProxyStore, fetcher::{FreeListFetcher, FreeListSource, load_from_fetcher}};
+///
+/// # async fn run() -> stygian_proxy::error::ProxyResult<()> {
+/// let manager = ProxyManager::builder()
+///     .storage(Arc::new(MemoryProxyStore::default()))
+///     .build()?;
+/// let fetcher = FreeListFetcher::new(vec![FreeListSource::TheSpeedXHttp]);
+/// let n = load_from_fetcher(&manager, &fetcher).await?;
+/// println!("Loaded {n} proxies");
+/// # Ok(())
+/// # }
+/// ```
+pub async fn load_from_fetcher(
+    manager: &ProxyManager,
+    fetcher: &dyn ProxyFetcher,
+) -> ProxyResult<usize> {
+    let proxies = fetcher.fetch().await?;
+    let total = proxies.len();
+    let mut loaded = 0usize;
+
+    for proxy in proxies {
+        match manager.add_proxy(proxy).await {
+            Ok(_) => loaded += 1,
+            Err(e) => warn!("Skipped proxy during load: {e}"),
+        }
+    }
+
+    debug!(total, loaded, "Proxy list loaded into manager");
+    Ok(loaded)
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn free_list_source_url_is_nonempty() {
+        let sources = [
+            FreeListSource::TheSpeedXHttp,
+            FreeListSource::TheSpeedXSocks4,
+            FreeListSource::TheSpeedXSocks5,
+            FreeListSource::ClarketmHttp,
+            FreeListSource::OpenProxyListHttp,
+            FreeListSource::Custom {
+                url: "https://example.com/proxies.txt".into(),
+                proxy_type: ProxyType::Http,
+            },
+        ];
+        for src in &sources {
+            assert!(
+                !src.url().is_empty(),
+                "FreeListSource::{src:?} has empty URL"
+            );
+        }
+    }
+
+    #[test]
+    fn free_list_source_proxy_types() {
+        assert_eq!(FreeListSource::TheSpeedXHttp.proxy_type(), ProxyType::Http);
+        assert_eq!(
+            FreeListSource::TheSpeedXSocks4.proxy_type(),
+            ProxyType::Socks4
+        );
+        assert_eq!(
+            FreeListSource::TheSpeedXSocks5.proxy_type(),
+            ProxyType::Socks5
+        );
+        assert_eq!(FreeListSource::ClarketmHttp.proxy_type(), ProxyType::Http);
+    }
+
+    #[test]
+    fn free_list_fetcher_parse_valid_lines() {
+        let fetcher = FreeListFetcher::new(vec![]);
+        // Test the parsing logic directly by calling parse on synthetic text.
+        let text = "1.2.3.4:8080\n# comment\n\nbad-line\n5.6.7.8:3128\n";
+        let parsed: Vec<Proxy> = text
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                if line.is_empty() || line.starts_with('#') {
+                    return None;
+                }
+                let mut parts = line.splitn(2, ':');
+                let host = parts.next()?.trim();
+                let port_str = parts.next()?.trim();
+                if port_str.parse::<u16>().is_err() {
+                    return None;
+                }
+                Some(Proxy {
+                    url: format!("http://{host}:{port_str}"),
+                    proxy_type: ProxyType::Http,
+                    username: None,
+                    password: None,
+                    weight: 1,
+                    tags: fetcher.tags.clone(),
+                })
+            })
+            .collect();
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].url, "http://1.2.3.4:8080");
+        assert_eq!(parsed[1].url, "http://5.6.7.8:3128");
+    }
+
+    #[test]
+    fn free_list_fetcher_with_tags_extends() {
+        let f = FreeListFetcher::new(vec![]).with_tags(vec!["custom".into()]);
+        assert!(f.tags.contains(&"free-list".to_string()));
+        assert!(f.tags.contains(&"custom".to_string()));
+    }
+
+    #[test]
+    fn free_list_fetcher_skips_invalid_port() {
+        let line = "1.2.3.4:notaport";
+        let mut parts = line.splitn(2, ':');
+        let _host = parts.next().unwrap();
+        let port_str = parts.next().unwrap();
+        assert!(port_str.parse::<u16>().is_err());
+    }
+
+    #[test]
+    fn proxy_error_fetch_failed_display() {
+        let e = ProxyError::FetchFailed {
+            origin: "https://example.com".into(),
+            message: "timed out".into(),
+        };
+        assert!(e.to_string().contains("https://example.com"));
+        assert!(e.to_string().contains("timed out"));
+    }
+}

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -201,7 +201,7 @@ impl FreeListFetcher {
             .timeout(Duration::from_secs(10))
             .build()
             .unwrap_or_else(|e| {
-                warn!("Failed to build HTTP client with 10 s timeout (TLS backend issue?): {e}; falling back to default client");
+                warn!("Failed to build HTTP client with 10 s timeout (TLS backend issue?): {e}; falling back to default client with per-request timeout enforcement");
                 Client::default()
             });
         Self {
@@ -241,7 +241,11 @@ impl FreeListFetcher {
             (host, port_str.trim())
         } else {
             let (host, port_str) = line.rsplit_once(':')?;
-            (host.trim(), port_str.trim())
+            let host = host.trim();
+            if host.contains(':') {
+                return None;
+            }
+            (host, port_str.trim())
         };
 
         if host.is_empty() || host == "[]" {
@@ -261,7 +265,13 @@ impl FreeListFetcher {
         let url = source.url();
         let proxy_type = source.proxy_type();
 
-        let body = match self.client.get(url).send().await {
+        let body = match self
+            .client
+            .get(url)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+        {
             Ok(resp) if resp.status().is_success() => match resp.text().await {
                 Ok(t) => t,
                 Err(e) => {
@@ -349,7 +359,8 @@ impl ProxyFetcher for FreeListFetcher {
 ///
 /// # Errors
 ///
-/// Returns [`ProxyError::FetchFailed`] if the fetcher itself fails.
+/// Returns any [`ProxyError`] emitted by `fetcher.fetch()` if the fetcher
+/// itself fails.
 ///
 /// # Example
 ///
@@ -483,6 +494,7 @@ mod tests {
         assert!(FreeListFetcher::parse_host_port_line("1.2.3.4:notaport").is_none());
         assert!(FreeListFetcher::parse_host_port_line("1.2.3.4:0").is_none());
         assert!(FreeListFetcher::parse_host_port_line(":8080").is_none());
+        assert!(FreeListFetcher::parse_host_port_line("2001:db8::1:8080").is_none());
     }
 
     #[test]

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -2,7 +2,7 @@
 //!
 //! [`ProxyFetcher`] is the port trait.  Implement it to pull proxies from any
 //! source (remote HTTP list, database, commercial API, etc.) and integrate with
-//! [`ProxyManager`][crate::ProxyManager] via [`load_from_fetcher`].
+//! [`ProxyManager`] via [`load_from_fetcher`].
 //!
 //! The built-in [`FreeListFetcher`] downloads plain-text `host:port` proxy
 //! lists from public URLs (e.g. the `TheSpeedX/PROXY-List` feeds on GitHub)
@@ -378,7 +378,10 @@ mod tests {
             },
         ];
         #[cfg(feature = "socks")]
-        sources.extend([FreeListSource::TheSpeedXSocks4, FreeListSource::TheSpeedXSocks5]);
+        sources.extend([
+            FreeListSource::TheSpeedXSocks4,
+            FreeListSource::TheSpeedXSocks5,
+        ]);
         for src in &sources {
             assert!(
                 !src.url().is_empty(),
@@ -391,9 +394,15 @@ mod tests {
     fn free_list_source_proxy_types() {
         assert_eq!(FreeListSource::TheSpeedXHttp.proxy_type(), ProxyType::Http);
         #[cfg(feature = "socks")]
-        assert_eq!(FreeListSource::TheSpeedXSocks4.proxy_type(), ProxyType::Socks4);
+        assert_eq!(
+            FreeListSource::TheSpeedXSocks4.proxy_type(),
+            ProxyType::Socks4
+        );
         #[cfg(feature = "socks")]
-        assert_eq!(FreeListSource::TheSpeedXSocks5.proxy_type(), ProxyType::Socks5);
+        assert_eq!(
+            FreeListSource::TheSpeedXSocks5.proxy_type(),
+            ProxyType::Socks5
+        );
         assert_eq!(FreeListSource::ClarketmHttp.proxy_type(), ProxyType::Http);
     }
 

--- a/crates/stygian-proxy/src/lib.rs
+++ b/crates/stygian-proxy/src/lib.rs
@@ -25,6 +25,7 @@
 
 pub mod circuit_breaker;
 pub mod error;
+pub mod fetcher;
 pub mod health;
 pub mod manager;
 pub mod session;
@@ -45,6 +46,7 @@ pub mod mcp;
 // Top-level re-exports
 pub use circuit_breaker::{CircuitBreaker, STATE_CLOSED, STATE_HALF_OPEN, STATE_OPEN};
 pub use error::{ProxyError, ProxyResult};
+pub use fetcher::{FreeListFetcher, FreeListSource, ProxyFetcher, load_from_fetcher};
 pub use health::{HealthChecker, HealthMap};
 pub use manager::{PoolStats, ProxyHandle, ProxyManager, ProxyManagerBuilder};
 pub use session::{SessionMap, StickyPolicy};


### PR DESCRIPTION
## Summary

Two commits closing gaps identified from Turnstile Layer 1 reverse-engineering and adding proxy list sourcing infrastructure.

---

### `feat(stealth)` — Turnstile fingerprint gaps + request pacing

**fingerprint.rs**
- `screen.availLeft` / `screen.availTop` — both spoofed to `0` (were absent, detectable)
- `font_measurement_intercept_script()` — intercepts `getBoundingClientRect` on hidden probe elements; returns seeded jitter dimensions instead of `0×0` (Turnstile uses this to detect headless via font enumeration)
- `storage_estimate_spoof_script()` — spoofs `navigator.storage.estimate()` quota to `(240 + seed % 20) GB`, usage to `(5 + seed % 10) MB`

**behavior.rs**
- `do_keyactivity()` on `InteractionSimulator` — dispatches `keydown`/`keyup` `KeyboardEvent`s for arrow/tab keys to `window`; satisfies Turnstile Signal Orchestrator's biometric keystroke telemetry requirement
- `InteractionLevel::Medium/High` — now include key activity in their interaction sequences
- `RequestPacer` struct — human-realistic inter-request delay with Gaussian jitter; constructors: `new()`, `with_rate(rps)`, `with_timing(mean, std, min, max)`; `throttle()` is async and sleeps only the remaining time since the last call

**lib.rs** — `RequestPacer` re-exported under `#[cfg(feature = "stealth")]`

---

### `feat(proxy)` — ProxyFetcher trait and FreeListFetcher

- `ProxyFetcher` async port trait (`fetch(&self) -> ProxyResult<Vec<Proxy>>`)
- `FreeListSource` enum — `TheSpeedXHttp/Socks4/Socks5`, `ClarketmHttp`, `OpenProxyListHttp`, `Custom { url, proxy_type }`
- `FreeListFetcher` — fetches all sources concurrently, parses `host:port` newlines, skips comments/blanks, `.with_tags()` builder
- `load_from_fetcher(&manager, &fetcher)` — convenience fn to pump fetcher output into `ProxyManager`
- `ProxyError::FetchFailed { origin, message }` variant added

---

All 32 proxy tests + all doctests pass. Clippy clean (`-D warnings`).