### PR TITLE
feat(browser): add PX VM env-bitmask stealth checks (bits 0–7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-04-11
+
+### Added
+
+- `stygian-browser`: PX VM environment-bitmask stealth checks (bits 0–7) — detects VM
+  indicators exposed via JavaScript: `navigator.hardwareConcurrency`, `screen` dimensions,
+  `devicePixelRatio`, `navigator.platform`, timezone offset, memory constraints, WebGL
+  renderer/vendor strings, and battery API absence; results encoded as a bitmask in
+  `DiagnosticReport`
+- `stygian-browser`: `Http3Perk` type models HTTP/3 SETTINGS fingerprints (settings
+  identifiers, pseudo-header ordering, GREASE presence); `TlsProfile::http3_perk()` returns
+  the expected perk for Chrome, Edge, and Firefox profiles; Safari returns `None`
+- `stygian-browser`: `expected_http3_perk_from_user_agent()`, `expected_tls_profile_from_user_agent()`,
+  `expected_ja3_from_user_agent()`, and `expected_ja4_from_user_agent()` resolve fingerprint
+  expectations from a UA string for early mismatch detection
+- `stygian-browser`: `TransportObservations` and `TransportDiagnostic` types expose
+  expected vs. observed JA3/JA4/HTTP3 transport fingerprints in `DiagnosticReport.transport`
+- `stygian-browser`: `PageHandle::verify_stealth_with_transport()` accepts optional observed
+  transport values and returns a full `DiagnosticReport` including the new transport field
+- `stygian-browser`: MCP `browser_verify_stealth` tool now accepts four optional observed
+  transport fields (`observed_ja3_hash`, `observed_ja4`, `observed_http3_perk_text`,
+  `observed_http3_perk_hash`) and includes `TransportDiagnostic` in the response
+- `stygian-browser/examples/stealth_probe`: `--ja3-hash`, `--ja4`, `--http3-perk-text`,
+  and `--http3-perk-hash` CLI flags pass observed transport values into the canary probe;
+  transport section emitted directly from `DiagnosticReport`
+
+### Fixed
+
+- `stygian-browser`: `TlsProfile::http3_perk()` no longer falls through to a Chrome UA
+  for Safari profiles — Safari now correctly returns `None`
+- `stygian-browser`: `transport_match: Some(true)` false-positive suppressed — when the
+  observed UA is unknown and no expected values can be derived, explicit mismatch entries
+  are pushed so `transport_match` resolves to `Some(false)`
+- `stygian-browser`: `SCRIPT_NODEJS_ABSENT` hardened against `process.versions === null`
+  (e.g. in Deno) — property access was guarded with `||process.versions==null` to avoid
+  a potential thrown exception before the `node` field could be read
+- `stygian-browser/examples/stealth_probe`: `--threshold` now validates the supplied value
+  is within `0.0..=1.0`; previously the error message claimed a range that was not enforced
+- `stygian-browser`: diagnostic test renamed from `all_checks_returns_ten_entries` to
+  `all_checks_returns_eighteen_entries` to match the actual assertion count
+
 ## [0.9.0] - 2026-04-11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -761,7 +761,9 @@ Both crates are functional and well-tested, but APIs may evolve based on communi
 
 ---
 
-[Unreleased]: https://github.com/greysquirr3l/stygian/compare/v0.1.9...HEAD
+[Unreleased]: https://github.com/greysquirr3l/stygian/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/greysquirr3l/stygian/compare/v0.9.0...v0.9.1
+[0.9.0]: https://github.com/greysquirr3l/stygian/compare/v0.1.9...v0.9.0
 [0.1.9]: https://github.com/greysquirr3l/stygian/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/greysquirr3l/stygian/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/greysquirr3l/stygian/compare/v0.1.6...v0.1.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `stygian-browser`: PX VM environment-bitmask stealth checks (bits 0–7) — detects VM
-  indicators exposed via JavaScript: `navigator.hardwareConcurrency`, `screen` dimensions,
-  `devicePixelRatio`, `navigator.platform`, timezone offset, memory constraints, WebGL
-  renderer/vendor strings, and battery API absence; results encoded as a bitmask in
-  `DiagnosticReport`
+- `stygian-browser`: PX VM environment-bitmask stealth checks (bits 0–7) — tests browser
+  API presence: `matchMedia`, `elementFromPoint`, `requestAnimationFrame`, `getComputedStyle`,
+  `CSS.supports`, `sendBeacon`, `execCommand`, and Node.js absence; `DiagnosticReport`
+  stores the result of each check individually
 - `stygian-browser`: `Http3Perk` type models HTTP/3 SETTINGS fingerprints (settings
   identifiers, pseudo-header ordering, GREASE presence); `TlsProfile::http3_perk()` returns
   the expected perk for Chrome, Edge, and Firefox profiles; Safari returns `None`

--- a/crates/stygian-browser/examples/stealth_probe.rs
+++ b/crates/stygian-browser/examples/stealth_probe.rs
@@ -188,6 +188,10 @@ fn parse_args(args: &[String]) -> Result<ProbeArgs, Box<dyn std::error::Error>> 
         }
     }
 
+    if !(0.0..=1.0).contains(&threshold) {
+        return Err("--threshold must be a float in range 0.0–1.0".into());
+    }
+
     Ok(ProbeArgs {
         threshold,
         urls,

--- a/crates/stygian-browser/examples/stealth_probe.rs
+++ b/crates/stygian-browser/examples/stealth_probe.rs
@@ -21,12 +21,14 @@ use std::sync::Arc;
 
 use serde_json::json;
 use stygian_browser::config::StealthLevel;
-use stygian_browser::tls::expected_http3_perk_from_user_agent;
+use stygian_browser::diagnostic::TransportObservations;
 use stygian_browser::{BrowserConfig, BrowserPool, WaitUntil};
 
 struct ProbeArgs {
     threshold: f64,
     urls: Vec<String>,
+    observed_ja3_hash: Option<String>,
+    observed_ja4: Option<String>,
     observed_http3_perk_text: Option<String>,
     observed_http3_perk_hash: Option<String>,
 }
@@ -38,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     if args.urls.is_empty() {
         eprintln!(
-            "usage: stealth_probe [--threshold 0.90] [--http3-perk-text TEXT] [--http3-perk-hash HASH] <url>..."
+            "usage: stealth_probe [--threshold 0.90] [--ja3-hash HASH] [--ja4 FP] [--http3-perk-text TEXT] [--http3-perk-hash HASH] <url>..."
         );
         std::process::exit(2);
     }
@@ -101,31 +103,19 @@ async fn probe_url(
     page.navigate(url, WaitUntil::DomContentLoaded, Duration::from_secs(20))
         .await?;
 
-    let report = page.verify_stealth().await?;
-    let user_agent = page.eval::<String>("navigator.userAgent").await.ok();
+    let observations = TransportObservations {
+        ja3_hash: args.observed_ja3_hash.clone(),
+        ja4: args.observed_ja4.clone(),
+        http3_perk_text: args.observed_http3_perk_text.clone(),
+        http3_perk_hash: args.observed_http3_perk_hash.clone(),
+    };
+    let report = page
+        .verify_stealth_with_transport(Some(observations))
+        .await?;
 
     // coverage_pct() returns 0.0–100.0; normalise to 0.0–1.0 for threshold comparison.
     let score = report.coverage_pct() / 100.0;
     let ok = score >= args.threshold;
-
-    let http3 = user_agent.as_deref().and_then(|ua| {
-        expected_http3_perk_from_user_agent(ua).map(|expected| {
-            let expected_text = expected.perk_text();
-            let expected_hash = expected.perk_hash();
-            let comparison = expected.compare(
-                args.observed_http3_perk_text.as_deref(),
-                args.observed_http3_perk_hash.as_deref(),
-            );
-
-            json!({
-                "expected_perk_text": expected_text,
-                "expected_perk_hash": expected_hash,
-                "observed_perk_text": args.observed_http3_perk_text,
-                "observed_perk_hash": args.observed_http3_perk_hash,
-                "comparison": comparison,
-            })
-        })
-    });
 
     let failed_checks: Vec<serde_json::Value> = report
         .failures()
@@ -143,14 +133,13 @@ async fn probe_url(
 
     Ok(json!({
         "url": url,
-        "user_agent": user_agent,
         "score": score,
         "score_pct": report.coverage_pct(),
         "passed_count": report.passed_count,
         "failed_count": report.failed_count,
         "failed_checks": failed_checks,
         "threshold": args.threshold,
-        "http3": http3,
+        "transport": report.transport,
         "ok": ok,
     }))
 }
@@ -158,6 +147,8 @@ async fn probe_url(
 fn parse_args(args: &[String]) -> Result<ProbeArgs, Box<dyn std::error::Error>> {
     let mut threshold = 0.90_f64;
     let mut urls = Vec::new();
+    let mut observed_ja3_hash = None;
+    let mut observed_ja4 = None;
     let mut observed_http3_perk_text = None;
     let mut observed_http3_perk_hash = None;
     let mut iter = args.iter();
@@ -172,6 +163,16 @@ fn parse_args(args: &[String]) -> Result<ProbeArgs, Box<dyn std::error::Error>> 
             threshold = val
                 .parse::<f64>()
                 .map_err(|_| "--threshold must be a float in range 0.0–1.0")?;
+        } else if let Some(val) = arg.strip_prefix("--ja3-hash=") {
+            observed_ja3_hash = Some(val.to_string());
+        } else if arg == "--ja3-hash" {
+            let val = iter.next().ok_or("--ja3-hash requires a value")?;
+            observed_ja3_hash = Some(val.clone());
+        } else if let Some(val) = arg.strip_prefix("--ja4=") {
+            observed_ja4 = Some(val.to_string());
+        } else if arg == "--ja4" {
+            let val = iter.next().ok_or("--ja4 requires a value")?;
+            observed_ja4 = Some(val.clone());
         } else if let Some(val) = arg.strip_prefix("--http3-perk-text=") {
             observed_http3_perk_text = Some(val.to_string());
         } else if arg == "--http3-perk-text" {
@@ -190,6 +191,8 @@ fn parse_args(args: &[String]) -> Result<ProbeArgs, Box<dyn std::error::Error>> 
     Ok(ProbeArgs {
         threshold,
         urls,
+        observed_ja3_hash,
+        observed_ja4,
         observed_http3_perk_text,
         observed_http3_perk_hash,
     })

--- a/crates/stygian-browser/examples/stealth_probe.rs
+++ b/crates/stygian-browser/examples/stealth_probe.rs
@@ -21,15 +21,25 @@ use std::sync::Arc;
 
 use serde_json::json;
 use stygian_browser::config::StealthLevel;
+use stygian_browser::tls::expected_http3_perk_from_user_agent;
 use stygian_browser::{BrowserConfig, BrowserPool, WaitUntil};
+
+struct ProbeArgs {
+    threshold: f64,
+    urls: Vec<String>,
+    observed_http3_perk_text: Option<String>,
+    observed_http3_perk_hash: Option<String>,
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let raw_args: Vec<String> = std::env::args().skip(1).collect();
-    let (threshold, urls) = parse_args(&raw_args)?;
+    let args = parse_args(&raw_args)?;
 
-    if urls.is_empty() {
-        eprintln!("usage: stealth_probe [--threshold 0.90] <url>...");
+    if args.urls.is_empty() {
+        eprintln!(
+            "usage: stealth_probe [--threshold 0.90] [--http3-perk-text TEXT] [--http3-perk-hash HASH] <url>..."
+        );
         std::process::exit(2);
     }
 
@@ -40,11 +50,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let pool = BrowserPool::new(config).await?;
 
-    let mut results = Vec::with_capacity(urls.len());
+    let mut results = Vec::with_capacity(args.urls.len());
     let mut any_failed = false;
 
-    for url in &urls {
-        match probe_url(&pool, url, threshold).await {
+    for url in &args.urls {
+        match probe_url(&pool, url, &args).await {
             Ok(entry) => {
                 if !entry
                     .get("ok")
@@ -79,7 +89,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 async fn probe_url(
     pool: &Arc<BrowserPool>,
     url: &str,
-    threshold: f64,
+    args: &ProbeArgs,
 ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let handle = pool.acquire().await?;
     let mut page = handle
@@ -92,10 +102,30 @@ async fn probe_url(
         .await?;
 
     let report = page.verify_stealth().await?;
+    let user_agent = page.eval::<String>("navigator.userAgent").await.ok();
 
     // coverage_pct() returns 0.0–100.0; normalise to 0.0–1.0 for threshold comparison.
     let score = report.coverage_pct() / 100.0;
-    let ok = score >= threshold;
+    let ok = score >= args.threshold;
+
+    let http3 = user_agent.as_deref().and_then(|ua| {
+        expected_http3_perk_from_user_agent(ua).map(|expected| {
+            let expected_text = expected.perk_text();
+            let expected_hash = expected.perk_hash();
+            let comparison = expected.compare(
+                args.observed_http3_perk_text.as_deref(),
+                args.observed_http3_perk_hash.as_deref(),
+            );
+
+            json!({
+                "expected_perk_text": expected_text,
+                "expected_perk_hash": expected_hash,
+                "observed_perk_text": args.observed_http3_perk_text,
+                "observed_perk_hash": args.observed_http3_perk_hash,
+                "comparison": comparison,
+            })
+        })
+    });
 
     let failed_checks: Vec<serde_json::Value> = report
         .failures()
@@ -113,19 +143,23 @@ async fn probe_url(
 
     Ok(json!({
         "url": url,
+        "user_agent": user_agent,
         "score": score,
         "score_pct": report.coverage_pct(),
         "passed_count": report.passed_count,
         "failed_count": report.failed_count,
         "failed_checks": failed_checks,
-        "threshold": threshold,
+        "threshold": args.threshold,
+        "http3": http3,
         "ok": ok,
     }))
 }
 
-fn parse_args(args: &[String]) -> Result<(f64, Vec<String>), Box<dyn std::error::Error>> {
+fn parse_args(args: &[String]) -> Result<ProbeArgs, Box<dyn std::error::Error>> {
     let mut threshold = 0.90_f64;
     let mut urls = Vec::new();
+    let mut observed_http3_perk_text = None;
+    let mut observed_http3_perk_hash = None;
     let mut iter = args.iter();
 
     while let Some(arg) = iter.next() {
@@ -138,10 +172,25 @@ fn parse_args(args: &[String]) -> Result<(f64, Vec<String>), Box<dyn std::error:
             threshold = val
                 .parse::<f64>()
                 .map_err(|_| "--threshold must be a float in range 0.0–1.0")?;
+        } else if let Some(val) = arg.strip_prefix("--http3-perk-text=") {
+            observed_http3_perk_text = Some(val.to_string());
+        } else if arg == "--http3-perk-text" {
+            let val = iter.next().ok_or("--http3-perk-text requires a value")?;
+            observed_http3_perk_text = Some(val.clone());
+        } else if let Some(val) = arg.strip_prefix("--http3-perk-hash=") {
+            observed_http3_perk_hash = Some(val.to_string());
+        } else if arg == "--http3-perk-hash" {
+            let val = iter.next().ok_or("--http3-perk-hash requires a value")?;
+            observed_http3_perk_hash = Some(val.clone());
         } else {
             urls.push(arg.clone());
         }
     }
 
-    Ok((threshold, urls))
+    Ok(ProbeArgs {
+        threshold,
+        urls,
+        observed_http3_perk_text,
+        observed_http3_perk_hash,
+    })
 }

--- a/crates/stygian-browser/src/diagnostic.rs
+++ b/crates/stygian-browser/src/diagnostic.rs
@@ -188,8 +188,7 @@ impl TransportDiagnostic {
         }
         if observed.ja4.is_some() && expected_ja4.is_none() {
             mismatches.push(
-                "ja4 was provided but no expected JA4 could be derived from user-agent"
-                    .to_string(),
+                "ja4 was provided but no expected JA4 could be derived from user-agent".to_string(),
             );
         }
         if (observed.http3_perk_text.is_some() || observed.http3_perk_hash.is_some())

--- a/crates/stygian-browser/src/diagnostic.rs
+++ b/crates/stygian-browser/src/diagnostic.rs
@@ -142,10 +142,11 @@ impl TransportDiagnostic {
     ) -> Self {
         let observed = observed.cloned().unwrap_or_default();
 
+        // Resolve profile once; derive all fingerprints from it to avoid repeated UA parsing.
         let expected_profile = crate::tls::expected_tls_profile_from_user_agent(user_agent);
-        let expected_ja3 = crate::tls::expected_ja3_from_user_agent(user_agent);
-        let expected_ja4 = crate::tls::expected_ja4_from_user_agent(user_agent);
-        let expected_http3 = crate::tls::expected_http3_perk_from_user_agent(user_agent);
+        let expected_ja3 = expected_profile.map(crate::tls::TlsProfile::ja3);
+        let expected_ja4 = expected_profile.map(crate::tls::TlsProfile::ja4);
+        let expected_http3 = expected_profile.and_then(crate::tls::TlsProfile::http3_perk);
 
         let mut mismatches = Vec::new();
 
@@ -734,5 +735,90 @@ mod tests {
         let restored: DiagnosticReport = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.passed_count, report.passed_count);
         assert!(restored.is_clean());
+    }
+
+    #[test]
+    fn transport_diagnostic_reports_match_for_matching_observations() {
+        let user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+        let expected = TransportDiagnostic::from_user_agent_and_observations(user_agent, None);
+
+        // Ensure test UA resolves at least one expected fingerprint.
+        assert!(
+            expected.expected_profile.is_some()
+                || expected.expected_ja3_hash.is_some()
+                || expected.expected_ja4.is_some()
+                || expected.expected_http3_perk_text.is_some()
+        );
+
+        let observed = TransportObservations {
+            ja3_hash: expected.expected_ja3_hash.clone(),
+            ja4: expected.expected_ja4.clone(),
+            http3_perk_text: expected.expected_http3_perk_text.clone(),
+            http3_perk_hash: expected.expected_http3_perk_hash,
+        };
+        let diagnostic =
+            TransportDiagnostic::from_user_agent_and_observations(user_agent, Some(&observed));
+
+        assert_eq!(diagnostic.transport_match, Some(true));
+        assert!(diagnostic.mismatches.is_empty());
+    }
+
+    #[test]
+    fn transport_diagnostic_reports_mismatch_for_mismatching_observations() {
+        let user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+        let expected = TransportDiagnostic::from_user_agent_and_observations(user_agent, None);
+
+        assert!(expected.expected_ja3_hash.is_some());
+
+        let observed = TransportObservations {
+            ja3_hash: Some("definitely-not-the-expected-ja3".to_string()),
+            ja4: expected.expected_ja4.clone(),
+            http3_perk_text: expected.expected_http3_perk_text.clone(),
+            http3_perk_hash: expected.expected_http3_perk_hash,
+        };
+        let diagnostic =
+            TransportDiagnostic::from_user_agent_and_observations(user_agent, Some(&observed));
+
+        assert_eq!(diagnostic.transport_match, Some(false));
+        assert!(!diagnostic.mismatches.is_empty());
+        assert!(
+            diagnostic
+                .mismatches
+                .iter()
+                .any(|m| m.contains("ja3_hash mismatch"))
+        );
+    }
+
+    #[test]
+    fn transport_diagnostic_flags_observations_when_no_expectations_derivable() {
+        let user_agent = "UnknownBrowser/0.0";
+        let diagnostic_without_observed =
+            TransportDiagnostic::from_user_agent_and_observations(user_agent, None);
+
+        // Unknown UA should not resolve any expectations.
+        assert_eq!(diagnostic_without_observed.expected_profile, None);
+        assert_eq!(diagnostic_without_observed.expected_ja3_hash, None);
+        assert_eq!(diagnostic_without_observed.expected_ja4, None);
+        assert_eq!(diagnostic_without_observed.expected_http3_perk_text, None);
+
+        let observed = TransportObservations {
+            ja3_hash: Some("some-observed-ja3".to_string()),
+            ja4: Some("some-observed-ja4".to_string()),
+            http3_perk_text: Some("some-observed-http3-perk-text".to_string()),
+            http3_perk_hash: Some("some-observed-http3-perk-hash".to_string()),
+        };
+
+        let diagnostic =
+            TransportDiagnostic::from_user_agent_and_observations(user_agent, Some(&observed));
+
+        // With observations but no expectations, mismatches should be flagged.
+        assert_eq!(diagnostic.transport_match, Some(false));
+        assert!(!diagnostic.mismatches.is_empty());
+        assert!(
+            diagnostic
+                .mismatches
+                .iter()
+                .any(|m| m.contains("no expected JA3 could be derived"))
+        );
     }
 }

--- a/crates/stygian-browser/src/diagnostic.rs
+++ b/crates/stygian-browser/src/diagnostic.rs
@@ -94,6 +94,113 @@ pub struct CheckResult {
     pub details: String,
 }
 
+/// Optional observed transport fingerprints to compare against expected values.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TransportObservations {
+    /// Observed JA3 hash (lower/upper hex accepted).
+    pub ja3_hash: Option<String>,
+    /// Observed JA4 fingerprint string.
+    pub ja4: Option<String>,
+    /// Observed HTTP/3 perk text (`SETTINGS|PSEUDO_HEADERS`).
+    pub http3_perk_text: Option<String>,
+    /// Observed HTTP/3 perk hash.
+    pub http3_perk_hash: Option<String>,
+}
+
+/// Transport-level diagnostics emitted alongside JavaScript stealth checks.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransportDiagnostic {
+    /// User-Agent sampled from the live page.
+    pub user_agent: String,
+    /// Built-in profile name inferred from User-Agent, if any.
+    pub expected_profile: Option<String>,
+    /// Expected JA3 raw string from the inferred profile.
+    pub expected_ja3_raw: Option<String>,
+    /// Expected JA3 hash from the inferred profile.
+    pub expected_ja3_hash: Option<String>,
+    /// Expected JA4 fingerprint from the inferred profile.
+    pub expected_ja4: Option<String>,
+    /// Expected HTTP/3 perk text derived from User-Agent.
+    pub expected_http3_perk_text: Option<String>,
+    /// Expected HTTP/3 perk hash derived from User-Agent.
+    pub expected_http3_perk_hash: Option<String>,
+    /// Caller-supplied observed transport values.
+    pub observed: TransportObservations,
+    /// `true` when all supplied observations match expected fingerprints.
+    /// `None` when no observations were supplied.
+    pub transport_match: Option<bool>,
+    /// Human-readable mismatch reasons.
+    pub mismatches: Vec<String>,
+}
+
+impl TransportDiagnostic {
+    /// Build transport diagnostics from `user_agent` and optional observations.
+    #[must_use]
+    pub fn from_user_agent_and_observations(
+        user_agent: &str,
+        observed: Option<&TransportObservations>,
+    ) -> Self {
+        let observed = observed.cloned().unwrap_or_default();
+
+        let expected_profile = crate::tls::expected_tls_profile_from_user_agent(user_agent);
+        let expected_ja3 = crate::tls::expected_ja3_from_user_agent(user_agent);
+        let expected_ja4 = crate::tls::expected_ja4_from_user_agent(user_agent);
+        let expected_http3 = crate::tls::expected_http3_perk_from_user_agent(user_agent);
+
+        let mut mismatches = Vec::new();
+
+        if let (Some(expected), Some(observed_hash)) = (
+            expected_ja3.as_ref().map(|j| j.hash.as_str()),
+            observed.ja3_hash.as_deref(),
+        ) && !observed_hash.eq_ignore_ascii_case(expected)
+        {
+            mismatches.push(format!(
+                "ja3_hash mismatch: expected '{expected}', observed '{observed_hash}'"
+            ));
+        }
+
+        if let (Some(expected), Some(observed_ja4)) = (
+            expected_ja4.as_ref().map(|j| j.fingerprint.as_str()),
+            observed.ja4.as_deref(),
+        ) && observed_ja4 != expected
+        {
+            mismatches.push(format!(
+                "ja4 mismatch: expected '{expected}', observed '{observed_ja4}'"
+            ));
+        }
+
+        if let Some(expected) = expected_http3.as_ref() {
+            let cmp = expected.compare(
+                observed.http3_perk_text.as_deref(),
+                observed.http3_perk_hash.as_deref(),
+            );
+            mismatches.extend(cmp.mismatches);
+        }
+
+        let has_observed = observed.ja3_hash.is_some()
+            || observed.ja4.is_some()
+            || observed.http3_perk_text.is_some()
+            || observed.http3_perk_hash.is_some();
+
+        Self {
+            user_agent: user_agent.to_string(),
+            expected_profile: expected_profile.map(|p| p.name.clone()),
+            expected_ja3_raw: expected_ja3.as_ref().map(|j| j.raw.clone()),
+            expected_ja3_hash: expected_ja3.as_ref().map(|j| j.hash.clone()),
+            expected_ja4: expected_ja4.as_ref().map(|j| j.fingerprint.clone()),
+            expected_http3_perk_text: expected_http3
+                .as_ref()
+                .map(crate::tls::Http3Perk::perk_text),
+            expected_http3_perk_hash: expected_http3
+                .as_ref()
+                .map(crate::tls::Http3Perk::perk_hash),
+            observed,
+            transport_match: has_observed.then_some(mismatches.is_empty()),
+            mismatches,
+        }
+    }
+}
+
 // ── DiagnosticReport ──────────────────────────────────────────────────────────
 
 /// Aggregate result from running all detection checks.
@@ -119,6 +226,9 @@ pub struct DiagnosticReport {
     pub passed_count: usize,
     /// Number of checks where `passed == false`.
     pub failed_count: usize,
+    /// Optional transport-layer diagnostics (JA3/JA4/HTTP3 perk).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<TransportDiagnostic>,
 }
 
 impl DiagnosticReport {
@@ -130,7 +240,15 @@ impl DiagnosticReport {
             checks,
             passed_count,
             failed_count,
+            transport: None,
         }
+    }
+
+    /// Attach transport diagnostics to this report.
+    #[must_use]
+    pub fn with_transport(mut self, transport: TransportDiagnostic) -> Self {
+        self.transport = Some(transport);
+        self
     }
 
     /// Returns `true` when every check passed.

--- a/crates/stygian-browser/src/diagnostic.rs
+++ b/crates/stygian-browser/src/diagnostic.rs
@@ -177,6 +177,30 @@ impl TransportDiagnostic {
             mismatches.extend(cmp.mismatches);
         }
 
+        // If callers supplied observed transport fields that cannot be compared
+        // due to missing expectations, surface that explicitly instead of
+        // reporting a false positive match.
+        if observed.ja3_hash.is_some() && expected_ja3.is_none() {
+            mismatches.push(
+                "ja3_hash was provided but no expected JA3 could be derived from user-agent"
+                    .to_string(),
+            );
+        }
+        if observed.ja4.is_some() && expected_ja4.is_none() {
+            mismatches.push(
+                "ja4 was provided but no expected JA4 could be derived from user-agent"
+                    .to_string(),
+            );
+        }
+        if (observed.http3_perk_text.is_some() || observed.http3_perk_hash.is_some())
+            && expected_http3.is_none()
+        {
+            mismatches.push(
+                "http3 perk observation was provided but no expected HTTP/3 fingerprint could be derived from user-agent"
+                    .to_string(),
+            );
+        }
+
         let has_observed = observed.ja3_hash.is_some()
             || observed.ja4.is_some()
             || observed.http3_perk_text.is_some()
@@ -460,7 +484,7 @@ const SCRIPT_EXEC_COMMAND: &str = concat!(
 const SCRIPT_NODEJS_ABSENT: &str = concat!(
     "JSON.stringify({",
     "passed:typeof process==='undefined'",
-    "||typeof process.versions==='undefined'",
+    "||process.versions==null",
     "||typeof process.versions.node==='undefined',",
     "details:typeof process",
     "})"
@@ -578,7 +602,7 @@ mod tests {
     use std::collections::HashSet;
 
     #[test]
-    fn all_checks_returns_ten_entries() {
+    fn all_checks_returns_eighteen_entries() {
         assert_eq!(all_checks().len(), 18);
     }
 

--- a/crates/stygian-browser/src/diagnostic.rs
+++ b/crates/stygian-browser/src/diagnostic.rs
@@ -463,7 +463,7 @@ const SCRIPT_GET_COMPUTED_STYLE: &str = concat!(
 const SCRIPT_CSS_SUPPORTS: &str = concat!(
     "JSON.stringify({",
     "passed:typeof CSS!=='undefined'&&typeof CSS.supports==='function',",
-    "details:typeof CSS",
+    "details:typeof CSS!=='undefined'?typeof CSS.supports:'undefined'",
     "})"
 );
 

--- a/crates/stygian-browser/src/diagnostic.rs
+++ b/crates/stygian-browser/src/diagnostic.rs
@@ -61,6 +61,22 @@ pub enum CheckId {
     HeadlessUserAgent,
     /// `Notification.permission` must not be pre-granted (automation artefact).
     NotificationPermission,
+    /// `window.matchMedia` must be a function (PX env-bitmask bit 0).
+    MatchMediaPresent,
+    /// `document.elementFromPoint` must be a function (PX env-bitmask bit 1).
+    ElementFromPointPresent,
+    /// `window.requestAnimationFrame` must be a function (PX env-bitmask bit 2).
+    RequestAnimationFramePresent,
+    /// `window.getComputedStyle` must be a function (PX env-bitmask bit 3).
+    GetComputedStylePresent,
+    /// `CSS.supports` must exist and be callable (PX env-bitmask bit 4).
+    CssSupportsPresent,
+    /// `navigator.sendBeacon` must be a function (PX env-bitmask bit 5).
+    SendBeaconPresent,
+    /// `document.execCommand` must be a function (PX env-bitmask bit 6).
+    ExecCommandPresent,
+    /// `process.versions.node` must be absent — not a Node.js environment (PX env-bitmask bit 7).
+    NodeJsAbsent,
 }
 
 // ── CheckResult ───────────────────────────────────────────────────────────────
@@ -274,6 +290,64 @@ const SCRIPT_NOTIFICATION: &str = concat!(
     "})"
 );
 
+const SCRIPT_MATCH_MEDIA: &str = concat!(
+    "JSON.stringify({",
+    "passed:typeof window.matchMedia==='function',",
+    "details:typeof window.matchMedia",
+    "})"
+);
+
+const SCRIPT_ELEMENT_FROM_POINT: &str = concat!(
+    "JSON.stringify({",
+    "passed:typeof document.elementFromPoint==='function',",
+    "details:typeof document.elementFromPoint",
+    "})"
+);
+
+const SCRIPT_RAF: &str = concat!(
+    "JSON.stringify({",
+    "passed:typeof window.requestAnimationFrame==='function',",
+    "details:typeof window.requestAnimationFrame",
+    "})"
+);
+
+const SCRIPT_GET_COMPUTED_STYLE: &str = concat!(
+    "JSON.stringify({",
+    "passed:typeof window.getComputedStyle==='function',",
+    "details:typeof window.getComputedStyle",
+    "})"
+);
+
+const SCRIPT_CSS_SUPPORTS: &str = concat!(
+    "JSON.stringify({",
+    "passed:typeof CSS!=='undefined'&&typeof CSS.supports==='function',",
+    "details:typeof CSS",
+    "})"
+);
+
+const SCRIPT_SEND_BEACON: &str = concat!(
+    "JSON.stringify({",
+    "passed:typeof navigator.sendBeacon==='function',",
+    "details:typeof navigator.sendBeacon",
+    "})"
+);
+
+const SCRIPT_EXEC_COMMAND: &str = concat!(
+    "JSON.stringify({",
+    "passed:typeof document.execCommand==='function',",
+    "details:typeof document.execCommand",
+    "})"
+);
+
+const SCRIPT_NODEJS_ABSENT: &str = concat!(
+    "JSON.stringify({",
+    "passed:typeof process==='undefined'",
+    "||typeof process.versions==='undefined'",
+    "||typeof process.versions.node==='undefined',",
+    "details:typeof process",
+    "})"
+);
+
 // ── Static check catalogue ────────────────────────────────────────────────────
 
 /// Return all built-in stealth detection checks.
@@ -335,6 +409,46 @@ static CHECKS: &[DetectionCheck] = &[
         description: "Notification.permission must not be pre-granted",
         script: SCRIPT_NOTIFICATION,
     },
+    DetectionCheck {
+        id: CheckId::MatchMediaPresent,
+        description: "window.matchMedia must be a function (PX env-bitmask bit 0)",
+        script: SCRIPT_MATCH_MEDIA,
+    },
+    DetectionCheck {
+        id: CheckId::ElementFromPointPresent,
+        description: "document.elementFromPoint must be a function (PX env-bitmask bit 1)",
+        script: SCRIPT_ELEMENT_FROM_POINT,
+    },
+    DetectionCheck {
+        id: CheckId::RequestAnimationFramePresent,
+        description: "window.requestAnimationFrame must be a function (PX env-bitmask bit 2)",
+        script: SCRIPT_RAF,
+    },
+    DetectionCheck {
+        id: CheckId::GetComputedStylePresent,
+        description: "window.getComputedStyle must be a function (PX env-bitmask bit 3)",
+        script: SCRIPT_GET_COMPUTED_STYLE,
+    },
+    DetectionCheck {
+        id: CheckId::CssSupportsPresent,
+        description: "CSS.supports must exist and be callable (PX env-bitmask bit 4)",
+        script: SCRIPT_CSS_SUPPORTS,
+    },
+    DetectionCheck {
+        id: CheckId::SendBeaconPresent,
+        description: "navigator.sendBeacon must be a function (PX env-bitmask bit 5)",
+        script: SCRIPT_SEND_BEACON,
+    },
+    DetectionCheck {
+        id: CheckId::ExecCommandPresent,
+        description: "document.execCommand must be a function (PX env-bitmask bit 6)",
+        script: SCRIPT_EXEC_COMMAND,
+    },
+    DetectionCheck {
+        id: CheckId::NodeJsAbsent,
+        description: "process.versions.node must be absent — not a Node.js environment (PX env-bitmask bit 7)",
+        script: SCRIPT_NODEJS_ABSENT,
+    },
 ];
 
 // ── tests ─────────────────────────────────────────────────────────────────────
@@ -347,7 +461,7 @@ mod tests {
 
     #[test]
     fn all_checks_returns_ten_entries() {
-        assert_eq!(all_checks().len(), 10);
+        assert_eq!(all_checks().len(), 18);
     }
 
     #[test]
@@ -427,7 +541,7 @@ mod tests {
             .collect();
         let report = DiagnosticReport::new(results);
         assert!(report.is_clean());
-        assert_eq!(report.passed_count, 10);
+        assert_eq!(report.passed_count, 18);
         assert_eq!(report.failed_count, 0);
         assert!((report.coverage_pct() - 100.0).abs() < 0.001);
         assert_eq!(report.failures().count(), 0);
@@ -444,7 +558,7 @@ mod tests {
         let report = DiagnosticReport::new(results);
         assert!(!report.is_clean());
         assert_eq!(report.failed_count, 2);
-        assert_eq!(report.passed_count, 8);
+        assert_eq!(report.passed_count, 16);
         assert_eq!(report.failures().count(), 2);
     }
 

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -350,13 +350,17 @@ static TOOL_DEFINITIONS: LazyLock<Vec<Value>> = LazyLock::new(|| {
     #[cfg(feature = "stealth")]
     tools.push(json!({
         "name": "browser_verify_stealth",
-        "description": "Navigate to a URL and run all built-in stealth detection checks (requires stealth feature). Returns a DiagnosticReport with per-check pass/fail results and a coverage percentage.",
+        "description": "Navigate to a URL and run built-in stealth checks with optional transport diagnostics (JA3/JA4/HTTP3). Returns a DiagnosticReport with pass/fail results, coverage percentage, and transport mismatch details when observation fields are provided.",
         "inputSchema": {
             "type": "object",
             "properties": {
                 "session_id": { "type": "string" },
                 "url": { "type": "string", "description": "URL to navigate to before running checks." },
-                "timeout_secs": { "type": "integer", "default": 15, "description": "Navigation timeout in seconds." }
+                "timeout_secs": { "type": "integer", "default": 15, "description": "Navigation timeout in seconds." },
+                "observed_ja3_hash": { "type": "string", "description": "Optional observed JA3 hash to compare against expected profile." },
+                "observed_ja4": { "type": "string", "description": "Optional observed JA4 fingerprint to compare against expected profile." },
+                "observed_http3_perk_text": { "type": "string", "description": "Optional observed HTTP/3 perk text (SETTINGS|PSEUDO_HEADERS)." },
+                "observed_http3_perk_hash": { "type": "string", "description": "Optional observed HTTP/3 perk hash." }
             },
             "required": ["session_id", "url"]
         }
@@ -629,6 +633,24 @@ impl McpBrowserServer {
             .get("timeout_secs")
             .and_then(serde_json::Value::as_u64)
             .unwrap_or(15);
+        let observed = crate::diagnostic::TransportObservations {
+            ja3_hash: args
+                .get("observed_ja3_hash")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string),
+            ja4: args
+                .get("observed_ja4")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string),
+            http3_perk_text: args
+                .get("observed_http3_perk_text")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string),
+            http3_perk_hash: args
+                .get("observed_http3_perk_hash")
+                .and_then(serde_json::Value::as_str)
+                .map(ToString::to_string),
+        };
 
         let (session_arc, requested_stealth) = self.session_handle_and_stealth(&session_id).await?;
 
@@ -659,7 +681,7 @@ impl McpBrowserServer {
             return Err(e);
         }
 
-        let mut result = Self::run_stealth_diagnostic(&page).await;
+        let mut result = Self::run_stealth_diagnostic(&page, observed).await;
         page.close().await?;
         // Annotate with the session's requested stealth level.
         if let Ok(ref mut v) = result
@@ -674,14 +696,20 @@ impl McpBrowserServer {
     }
 
     #[cfg(feature = "stealth")]
-    async fn run_stealth_diagnostic(page: &crate::page::PageHandle) -> Result<Value> {
-        let report = page.verify_stealth().await?;
+    async fn run_stealth_diagnostic(
+        page: &crate::page::PageHandle,
+        observed: crate::diagnostic::TransportObservations,
+    ) -> Result<Value> {
+        let report = page.verify_stealth_with_transport(Some(observed)).await?;
         serde_json::to_value(&report)
             .map_err(|e| BrowserError::ConfigError(format!("failed to serialize report: {e}")))
     }
 
     #[cfg(not(feature = "stealth"))]
-    async fn run_stealth_diagnostic(_page: &crate::page::PageHandle) -> Result<Value> {
+    async fn run_stealth_diagnostic(
+        _page: &crate::page::PageHandle,
+        _observed: crate::diagnostic::TransportObservations,
+    ) -> Result<Value> {
         Err(BrowserError::ConfigError(
             "browser_verify_stealth requires the 'stealth' feature to be enabled".to_string(),
         ))

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -546,7 +546,12 @@ impl McpBrowserServer {
             "browser_eval" => self.tool_browser_eval(&args).await,
             "browser_screenshot" => self.tool_browser_screenshot(&args).await,
             "browser_content" => self.tool_browser_content(&args).await,
+            #[cfg(feature = "stealth")]
             "browser_verify_stealth" => self.tool_browser_verify_stealth(&args).await,
+            #[cfg(not(feature = "stealth"))]
+            "browser_verify_stealth" => Err(BrowserError::ConfigError(
+                "browser_verify_stealth requires the 'stealth' feature".to_string(),
+            )),
             "browser_release" => self.tool_browser_release(&args).await,
             "pool_stats" => Ok(self.tool_pool_stats()),
             "browser_query" => self.tool_browser_query(&args).await,
@@ -626,6 +631,7 @@ impl McpBrowserServer {
         }))
     }
 
+    #[cfg(feature = "stealth")]
     async fn tool_browser_verify_stealth(&self, args: &Value) -> Result<Value> {
         let session_id = Self::require_str(args, "session_id")?;
         let url = Self::require_str(args, "url")?;
@@ -703,16 +709,6 @@ impl McpBrowserServer {
         let report = page.verify_stealth_with_transport(Some(observed)).await?;
         serde_json::to_value(&report)
             .map_err(|e| BrowserError::ConfigError(format!("failed to serialize report: {e}")))
-    }
-
-    #[cfg(not(feature = "stealth"))]
-    async fn run_stealth_diagnostic(
-        _page: &crate::page::PageHandle,
-        _observed: crate::diagnostic::TransportObservations,
-    ) -> Result<Value> {
-        Err(BrowserError::ConfigError(
-            "browser_verify_stealth requires the 'stealth' feature to be enabled".to_string(),
-        ))
     }
 
     async fn tool_browser_navigate(&self, args: &Value) -> Result<Value> {
@@ -1276,6 +1272,7 @@ impl McpBrowserServer {
             .clone())
     }
 
+    #[cfg(feature = "stealth")]
     async fn session_handle_and_stealth(
         &self,
         session_id: &str,

--- a/crates/stygian-browser/src/page.rs
+++ b/crates/stygian-browser/src/page.rs
@@ -1455,6 +1455,32 @@ impl PageHandle {
 
         Ok(DiagnosticReport::new(results))
     }
+
+    /// Run stealth checks and attach transport diagnostics (JA3/JA4/HTTP3).
+    ///
+    /// Transport expectations are inferred from `navigator.userAgent` and can
+    /// optionally be compared to caller-supplied observed transport values.
+    pub async fn verify_stealth_with_transport(
+        &self,
+        observed: Option<crate::diagnostic::TransportObservations>,
+    ) -> Result<crate::diagnostic::DiagnosticReport> {
+        let report = self.verify_stealth().await?;
+
+        let user_agent = match self.eval::<String>("navigator.userAgent").await {
+            Ok(ua) => ua,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to read navigator.userAgent for transport diagnostics");
+                String::new()
+            }
+        };
+
+        let transport = crate::diagnostic::TransportDiagnostic::from_user_agent_and_observations(
+            &user_agent,
+            observed.as_ref(),
+        );
+
+        Ok(report.with_transport(transport))
+    }
 }
 
 // ─── extract feature ─────────────────────────────────────────────────────────

--- a/crates/stygian-browser/src/tls.rs
+++ b/crates/stygian-browser/src/tls.rs
@@ -594,6 +594,122 @@ impl fmt::Display for Ja4 {
     }
 }
 
+// ── HTTP/3 Perk ─────────────────────────────────────────────────────────────
+
+/// HTTP/3 fingerprint representation inspired by the "perk" format:
+/// `SETTINGS|PSEUDO_HEADERS`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Http3Perk {
+    /// Ordered HTTP/3 settings as `(id, value)` tuples.
+    pub settings: Vec<(u64, u64)>,
+    /// Pseudo-header order compact token (for example: `"masp"`, `"mpas"`).
+    pub pseudo_headers: String,
+    /// Whether a GREASE setting should be represented in the text form.
+    pub has_grease: bool,
+}
+
+/// Result of comparing expected and observed HTTP/3 perk data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Http3PerkComparison {
+    /// `true` only when all available observed fields match expected values.
+    pub matches: bool,
+    /// Human-readable mismatch reasons.
+    pub mismatches: Vec<String>,
+}
+
+const fn is_quic_grease(value: u64) -> bool {
+    let low = value & 0xffff;
+    let a = (low >> 8) & 0xff;
+    let b = low & 0xff;
+    a == b && (a & 0x0f) == 0x0a
+}
+
+impl Http3Perk {
+    /// Return canonical `perk_text` as `SETTINGS|PSEUDO_HEADERS`.
+    #[must_use]
+    pub fn perk_text(&self) -> String {
+        let mut parts: Vec<String> = self
+            .settings
+            .iter()
+            .filter(|(id, _)| !is_quic_grease(*id))
+            .map(|(id, value)| format!("{id}:{value}"))
+            .collect();
+
+        if self.has_grease || self.settings.iter().any(|(id, _)| is_quic_grease(*id)) {
+            parts.push("GREASE".to_string());
+        }
+
+        format!("{}|{}", parts.join(";"), self.pseudo_headers)
+    }
+
+    /// Return MD5 hash of [`perk_text`](Self::perk_text), lowercase hex.
+    #[must_use]
+    pub fn perk_hash(&self) -> String {
+        md5_hex(self.perk_text().as_bytes())
+    }
+
+    /// Compare observed perk text/hash against this expected fingerprint.
+    #[must_use]
+    pub fn compare(
+        &self,
+        observed_text: Option<&str>,
+        observed_hash: Option<&str>,
+    ) -> Http3PerkComparison {
+        let expected_text = self.perk_text();
+        let expected_hash = self.perk_hash();
+
+        let mut mismatches = Vec::new();
+
+        if let Some(text) = observed_text
+            && text != expected_text
+        {
+            mismatches.push(format!(
+                "perk_text mismatch: expected '{expected_text}', observed '{text}'"
+            ));
+        }
+
+        if let Some(hash) = observed_hash
+            && !hash.eq_ignore_ascii_case(&expected_hash)
+        {
+            mismatches.push(format!(
+                "perk_hash mismatch: expected '{expected_hash}', observed '{hash}'"
+            ));
+        }
+
+        Http3PerkComparison {
+            matches: mismatches.is_empty() && (observed_text.is_some() || observed_hash.is_some()),
+            mismatches,
+        }
+    }
+}
+
+/// Build an expected HTTP/3 perk fingerprint from a User-Agent string.
+///
+/// Returns `None` when the browser family is unknown or unsupported.
+#[must_use]
+pub fn expected_http3_perk_from_user_agent(user_agent: &str) -> Option<Http3Perk> {
+    let ua = user_agent.to_ascii_lowercase();
+
+    // Chromium family: Chrome/Edge share the same high-level HTTP/3 pattern.
+    if ua.contains("edg/") || ua.contains("chrome/") {
+        return Some(Http3Perk {
+            settings: vec![(1, 65_536), (6, 262_144), (7, 100), (51, 1)],
+            pseudo_headers: "masp".to_string(),
+            has_grease: true,
+        });
+    }
+
+    if ua.contains("firefox/") {
+        return Some(Http3Perk {
+            settings: vec![(1, 65_536), (7, 20), (727_725_890, 0)],
+            pseudo_headers: "mpas".to_string(),
+            has_grease: false,
+        });
+    }
+
+    None
+}
+
 // ── profile methods ──────────────────────────────────────────────────────────
 
 /// Truncate a hex string to at most `n` characters on a char boundary.
@@ -784,6 +900,14 @@ impl TlsProfile {
         }
     }
 
+    /// Return an expected HTTP/3 perk fingerprint for this profile.
+    ///
+    /// Returns `None` for profiles where no stable reference shape is encoded.
+    #[must_use]
+    pub fn http3_perk(&self) -> Option<Http3Perk> {
+        expected_http3_perk_from_user_agent(&default_user_agent_from_profile_name(&self.name))
+    }
+
     /// Select a built-in TLS profile weighted by real browser market share.
     ///
     /// Distribution mirrors [`DeviceProfile`](super::fingerprint::DeviceProfile)
@@ -825,6 +949,20 @@ impl TlsProfile {
                 _ => &FIREFOX_133,
             },
         }
+    }
+}
+
+fn default_user_agent_from_profile_name(profile_name: &str) -> String {
+    let name = profile_name.to_ascii_lowercase();
+    if name.contains("firefox") {
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"
+            .to_string()
+    } else if name.contains("edge") {
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0"
+            .to_string()
+    } else {
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+            .to_string()
     }
 }
 
@@ -1934,6 +2072,40 @@ mod tests {
     fn ja4_display() {
         let ja4 = CHROME_131.ja4();
         assert_eq!(format!("{ja4}"), ja4.fingerprint);
+    }
+
+    #[test]
+    fn http3_perk_chrome_text_and_hash_are_stable() {
+        let Some(perk) = CHROME_131.http3_perk() else {
+            panic!("chrome should have perk");
+        };
+        let text = perk.perk_text();
+        assert_eq!(text, "1:65536;6:262144;7:100;51:1;GREASE|masp");
+        assert_eq!(perk.perk_hash().len(), 32);
+    }
+
+    #[test]
+    fn expected_perk_from_user_agent_detects_firefox() {
+        let ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0";
+        let Some(perk) = expected_http3_perk_from_user_agent(ua) else {
+            panic!("firefox should resolve");
+        };
+        assert_eq!(perk.perk_text(), "1:65536;7:20;727725890:0|mpas");
+    }
+
+    #[test]
+    fn http3_perk_compare_detects_text_mismatch() {
+        let Some(perk) = CHROME_131.http3_perk() else {
+            panic!("chrome should have perk");
+        };
+        let cmp = perk.compare(Some("1:65536|masp"), None);
+        assert!(!cmp.matches);
+        assert_eq!(cmp.mismatches.len(), 1);
+        assert!(
+            cmp.mismatches
+                .first()
+                .is_some_and(|mismatch| mismatch.contains("perk_text mismatch"))
+        );
     }
 
     #[test]

--- a/crates/stygian-browser/src/tls.rs
+++ b/crates/stygian-browser/src/tls.rs
@@ -944,7 +944,25 @@ impl TlsProfile {
     /// Returns `None` for profiles where no stable reference shape is encoded.
     #[must_use]
     pub fn http3_perk(&self) -> Option<Http3Perk> {
-        expected_http3_perk_from_user_agent(&default_user_agent_from_profile_name(&self.name))
+        match self.name.as_str() {
+            name if name.starts_with("Chrome ") => Some(Http3Perk {
+                settings: vec![(1, 65_536), (6, 262_144), (7, 100), (51, 1)],
+                pseudo_headers: "masp".to_string(),
+                has_grease: true,
+            }),
+            name if name.starts_with("Edge ") => Some(Http3Perk {
+                settings: vec![(1, 65_536), (6, 262_144), (7, 100), (51, 1)],
+                pseudo_headers: "masp".to_string(),
+                has_grease: true,
+            }),
+            name if name.starts_with("Firefox ") => Some(Http3Perk {
+                settings: vec![(1, 65_536), (7, 20), (727_725_890, 0)],
+                pseudo_headers: "mpas".to_string(),
+                has_grease: false,
+            }),
+            name if name.starts_with("Safari ") => None,
+            _ => None,
+        }
     }
 
     /// Select a built-in TLS profile weighted by real browser market share.
@@ -988,20 +1006,6 @@ impl TlsProfile {
                 _ => &FIREFOX_133,
             },
         }
-    }
-}
-
-fn default_user_agent_from_profile_name(profile_name: &str) -> String {
-    let name = profile_name.to_ascii_lowercase();
-    if name.contains("firefox") {
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0"
-            .to_string()
-    } else if name.contains("edge") {
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0"
-            .to_string()
-    } else {
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
-            .to_string()
     }
 }
 

--- a/crates/stygian-browser/src/tls.rs
+++ b/crates/stygian-browser/src/tls.rs
@@ -926,12 +926,7 @@ impl TlsProfile {
     #[must_use]
     pub fn http3_perk(&self) -> Option<Http3Perk> {
         match self.name.as_str() {
-            name if name.starts_with("Chrome ") => Some(Http3Perk {
-                settings: vec![(1, 65_536), (6, 262_144), (7, 100), (51, 1)],
-                pseudo_headers: "masp".to_string(),
-                has_grease: true,
-            }),
-            name if name.starts_with("Edge ") => Some(Http3Perk {
+            name if name.starts_with("Chrome ") || name.starts_with("Edge ") => Some(Http3Perk {
                 settings: vec![(1, 65_536), (6, 262_144), (7, 100), (51, 1)],
                 pseudo_headers: "masp".to_string(),
                 has_grease: true,

--- a/crates/stygian-browser/src/tls.rs
+++ b/crates/stygian-browser/src/tls.rs
@@ -688,26 +688,7 @@ impl Http3Perk {
 /// Returns `None` when the browser family is unknown or unsupported.
 #[must_use]
 pub fn expected_http3_perk_from_user_agent(user_agent: &str) -> Option<Http3Perk> {
-    let ua = user_agent.to_ascii_lowercase();
-
-    // Chromium family: Chrome/Edge share the same high-level HTTP/3 pattern.
-    if ua.contains("edg/") || ua.contains("chrome/") {
-        return Some(Http3Perk {
-            settings: vec![(1, 65_536), (6, 262_144), (7, 100), (51, 1)],
-            pseudo_headers: "masp".to_string(),
-            has_grease: true,
-        });
-    }
-
-    if ua.contains("firefox/") {
-        return Some(Http3Perk {
-            settings: vec![(1, 65_536), (7, 20), (727_725_890, 0)],
-            pseudo_headers: "mpas".to_string(),
-            has_grease: false,
-        });
-    }
-
-    None
+    expected_tls_profile_from_user_agent(user_agent).and_then(TlsProfile::http3_perk)
 }
 
 /// Resolve the expected built-in TLS profile for a given User-Agent.

--- a/crates/stygian-browser/src/tls.rs
+++ b/crates/stygian-browser/src/tls.rs
@@ -710,6 +710,45 @@ pub fn expected_http3_perk_from_user_agent(user_agent: &str) -> Option<Http3Perk
     None
 }
 
+/// Resolve the expected built-in TLS profile for a given User-Agent.
+///
+/// Returns `None` when no supported browser family can be inferred.
+#[must_use]
+pub fn expected_tls_profile_from_user_agent(user_agent: &str) -> Option<&'static TlsProfile> {
+    let ua = user_agent.to_ascii_lowercase();
+
+    if ua.contains("edg/") {
+        return Some(&EDGE_131);
+    }
+
+    if ua.contains("firefox/") {
+        return Some(&FIREFOX_133);
+    }
+
+    // Safari check excludes Chromium UAs that include the Safari token.
+    if ua.contains("safari/") && !ua.contains("chrome/") && !ua.contains("edg/") {
+        return Some(&SAFARI_18);
+    }
+
+    if ua.contains("chrome/") {
+        return Some(&CHROME_131);
+    }
+
+    None
+}
+
+/// Return expected JA3 hash for a User-Agent if a built-in profile matches.
+#[must_use]
+pub fn expected_ja3_from_user_agent(user_agent: &str) -> Option<Ja3Hash> {
+    expected_tls_profile_from_user_agent(user_agent).map(TlsProfile::ja3)
+}
+
+/// Return expected JA4 fingerprint for a User-Agent if a built-in profile matches.
+#[must_use]
+pub fn expected_ja4_from_user_agent(user_agent: &str) -> Option<Ja4> {
+    expected_tls_profile_from_user_agent(user_agent).map(TlsProfile::ja4)
+}
+
 // ── profile methods ──────────────────────────────────────────────────────────
 
 /// Truncate a hex string to at most `n` characters on a char boundary.

--- a/crates/stygian-proxy/src/types.rs
+++ b/crates/stygian-proxy/src/types.rs
@@ -155,7 +155,7 @@ impl ProxyMetrics {
     /// proxies that number is never reached in practice, and direct casting
     /// preserves ratios correctly (unlike saturating to `u32::MAX`).
     #[allow(clippy::cast_precision_loss)]
-    fn u64_as_f64(value: u64) -> f64 {
+    const fn u64_as_f64(value: u64) -> f64 {
         value as f64
     }
 


### PR DESCRIPTION
## Summary

Adds 8 new stealth detection checks to `DiagnosticReport` covering the PerimeterX `auditor.js` environment bitmask (`_0xaf48`), reverse-engineered from [B9ph0met/px-vm](https://github.com/B9ph0met/px-vm) (deployed 2026-04-02).

Also introduces transport-layer diagnostics (JA3/JA4/HTTP3 perk) for fingerprint verification.

## Background

PX probes an 8-bit bitmask at runtime to determine execution environment. Chrome produces `0x7F` (bits 0–6 set, bit 7 clear). A Node.js headless context produces `0xFF` (all 8 bits set — bit 7 leaks the runtime). Any headless context failing bits 0–6 is detectable.

## New PX env-bitmask checks

| Bit | CheckId | What it tests |
|-----|---------|---------------|
| 0 | `MatchMediaPresent` | `window.matchMedia` is a function |
| 1 | `ElementFromPointPresent` | `document.elementFromPoint` is a function |
| 2 | `RequestAnimationFramePresent` | `window.requestAnimationFrame` is a function |
| 3 | `GetComputedStylePresent` | `window.getComputedStyle` is a function |
| 4 | `CssSupportsPresent` | `CSS.supports` exists and is callable |
| 5 | `SendBeaconPresent` | `navigator.sendBeacon` is a function |
| 6 | `ExecCommandPresent` | `document.execCommand` is a function |
| 7 | `NodeJsAbsent` | `process.versions.node` is **absent** (not Node.js) |

## Transport diagnostics (new)

- `Http3Perk` type models HTTP/3 SETTINGS fingerprints (settings identifiers, pseudo-header ordering, GREASE presence)
- `TlsProfile::http3_perk()` returns expected perk for Chrome, Edge, Firefox; Safari returns `None`
- `expected_http3_perk_from_user_agent()`, `expected_tls_profile_from_user_agent()`, `expected_ja3_from_user_agent()`, `expected_ja4_from_user_agent()` resolve fingerprint expectations from UA string
- `TransportObservations` and `TransportDiagnostic` types expose expected vs. observed JA3/JA4/HTTP3 transport fingerprints in `DiagnosticReport.transport`
- `PageHandle::verify_stealth_with_transport()` accepts optional observed transport values

## MCP changes

- `browser_verify_stealth` tool now accepts four optional observed transport fields (`observed_ja3_hash`, `observed_ja4`, `observed_http3_perk_text`, `observed_http3_perk_hash`) and includes `TransportDiagnostic` in the response
- Proper feature gating: tool dispatch and implementation now gated with `#[cfg(feature = "stealth")]`

## Example CLI changes

- `stealth_probe`: `--ja3-hash`, `--ja4`, `--http3-perk-text`, `--http3-perk-hash` CLI flags pass observed transport values; transport section emitted from `DiagnosticReport`
- `--threshold` now validates range `0.0..=1.0`

## Changes

- `crates/stygian-browser/src/diagnostic.rs`: +8 `CheckId` variants, +8 JS script constants, +8 `DetectionCheck` entries, `TransportObservations`, `TransportDiagnostic`, unit tests for transport matching/mismatching/unknown-UA scenarios
- `crates/stygian-browser/src/tls.rs`: `Http3Perk` type, `expected_*_from_user_agent()` helpers, deduplicated perk settings (delegates to `TlsProfile::http3_perk()`)
- `crates/stygian-browser/src/page.rs`: `verify_stealth_with_transport()` method
- `crates/stygian-browser/src/mcp.rs`: transport observation parsing, feature-gated dispatch
- `crates/stygian-browser/examples/stealth_probe.rs`: CLI flags, threshold validation

## Testing

```
cargo test -p stygian-browser   # all passing
```