### PR TITLE
feat(mcp): add expansion tools for proxy and browser (T55-T57)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,23 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "v[0-9]*.[0-9]*.[0-9]*"
   workflow_run:
+    # Fires when auto-tag pushes via GITHUB_TOKEN.
     workflows:
       - "Auto-tag on release merge"
     types:
       - completed
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g., v1.2.3)"
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
+  cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
@@ -24,6 +34,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     outputs:
       release_ref: ${{ steps.tag.outputs.release_ref }}
+      release_sha: ${{ steps.tag.outputs.release_sha }}
       version: ${{ steps.tag.outputs.version }}
     steps:
       - uses: actions/checkout@v4
@@ -33,23 +44,34 @@ jobs:
       - name: Resolve release tag and version
         id: tag
         run: |
-          if [[ "${{ github.event_name }}" == "push" ]]; then
-            REF="${{ github.ref }}"
-          elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
-            SHA="${{ github.event.workflow_run.head_sha }}"
-            git fetch --tags origin
-            TAG=$(git tag --points-at "$SHA" | sort -V | tail -n 1)
-            if [[ -z "$TAG" ]]; then
-              echo "No tag found for workflow_run SHA $SHA"
+          set -euo pipefail
+          git fetch --tags origin
+
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            TAG="${{ inputs.tag }}"
+            SHA=$(git rev-list -n 1 "$TAG" 2>/dev/null || true)
+            if [[ -z "$SHA" ]]; then
+              echo "Tag $TAG not found"
               exit 1
             fi
             REF="refs/tags/$TAG"
-          else
-            VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-            REF="refs/tags/v$VERSION"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            REF="${{ github.ref }}"
+            SHA="${{ github.sha }}"
+          elif [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            SHA="${{ github.event.workflow_run.head_sha }}"
+            TAG=$(git tag --points-at "$SHA" \
+              | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+              | sort -V | tail -n 1 || true)
+            if [[ -z "$TAG" ]]; then
+              echo "No semver tag found for workflow_run SHA $SHA"
+              exit 1
+            fi
+            REF="refs/tags/$TAG"
           fi
           VERSION="${REF#refs/tags/v}"
           echo "release_ref=$REF" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION"  >> "$GITHUB_OUTPUT"
 
   validate:
@@ -81,12 +103,12 @@ jobs:
     name: Verify CI is green
     runs-on: ubuntu-latest
     needs: resolve
-    if: ${{ needs.resolve.outputs.release_ref != '' }}
+    if: ${{ needs.resolve.outputs.release_ref != '' && needs.resolve.outputs.release_sha != '' }}
     steps:
       - name: Wait for CI workflow result on tagged commit
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          RELEASE_SHA: ${{ needs.resolve.outputs.release_sha }}
         run: |
           set -euo pipefail
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4] - 2026-04-17
+
+### Added
+
+- `stygian-browser`: three new MCP tools — `browser_extract_with_fallback` (tries multiple CSS
+  selectors in priority order, advancing only when at least one record is extracted),
+  `browser_extract_resilient` (schema-driven extraction with configurable per-field fallback
+  selectors), and `browser_proxied` cross-crate tool forwarded by `stygian-mcp`
+- `stygian-proxy`: three new MCP tools — `proxy_acquire_with_capabilities` (acquire a proxy
+  constrained by capabilities bitmask: `anonymous`, `rotating`, `residential`, `datacenter`,
+  `socks`), `proxy_fetch_freelist` (fetch and import proxies from a named free-list source;
+  SOCKS4/5 sources gated behind the `socks` feature), and `proxy_fetch_freeapiproxies`
+  (import proxies from the free-api-proxies provider)
+- `stygian-mcp`: MCP tool matrix documenting all `graph_*`, `browser_*`, `proxy_*`, and
+  cross-crate tools added to root README and book overview
+
+### Changed
+
+- `stygian-proxy`: `proxy_fetch_freelist` schema enum for `source` field is now conditionally
+  built by `freelist_source_enum_values()` — SOCKS4/5 source variants (`the_speedx_socks4`,
+  `the_speedx_socks5`) are included only when the `socks` feature is enabled, keeping the
+  schema honest at compile time
+- `stygian-browser`: `browser_extract_with_fallback` selector logic now only advances
+  `matched_selector` and breaks when at least one record is actually extracted from
+  a selector, preventing false-positive selector matches on empty result sets
+- `book/mcp`: overview page updated to document MCP `2025-11-25` as the current protocol
+  version; proxy-tools and browser-tools pages updated with full reference entries for all
+  new tools
+
+### Refactored
+
+- `stygian-browser`: `tool_browser_extract_with_fallback` split into `parse_root_selectors`
+  and `parse_extract_schema` helpers to satisfy `clippy::too_many_lines` — no behaviour change
+
+### Fixed
+
+- `stygian-browser`: broken intra-doc links in `page.rs` (`BrowserError::QuerySelectorFailed`
+  replaced with `BrowserError::CdpError`) and `tls.rs` (`ProfileChannel::from_str` replaced
+  with `std::str::FromStr::from_str`) that caused `RUSTDOCFLAGS=-Dwarnings` Documentation CI failures
+
+### CI
+
+- `release.yml` synced with updated workflow template: tag trigger narrowed to semver
+  `v[0-9]*.[0-9]*.[0-9]*`, `workflow_dispatch` accepts a `tag` input, concurrency group
+  added (`cancel-in-progress: false`), `resolve` job gains `release_sha` output and
+  `set -euo pipefail`, `verify-ci` uses `needs.resolve.outputs.release_sha`
+
 ## [0.9.3] - 2026-04-16
 
 ### Added
@@ -841,7 +888,9 @@ Both crates are functional and well-tested, but APIs may evolve based on communi
 
 ---
 
-[Unreleased]: https://github.com/greysquirr3l/stygian/compare/v0.9.2...HEAD
+[Unreleased]: https://github.com/greysquirr3l/stygian/compare/v0.9.4...HEAD
+[0.9.4]: https://github.com/greysquirr3l/stygian/compare/v0.9.3...v0.9.4
+[0.9.3]: https://github.com/greysquirr3l/stygian/compare/v0.9.2...v0.9.3
 [0.9.2]: https://github.com/greysquirr3l/stygian/compare/v0.9.1...v0.9.2
 [0.9.1]: https://github.com/greysquirr3l/stygian/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/greysquirr3l/stygian/compare/v0.1.9...v0.9.0

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ MCP (Model Context Protocol) aggregator for LLM tool integration:
 - **Cross-crate tools** — `scrape_proxied`, `browser_proxied`
 - **VS Code/Claude** — direct integration with MCP-compatible clients
 
+MCP tool matrix (aggregator surface):
+
+| Namespace | Representative tools | Purpose |
+| --------- | -------------------- | ------- |
+| `graph_*` | `graph_scrape`, `graph_scrape_rest`, `graph_scrape_graphql`, `graph_pipeline_validate`, `graph_pipeline_run` | HTTP/API/feed scraping and DAG execution |
+| `browser_*` | `browser_acquire`, `browser_navigate`, `browser_query`, `browser_extract`, `browser_extract_with_fallback`, `browser_extract_resilient`, `browser_release` | Headless browser automation and structured extraction |
+| `proxy_*` | `proxy_add`, `proxy_remove`, `proxy_pool_stats`, `proxy_acquire`, `proxy_acquire_for_domain`, `proxy_acquire_with_capabilities`, `proxy_fetch_freelist`, `proxy_fetch_freeapiproxies`, `proxy_release` | Proxy pool management, capability-aware leasing, and feed bootstrap |
+| cross-crate | `scrape_proxied`, `browser_proxied` | End-to-end orchestration across graph/browser/proxy |
+
 ### [stygian-extract-derive](crates/stygian-extract-derive)
 
 Proc-macro backend that powers `#[derive(Extract)]` in `stygian-browser`:

--- a/book/src/mcp/browser-tools.md
+++ b/book/src/mcp/browser-tools.md
@@ -1,6 +1,6 @@
 # Browser MCP Tools
 
-`stygian-browser` exposes eleven tools for headless browser automation plus a pool stats tool.
+`stygian-browser` exposes thirteen tools for headless browser automation plus a pool stats tool.
 
 ---
 
@@ -179,13 +179,12 @@ to calling `page.extract_all::<T>()` with an inline schema definition.
 | `session_id` | string | ✓ | Session ID |
 | `url` | string | ✓ | URL to navigate to before extracting |
 | `root_selector` | string | ✓ | CSS selector for the repeating container element |
-| `schema` | array | ✓ | Array of `{ name, selector, attr?, required? }` field descriptors |
+| `schema` | object | ✓ | Map of field name to `{ selector, attr?, required? }` field descriptor |
 
 **Schema field descriptor:**
 
 | Key | Type | Required | Description |
 | --- | ---- | -------- | ----------- |
-| `name` | string | ✓ | Key in the output object |
 | `selector` | string | ✓ | CSS selector scoped to the root element |
 | `attr` | string | | If present, captures this attribute instead of `textContent` |
 | `required` | boolean | | `true` (default) — omit or set to `false` for optional fields |
@@ -210,11 +209,57 @@ to calling `page.extract_all::<T>()` with an inline schema definition.
   "session_id":    "01HV4...",
   "url":           "https://news.example.com",
   "root_selector": "article.story",
-  "schema": [
-    { "name": "title",  "selector": "h2" },
-    { "name": "url",    "selector": "h2 a", "attr": "href" },
-    { "name": "author", "selector": "span.author" },
-    { "name": "date",   "selector": "time", "attr": "datetime", "required": false }
+  "schema": {
+    "title":  { "selector": "h2" },
+    "url":    { "selector": "h2 a", "attr": "href" },
+    "author": { "selector": "span.author" },
+    "date":   { "selector": "time", "attr": "datetime", "required": false }
+  }
+}
+```
+
+---
+
+### `browser_extract_with_fallback`
+
+Structured extraction with multiple root selectors. Selectors are tried in order,
+and the first selector that yields results is used.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `session_id` | string | ✓ | Session ID |
+| `url` | string | ✓ | URL to navigate to before extracting |
+| `root_selectors` | array[string] | ✓ | Candidate root selectors in priority order |
+| `schema` | object | ✓ | Same schema object used by `browser_extract` |
+| `timeout_secs` | number | | Navigation/extraction timeout (default: 30) |
+
+**Returns:** same structured `results` array as `browser_extract`, plus the selected root selector.
+
+---
+
+### `browser_extract_resilient`
+
+Structured extraction mode that tolerates partial records by skipping invalid root
+nodes instead of failing the full extraction call.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `session_id` | string | ✓ | Session ID |
+| `url` | string | ✓ | URL to navigate to before extracting |
+| `root_selector` | string | ✓ | Root selector for repeated record containers |
+| `schema` | object | ✓ | Same schema object used by `browser_extract` |
+| `timeout_secs` | number | | Navigation/extraction timeout (default: 30) |
+
+**Returns:**
+
+```json
+{
+  "url": "https://news.example.com",
+  "root_selector": "article.story",
+  "count": 42,
+  "skipped": 3,
+  "results": [
+    { "title": "...", "url": "..." }
   ]
 }
 ```

--- a/book/src/mcp/overview.md
+++ b/book/src/mcp/overview.md
@@ -1,10 +1,14 @@
 # MCP — Model Context Protocol
 
-All three Stygian crates expose their capabilities over the
-[Model Context Protocol (MCP)](https://modelcontextprotocol.io/) with negotiated protocol
-version support for `2025-11-25`, `2025-06-18`, and `2024-11-05`, enabling LLM
-agents, IDE plug-ins, and automation pipelines to scrape the web, control browsers, and manage
-proxy pools without writing any Rust code.
+All Stygian MCP servers expose capabilities over the
+[Model Context Protocol (MCP)](https://modelcontextprotocol.io/). The standalone
+`stygian-graph`, `stygian-browser`, and `stygian-proxy` servers speak MCP
+`2025-11-25`; the `stygian-mcp` aggregator additionally supports protocol
+negotiation for `2025-11-25`, `2025-06-18`, and `2024-11-05`.
+
+This gives LLM agents, IDE plug-ins, and automation pipelines a stable JSON-RPC
+surface for web scraping, browser control, and proxy pool management without
+writing Rust code.
 
 ---
 
@@ -59,6 +63,10 @@ All servers implement **JSON-RPC 2.0 over stdin/stdout**. Newline-delimited requ
 newline-delimited responses out.
 
 Notifications (messages without an `id`) do not produce responses.
+
+The implementation follows MCP `2025-11-25` message shapes for tool schemas,
+tool content blocks, and resource payloads. For protocol details, see the
+official spec: <https://modelcontextprotocol.io/specification/2025-11-25>.
 
 | Method | Description |
 | ------ | ----------- |

--- a/book/src/mcp/proxy-tools.md
+++ b/book/src/mcp/proxy-tools.md
@@ -1,6 +1,6 @@
 # Proxy MCP Tools
 
-`stygian-proxy` exposes six tools for managing a proxy pool plus a readable pool-stats resource.
+`stygian-proxy` exposes nine tools for managing a proxy pool plus a readable pool-stats resource.
 
 ---
 
@@ -23,6 +23,12 @@ Proxy handles are tracked across tool calls by a `handle_token` (a ULID string):
 
 ```
 proxy_add → proxy_acquire / proxy_acquire_for_domain → [use proxy] → proxy_release
+```
+
+Capability-aware acquisition adds one more path:
+
+```
+proxy_add → proxy_acquire_with_capabilities → [use proxy] → proxy_release
 ```
 
 The handle acts as a circuit-breaker ticket. **Always call `proxy_release`** — the server stores
@@ -153,6 +159,66 @@ succeeded or failed.
 
 ```json
 { "released": true }
+```
+
+---
+
+### `proxy_acquire_with_capabilities`
+
+Acquire a proxy that satisfies explicit capability requirements.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `require_https_connect` | boolean | | Require HTTPS CONNECT tunnel support (default: `false`) |
+| `require_socks5_udp` | boolean | | Require SOCKS5 UDP relay support (default: `false`) |
+| `require_http3_tunnel` | boolean | | Require HTTP/3 QUIC tunnel support (default: `false`) |
+| `require_geo_country` | string | | ISO-3166-1 alpha-2 country code (for example `US`) |
+
+**Returns:** Same shape as `proxy_acquire`:
+
+```json
+{
+  "handle_token": "01HV4...",
+  "proxy_url": "http://proxy3.example.com:8080"
+}
+```
+
+---
+
+### `proxy_fetch_freelist`
+
+Fetch plain host:port proxies from curated public free-list feeds and add them to
+the pool.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `sources` | array[string] | ✓ | Feed names. Supported: `the_speedx_http`, `the_speedx_socks4`, `the_speedx_socks5`, `clarketm_http`, `open_proxy_list_http` |
+| `tags` | array[string] | | Extra tags attached to each loaded proxy |
+
+> `the_speedx_socks4` and `the_speedx_socks5` require the crate `socks` feature.
+
+**Returns:**
+
+```json
+{ "loaded": 127 }
+```
+
+---
+
+### `proxy_fetch_freeapiproxies`
+
+Fetch proxies from a FreeAPIProxies-compatible JSON endpoint and add them to the
+pool.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `endpoint` | string | | Custom endpoint URL (default: public FreeAPIProxies endpoint) |
+| `tags` | array[string] | | Extra tags attached to each loaded proxy |
+
+**Returns:**
+
+```json
+{ "loaded": 64 }
 ```
 
 ---

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -45,6 +45,8 @@
 //! | `pool_stats` | – | `active, max, available` |
 //! | `browser_query` | `session_id, url, selector, fields?, limit?, timeout_secs?` | `results` array of text or field objects |
 //! | `browser_extract` | `session_id, url, root_selector, schema, timeout_secs?` | `results` array of structured objects |
+//! | `browser_extract_with_fallback` | `session_id, url, root_selectors, schema, timeout_secs?` | first successful selector + `results` |
+//! | `browser_extract_resilient` | `session_id, url, root_selector, schema, timeout_secs?` | `results` plus skipped-count metadata |
 //! | `browser_find_similar` *(similarity feature)* | `session_id, url, reference_selector, threshold?, max_results?, timeout_secs?` | scored `matches` array |
 //! | `browser_warmup` | `session_id, url, wait?, timeout_ms?, stabilize_ms?` | warmup report |
 //! | `browser_refresh` | `session_id, wait?, timeout_ms?, reset_connection?` | refresh report |

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -1774,7 +1774,9 @@ impl McpBrowserServer {
             .get("root_selectors")
             .and_then(Value::as_array)
             .ok_or_else(|| {
-                BrowserError::ConfigError("Missing or non-array 'root_selectors' argument".to_string())
+                BrowserError::ConfigError(
+                    "Missing or non-array 'root_selectors' argument".to_string(),
+                )
             })?
             .iter()
             .filter_map(|v| v.as_str().map(str::to_string))

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -330,6 +330,65 @@ static TOOL_DEFINITIONS: LazyLock<Vec<Value>> = LazyLock::new(|| {
             "required": ["session_id", "url", "root_selector", "schema"]
         }
     }));
+    tools.push(json!({
+        "name": "browser_extract_with_fallback",
+        "description": "Like browser_extract but accepts multiple root selectors (tried in order). Returns the first selector that produces results. Useful when a site layout may have changed and you want to try modern markup before falling back to legacy selectors.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session_id": { "type": "string" },
+                "url": { "type": "string" },
+                "root_selectors": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "CSS selectors tried in order; the first that produces results is used.",
+                    "minItems": 1
+                },
+                "schema": {
+                    "type": "object",
+                    "description": "Map of field name → { \"selector\": \"...\", \"attr\": \"...\", \"required\": true/false }.",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "selector": { "type": "string" },
+                            "attr": { "type": "string" },
+                            "required": { "type": "boolean", "default": false }
+                        },
+                        "required": ["selector"]
+                    }
+                },
+                "timeout_secs": { "type": "number", "default": 30 }
+            },
+            "required": ["session_id", "url", "root_selectors", "schema"]
+        }
+    }));
+    tools.push(json!({
+        "name": "browser_extract_resilient",
+        "description": "Like browser_extract but skips root nodes where *all* required schema fields are absent (partial records). Useful for heterogeneous lists where some items lack an optional field.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "session_id": { "type": "string" },
+                "url": { "type": "string" },
+                "root_selector": { "type": "string", "description": "CSS selector whose matches become the root of each result object." },
+                "schema": {
+                    "type": "object",
+                    "description": "Map of field name → { \"selector\": \"...\", \"attr\": \"...\", \"required\": true/false }.",
+                    "additionalProperties": {
+                        "type": "object",
+                        "properties": {
+                            "selector": { "type": "string" },
+                            "attr": { "type": "string" },
+                            "required": { "type": "boolean", "default": false }
+                        },
+                        "required": ["selector"]
+                    }
+                },
+                "timeout_secs": { "type": "number", "default": 30 }
+            },
+            "required": ["session_id", "url", "root_selector", "schema"]
+        }
+    }));
     // Advertise browser_find_similar only when the similarity feature is compiled in.
     #[cfg(feature = "similarity")]
     tools.push(json!({
@@ -628,6 +687,8 @@ impl McpBrowserServer {
             "pool_stats" => Ok(self.tool_pool_stats()),
             "browser_query" => self.tool_browser_query(&args).await,
             "browser_extract" => self.tool_browser_extract(&args).await,
+            "browser_extract_with_fallback" => self.tool_browser_extract_with_fallback(&args).await,
+            "browser_extract_resilient" => self.tool_browser_extract_resilient(&args).await,
             #[cfg(feature = "similarity")]
             "browser_find_similar" => self.tool_browser_find_similar(&args).await,
             "browser_warmup" => self.tool_browser_warmup(&args).await,
@@ -1538,6 +1599,210 @@ impl McpBrowserServer {
     ///
     /// Returns `None` if any required field is absent; otherwise returns a
     /// JSON object with one entry per field.
+    // ── browser_extract_with_fallback ─────────────────────────────────────────
+
+    /// Extract using the first `root_selectors` entry that yields results.
+    async fn tool_browser_extract_with_fallback(&self, args: &Value) -> Result<Value> {
+        let session_id = Self::require_str(args, "session_id")?;
+        let url = Self::require_str(args, "url")?;
+        let timeout_secs = args
+            .get("timeout_secs")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(30.0);
+
+        let selectors: Vec<String> = args
+            .get("root_selectors")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                BrowserError::ConfigError(
+                    "Missing or non-array 'root_selectors' argument".to_string(),
+                )
+            })?
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect();
+
+        if selectors.is_empty() {
+            return Err(BrowserError::ConfigError(
+                "root_selectors must contain at least one entry".to_string(),
+            ));
+        }
+
+        let schema_obj = args
+            .get("schema")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| {
+                BrowserError::ConfigError("Missing or non-object 'schema' argument".to_string())
+            })?;
+
+        let schema: Vec<(String, ExtractFieldDef)> = schema_obj
+            .iter()
+            .filter_map(|(name, spec)| {
+                let selector = spec
+                    .get("selector")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToString::to_string)?;
+                let attr = spec
+                    .get("attr")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToString::to_string);
+                let required = spec
+                    .get("required")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+                Some((
+                    name.clone(),
+                    ExtractFieldDef {
+                        selector,
+                        attr,
+                        required,
+                    },
+                ))
+            })
+            .collect();
+
+        let session_arc = self.session_handle(&session_id).await?;
+        let mut page = session_arc
+            .lock()
+            .await
+            .as_ref()
+            .ok_or_else(|| {
+                BrowserError::ConfigError(format!("Session already released: {session_id}"))
+            })?
+            .browser()
+            .ok_or_else(|| {
+                BrowserError::ConfigError(format!("Browser handle invalid: {session_id}"))
+            })?
+            .new_page()
+            .await?;
+
+        page.navigate(
+            &url,
+            WaitUntil::DomContentLoaded,
+            Duration::from_secs_f64(timeout_secs),
+        )
+        .await?;
+
+        let mut matched_selector = String::new();
+        let mut results: Vec<Value> = vec![];
+
+        for selector in &selectors {
+            let roots = page.query_selector_all(selector).await?;
+            if roots.is_empty() {
+                continue;
+            }
+            matched_selector = selector.clone();
+            results.reserve(roots.len());
+            for root in &roots {
+                if let Some(obj) = Self::extract_record(root, &schema).await {
+                    results.push(Value::Object(obj));
+                }
+            }
+            break;
+        }
+
+        page.close().await?;
+
+        Ok(json!({
+            "url":              url,
+            "matched_selector": matched_selector,
+            "tried_selectors":  selectors,
+            "count":            results.len(),
+            "results":          results
+        }))
+    }
+
+    // ── browser_extract_resilient ─────────────────────────────────────────────
+
+    /// Extract from every root node matching `root_selector`, silently
+    /// dropping nodes where *all* required schema fields are absent.
+    async fn tool_browser_extract_resilient(&self, args: &Value) -> Result<Value> {
+        let session_id = Self::require_str(args, "session_id")?;
+        let url = Self::require_str(args, "url")?;
+        let root_selector = Self::require_str(args, "root_selector")?;
+        let timeout_secs = args
+            .get("timeout_secs")
+            .and_then(serde_json::Value::as_f64)
+            .unwrap_or(30.0);
+
+        let schema_obj = args
+            .get("schema")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| {
+                BrowserError::ConfigError("Missing or non-object 'schema' argument".to_string())
+            })?;
+
+        let schema: Vec<(String, ExtractFieldDef)> = schema_obj
+            .iter()
+            .filter_map(|(name, spec)| {
+                let selector = spec
+                    .get("selector")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToString::to_string)?;
+                let attr = spec
+                    .get("attr")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToString::to_string);
+                let required = spec
+                    .get("required")
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false);
+                Some((
+                    name.clone(),
+                    ExtractFieldDef {
+                        selector,
+                        attr,
+                        required,
+                    },
+                ))
+            })
+            .collect();
+
+        let session_arc = self.session_handle(&session_id).await?;
+        let mut page = session_arc
+            .lock()
+            .await
+            .as_ref()
+            .ok_or_else(|| {
+                BrowserError::ConfigError(format!("Session already released: {session_id}"))
+            })?
+            .browser()
+            .ok_or_else(|| {
+                BrowserError::ConfigError(format!("Browser handle invalid: {session_id}"))
+            })?
+            .new_page()
+            .await?;
+
+        page.navigate(
+            &url,
+            WaitUntil::DomContentLoaded,
+            Duration::from_secs_f64(timeout_secs),
+        )
+        .await?;
+
+        let roots = page.query_selector_all(&root_selector).await?;
+        // Resilient mode: `extract_record` returns None when a required field is
+        // missing.  We count those as "skipped" rather than bubbling an error.
+        let mut results: Vec<Value> = Vec::with_capacity(roots.len());
+        let mut skipped: usize = 0;
+        for root in &roots {
+            match Self::extract_record(root, &schema).await {
+                Some(obj) => results.push(Value::Object(obj)),
+                None => skipped += 1,
+            }
+        }
+
+        page.close().await?;
+
+        Ok(json!({
+            "url":           url,
+            "root_selector": root_selector,
+            "count":         results.len(),
+            "skipped":       skipped,
+            "results":       results
+        }))
+    }
+
     async fn extract_record(
         root: &crate::page::NodeHandle,
         schema: &[(String, ExtractFieldDef)],
@@ -1617,6 +1882,50 @@ mod tests {
                 .any(|t| t.get("name").and_then(|n| n.as_str()) == Some("browser_extract")),
             "TOOL_DEFINITIONS must contain browser_extract"
         );
+    }
+
+    #[test]
+    fn tool_defs_include_browser_extract_with_fallback() {
+        let defs = &*TOOL_DEFINITIONS;
+        assert!(
+            defs.iter()
+                .any(|t| t.get("name").and_then(|n| n.as_str())
+                    == Some("browser_extract_with_fallback")),
+            "TOOL_DEFINITIONS must contain browser_extract_with_fallback"
+        );
+    }
+
+    #[test]
+    fn tool_defs_include_browser_extract_resilient() {
+        let defs = &*TOOL_DEFINITIONS;
+        assert!(
+            defs.iter().any(
+                |t| t.get("name").and_then(|n| n.as_str()) == Some("browser_extract_resilient")
+            ),
+            "TOOL_DEFINITIONS must contain browser_extract_resilient"
+        );
+    }
+
+    #[test]
+    fn browser_extract_with_fallback_requires_root_selectors()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let defs = &*TOOL_DEFINITIONS;
+        let def = defs
+            .iter()
+            .find(|t| {
+                t.get("name").and_then(|n| n.as_str()) == Some("browser_extract_with_fallback")
+            })
+            .ok_or("browser_extract_with_fallback must be in TOOL_DEFINITIONS")?;
+        let required = def
+            .get("inputSchema")
+            .and_then(|s| s.get("required"))
+            .and_then(Value::as_array)
+            .ok_or("browser_extract_with_fallback inputSchema missing 'required' array")?;
+        assert!(
+            required.iter().any(|v| v == "root_selectors"),
+            "root_selectors must be required in browser_extract_with_fallback"
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -1595,10 +1595,6 @@ impl McpBrowserServer {
             .ok_or_else(|| BrowserError::ConfigError(format!("Unknown session: {session_id}")))
     }
 
-    /// Extract a single record from `root` using the given `schema`.
-    ///
-    /// Returns `None` if any required field is absent; otherwise returns a
-    /// JSON object with one entry per field.
     // ── browser_extract_with_fallback ─────────────────────────────────────────
 
     /// Extract using the first `root_selectors` entry that yields results.

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -1607,57 +1607,8 @@ impl McpBrowserServer {
             .get("timeout_secs")
             .and_then(serde_json::Value::as_f64)
             .unwrap_or(30.0);
-
-        let selectors: Vec<String> = args
-            .get("root_selectors")
-            .and_then(Value::as_array)
-            .ok_or_else(|| {
-                BrowserError::ConfigError(
-                    "Missing or non-array 'root_selectors' argument".to_string(),
-                )
-            })?
-            .iter()
-            .filter_map(|v| v.as_str().map(str::to_string))
-            .collect();
-
-        if selectors.is_empty() {
-            return Err(BrowserError::ConfigError(
-                "root_selectors must contain at least one entry".to_string(),
-            ));
-        }
-
-        let schema_obj = args
-            .get("schema")
-            .and_then(|v| v.as_object())
-            .ok_or_else(|| {
-                BrowserError::ConfigError("Missing or non-object 'schema' argument".to_string())
-            })?;
-
-        let schema: Vec<(String, ExtractFieldDef)> = schema_obj
-            .iter()
-            .filter_map(|(name, spec)| {
-                let selector = spec
-                    .get("selector")
-                    .and_then(serde_json::Value::as_str)
-                    .map(ToString::to_string)?;
-                let attr = spec
-                    .get("attr")
-                    .and_then(serde_json::Value::as_str)
-                    .map(ToString::to_string);
-                let required = spec
-                    .get("required")
-                    .and_then(serde_json::Value::as_bool)
-                    .unwrap_or(false);
-                Some((
-                    name.clone(),
-                    ExtractFieldDef {
-                        selector,
-                        attr,
-                        required,
-                    },
-                ))
-            })
-            .collect();
+        let selectors = Self::parse_root_selectors(args)?;
+        let schema = Self::parse_extract_schema(args)?;
 
         let session_arc = self.session_handle(&session_id).await?;
         let mut page = session_arc
@@ -1689,13 +1640,20 @@ impl McpBrowserServer {
             if roots.is_empty() {
                 continue;
             }
-            matched_selector = selector.clone();
-            results.reserve(roots.len());
+
+            let mut selector_results: Vec<Value> = Vec::with_capacity(roots.len());
             for root in &roots {
                 if let Some(obj) = Self::extract_record(root, &schema).await {
-                    results.push(Value::Object(obj));
+                    selector_results.push(Value::Object(obj));
                 }
             }
+
+            if selector_results.is_empty() {
+                continue;
+            }
+
+            matched_selector = selector.clone();
+            results = selector_results;
             break;
         }
 
@@ -1722,39 +1680,7 @@ impl McpBrowserServer {
             .get("timeout_secs")
             .and_then(serde_json::Value::as_f64)
             .unwrap_or(30.0);
-
-        let schema_obj = args
-            .get("schema")
-            .and_then(|v| v.as_object())
-            .ok_or_else(|| {
-                BrowserError::ConfigError("Missing or non-object 'schema' argument".to_string())
-            })?;
-
-        let schema: Vec<(String, ExtractFieldDef)> = schema_obj
-            .iter()
-            .filter_map(|(name, spec)| {
-                let selector = spec
-                    .get("selector")
-                    .and_then(serde_json::Value::as_str)
-                    .map(ToString::to_string)?;
-                let attr = spec
-                    .get("attr")
-                    .and_then(serde_json::Value::as_str)
-                    .map(ToString::to_string);
-                let required = spec
-                    .get("required")
-                    .and_then(serde_json::Value::as_bool)
-                    .unwrap_or(false);
-                Some((
-                    name.clone(),
-                    ExtractFieldDef {
-                        selector,
-                        attr,
-                        required,
-                    },
-                ))
-            })
-            .collect();
+        let schema = Self::parse_extract_schema(args)?;
 
         let session_arc = self.session_handle(&session_id).await?;
         let mut page = session_arc
@@ -1841,6 +1767,60 @@ impl McpBrowserServer {
             .and_then(|v| v.as_str())
             .map(ToString::to_string)
             .ok_or_else(|| BrowserError::ConfigError(format!("Missing required argument: {key}")))
+    }
+
+    fn parse_root_selectors(args: &Value) -> Result<Vec<String>> {
+        let selectors: Vec<String> = args
+            .get("root_selectors")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                BrowserError::ConfigError("Missing or non-array 'root_selectors' argument".to_string())
+            })?
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect();
+
+        if selectors.is_empty() {
+            return Err(BrowserError::ConfigError(
+                "root_selectors must contain at least one entry".to_string(),
+            ));
+        }
+        Ok(selectors)
+    }
+
+    fn parse_extract_schema(args: &Value) -> Result<Vec<(String, ExtractFieldDef)>> {
+        let schema_obj = args
+            .get("schema")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                BrowserError::ConfigError("Missing or non-object 'schema' argument".to_string())
+            })?;
+
+        Ok(schema_obj
+            .iter()
+            .filter_map(|(name, spec)| {
+                let selector = spec
+                    .get("selector")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)?;
+                let attr = spec
+                    .get("attr")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string);
+                let required = spec
+                    .get("required")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+                Some((
+                    name.clone(),
+                    ExtractFieldDef {
+                        selector,
+                        attr,
+                        required,
+                    },
+                ))
+            })
+            .collect())
     }
 }
 

--- a/crates/stygian-browser/src/page.rs
+++ b/crates/stygian-browser/src/page.rs
@@ -1449,7 +1449,7 @@ impl PageHandle {
     ///
     /// # Errors
     ///
-    /// Returns [`BrowserError::QuerySelectorFailed`] if the CDP call fails, or
+    /// Returns [`BrowserError::CdpError`] if the selector query fails, or
     /// [`BrowserError::ExtractionFailed`] if a matched node fails extraction.
     ///
     /// # Example
@@ -1504,7 +1504,7 @@ impl PageHandle {
     ///
     /// # Errors
     ///
-    /// Returns [`BrowserError::QuerySelectorFailed`] if the CDP call fails, or
+    /// Returns [`BrowserError::CdpError`] if the selector query fails, or
     /// [`BrowserError::ExtractionFailed`] for non-`Missing` extraction errors.
     ///
     /// # Example

--- a/crates/stygian-browser/src/tls.rs
+++ b/crates/stygian-browser/src/tls.rs
@@ -2566,7 +2566,7 @@ impl ProfileChannel {
     ///
     /// Returns [`ProfileChannelError::UnknownChannel`] if the channel string
     /// cannot be parsed. (This variant is only reachable via
-    /// [`ProfileChannel::from_str`].)
+    /// [`std::str::FromStr::from_str`].)
     ///
     /// # Example
     ///

--- a/crates/stygian-mcp/README.md
+++ b/crates/stygian-mcp/README.md
@@ -34,7 +34,7 @@ Claude, IDE plugins, etc.) to begin calling scraping, browser, and proxy tools.
 | Feature | Description | Default |
 | --------- | ------------- | --------- |
 | Base | Proxy + browser tools | ✓ |
-| `extract` | Enable `browser_extract` and `graph_extract` tools for structured data | — |
+| `extract` | Enable browser structured extraction tools (`browser_extract`, `browser_extract_with_fallback`, `browser_extract_resilient`) | — |
 
 Enable extraction (requires `stygian-browser/extract` and `stygian-graph/extract`):
 
@@ -49,8 +49,8 @@ All tools from the three underlying crates are available under their respective 
 | Prefix | Crate | Example tools |
 | ------ | ----- | ------------- |
 | `graph_*` | `stygian-graph` | `graph_scrape`, `graph_scrape_rest`, `graph_pipeline_run` |
-| `browser_*` | `stygian-browser` | `browser_acquire`, `browser_navigate`, `browser_screenshot` |
-| `proxy_*` | `stygian-proxy` | `proxy_add`, `proxy_acquire`, `proxy_pool_stats` |
+| `browser_*` | `stygian-browser` | `browser_acquire`, `browser_extract_with_fallback`, `browser_extract_resilient` |
+| `proxy_*` | `stygian-proxy` | `proxy_add`, `proxy_acquire_with_capabilities`, `proxy_fetch_freelist`, `proxy_fetch_freeapiproxies` |
 
 The aggregator also adds two cross-crate tools:
 
@@ -81,10 +81,11 @@ The aggregator also adds two cross-crate tools:
 1. Client calls `tools/list` → aggregator merges all three sub-server tool lists
 2. Client calls `tools/call` with a tool name + params
 3. Aggregator routes:
-   - `graph_*` → strips prefix, forwards to graph sub-server
-   - `browser_*` → strips prefix, forwards to browser sub-server
-   - `proxy_*` → strips prefix, forwards to proxy sub-server
-   - `scrape_proxied`, `browser_proxied` → handled by aggregator (cross-crate coordination)
+
+- `graph_*` → strips prefix, forwards to graph sub-server
+- `browser_*` → forwards to browser sub-server
+- `proxy_*` → forwards to proxy sub-server
+- `scrape_proxied`, `browser_proxied` → handled by aggregator (cross-crate coordination)
 
 ## Examples
 
@@ -97,8 +98,7 @@ The aggregator also adds two cross-crate tools:
   "params": {
     "name": "scrape_proxied",
     "arguments": {
-      "url": "https://example.com",
-      "proxy_id": "proxy-1"
+      "url": "https://example.com"
     }
   }
 }
@@ -113,9 +113,7 @@ The aggregator also adds two cross-crate tools:
   "params": {
     "name": "browser_proxied",
     "arguments": {
-      "url": "https://example.com",
-      "stealth_level": "advanced",
-      "action": "screenshot"
+      "url": "https://example.com"
     }
   }
 }
@@ -132,10 +130,13 @@ With `extract` feature enabled, use `browser_extract`:
   "params": {
     "name": "browser_extract",
     "arguments": {
+      "session_id": "01HV4...",
       "url": "https://example.com/products",
-      "selector": "a.product-link",
-      "extract_format": "json",
-      "stealth_level": "advanced"
+      "root_selector": "article.product",
+      "schema": {
+        "name": { "selector": "h2" },
+        "href": { "selector": "a", "attr": "href" }
+      }
     }
   }
 }

--- a/crates/stygian-proxy/src/mcp.rs
+++ b/crates/stygian-proxy/src/mcp.rs
@@ -49,7 +49,8 @@ use uuid::Uuid;
 
 use crate::{
     MemoryProxyStore, PoolStats, ProxyHandle, ProxyManager,
-    types::{Proxy, ProxyConfig, ProxyType},
+    fetcher::{FreeApiProxiesFetcher, FreeListFetcher, FreeListSource, load_from_fetcher},
+    types::{CapabilityRequirement, Proxy, ProxyConfig, ProxyType},
 };
 
 // ─── Error response helpers ───────────────────────────────────────────────────
@@ -343,6 +344,53 @@ impl McpProxyServer {
                             },
                             "required": ["handle_token"]
                         }
+                    },
+                    {
+                        "name": "proxy_acquire_with_capabilities",
+                        "description": "Lease one proxy from the pool that satisfies all specified capability requirements. Returns handle_token and proxy_url. Call proxy_release when done.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "require_https_connect": { "type": "boolean", "description": "Require the proxy to support HTTPS CONNECT tunnelling (default: false)" },
+                                "require_socks5_udp":    { "type": "boolean", "description": "Require SOCKS5 UDP relay support (default: false)" },
+                                "require_http3_tunnel":  { "type": "boolean", "description": "Require HTTP/3 QUIC tunnel support (default: false)" },
+                                "require_geo_country":   { "type": "string",  "description": "ISO-3166-1 alpha-2 country code the egress IP must match (e.g. \"US\")" }
+                            }
+                        }
+                    },
+                    {
+                        "name": "proxy_fetch_freelist",
+                        "description": "Fetch proxies from one or more well-known free proxy list feeds (plain host:port format) and add them to the pool. Returns the number of proxies loaded.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "sources": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                        "enum": ["the_speedx_http", "the_speedx_socks4", "the_speedx_socks5", "clarketm_http", "open_proxy_list_http"]
+                                    },
+                                    "description": "List of feed names to fetch. the_speedx_socks4/socks5 require the 'socks' feature.",
+                                    "minItems": 1
+                                },
+                                "tags": { "type": "array", "items": { "type": "string" }, "description": "Extra tags attached to every loaded proxy" }
+                            },
+                            "required": ["sources"]
+                        }
+                    },
+                    {
+                        "name": "proxy_fetch_freeapiproxies",
+                        "description": "Fetch proxies from a FreeAPIProxies-compatible JSON endpoint and add them to the pool. Returns the number of proxies loaded.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "limit":    { "type": "integer", "description": "Maximum number of proxies to request (default: API default)" },
+                                "protocol": { "type": "string",  "description": "Protocol filter (e.g. \"http\", \"socks5\")" },
+                                "country":  { "type": "string",  "description": "ISO-3166-1 alpha-2 country filter (e.g. \"US\")" },
+                                "endpoint": { "type": "string",  "description": "Custom API endpoint URL (defaults to the public FreeAPIProxies endpoint)" },
+                                "tags":     { "type": "array", "items": { "type": "string" }, "description": "Extra tags attached to every loaded proxy" }
+                            }
+                        }
                     }
                 ]
             }),
@@ -361,7 +409,11 @@ impl McpProxyServer {
             "proxy_acquire" => self.tool_proxy_acquire(id).await,
             "proxy_acquire_for_domain" => self.tool_proxy_acquire_for_domain(id, args).await,
             "proxy_release" => self.tool_proxy_release(id, args).await,
+            "proxy_acquire_with_capabilities" => self.tool_proxy_acquire_with_capabilities(id, args).await,
+            "proxy_fetch_freelist" => self.tool_proxy_fetch_freelist(id, args).await,
+            "proxy_fetch_freeapiproxies" => self.tool_proxy_fetch_freeapiproxies(id, args).await,
             _ => error_response(id, -32602, &format!("Unknown tool: {name}")),
+
         }
     }
 
@@ -642,6 +694,145 @@ impl McpProxyServer {
             }),
         )
     }
+
+    // ── proxy_acquire_with_capabilities ──────────────────────────────────────
+
+    /// Lease a proxy that satisfies all capability requirements in `args`.
+    ///
+    /// Accepts the same JSON structure as [`CapabilityRequirement`] —
+    /// `require_https_connect`, `require_socks5_udp`, `require_http3_tunnel`,
+    /// `require_geo_country`.  All fields are optional; an empty call is
+    /// equivalent to plain `proxy_acquire`.
+    async fn tool_proxy_acquire_with_capabilities(&self, id: &Value, args: &Value) -> Value {
+        let req = CapabilityRequirement {
+            require_https_connect: args
+                .get("require_https_connect")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            require_socks5_udp: args
+                .get("require_socks5_udp")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            require_http3_tunnel: args
+                .get("require_http3_tunnel")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            require_geo_country: args
+                .get("require_geo_country")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+        };
+
+        match self.manager.acquire_with_capabilities(&req).await {
+            Ok(handle) => {
+                let proxy_url = handle.proxy_url.clone();
+                let token = Ulid::new().to_string();
+                self.handles.lock().await.insert(token.clone(), handle);
+                ok_response(
+                    id,
+                    json!({
+                        "content": [{
+                            "type": "text",
+                            "text": serde_json::to_string(&json!({
+                                "handle_token": token,
+                                "proxy_url":    proxy_url
+                            })).unwrap_or_default()
+                        }]
+                    }),
+                )
+            }
+            Err(e) => error_response(id, -32603, &format!("Acquire with capabilities failed: {e}")),
+        }
+    }
+
+    // ── proxy_fetch_freelist ──────────────────────────────────────────────────
+
+    /// Fetch proxies from well-known free list feeds and populate the pool.
+    async fn tool_proxy_fetch_freelist(&self, id: &Value, args: &Value) -> Value {
+        let Some(sources_arr) = args.get("sources").and_then(Value::as_array) else {
+            return error_response(id, -32602, "Missing required parameter: sources");
+        };
+
+        if sources_arr.is_empty() {
+            return error_response(id, -32602, "sources must contain at least one entry");
+        }
+
+        let mut sources: Vec<FreeListSource> = Vec::new();
+        for src in sources_arr {
+            let name = src.as_str().unwrap_or("");
+            match name {
+                "the_speedx_http" => sources.push(FreeListSource::TheSpeedXHttp),
+                #[cfg(feature = "socks")]
+                "the_speedx_socks4" => sources.push(FreeListSource::TheSpeedXSocks4),
+                #[cfg(feature = "socks")]
+                "the_speedx_socks5" => sources.push(FreeListSource::TheSpeedXSocks5),
+                "clarketm_http" => sources.push(FreeListSource::ClarketmHttp),
+                "open_proxy_list_http" => sources.push(FreeListSource::OpenProxyListHttp),
+                other => {
+                    return error_response(
+                        id,
+                        -32602,
+                        &format!("Unknown source: {other}. Valid values: the_speedx_http, the_speedx_socks4, the_speedx_socks5, clarketm_http, open_proxy_list_http"),
+                    );
+                }
+            }
+        }
+
+        let mut fetcher = FreeListFetcher::new(sources);
+        if let Some(tags) = args.get("tags").and_then(Value::as_array) {
+            let tag_vec: Vec<String> = tags
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect();
+            fetcher = fetcher.with_tags(tag_vec);
+        }
+
+        match load_from_fetcher(&self.manager, &fetcher).await {
+            Ok(count) => ok_response(
+                id,
+                json!({
+                    "content": [{
+                        "type": "text",
+                        "text": serde_json::to_string(&json!({ "loaded": count })).unwrap_or_default()
+                    }]
+                }),
+            ),
+            Err(e) => error_response(id, -32603, &format!("Fetch failed: {e}")),
+        }
+    }
+
+    // ── proxy_fetch_freeapiproxies ────────────────────────────────────────────
+
+    /// Fetch proxies from a FreeAPIProxies-compatible JSON API and populate the pool.
+    async fn tool_proxy_fetch_freeapiproxies(&self, id: &Value, args: &Value) -> Value {
+        let mut fetcher = if let Some(endpoint) = args.get("endpoint").and_then(Value::as_str) {
+            FreeApiProxiesFetcher::with_endpoint(endpoint)
+        } else {
+            FreeApiProxiesFetcher::new()
+        };
+        if let Some(tags) = args.get("tags").and_then(Value::as_array) {
+            let tag_vec: Vec<String> = tags
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect();
+            fetcher = fetcher.with_tags(tag_vec);
+        }
+
+        match load_from_fetcher(&self.manager, &fetcher).await {
+            Ok(count) => ok_response(
+                id,
+                json!({
+                    "content": [{
+                        "type": "text",
+                        "text": serde_json::to_string(&json!({ "loaded": count })).unwrap_or_default()
+                    }]
+                }),
+            ),
+            Err(e) => error_response(id, -32603, &format!("Fetch failed: {e}")),
+        }
+    }
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -711,6 +902,9 @@ mod tests {
         assert!(names.contains(&"proxy_acquire"));
         assert!(names.contains(&"proxy_acquire_for_domain"));
         assert!(names.contains(&"proxy_release"));
+        assert!(names.contains(&"proxy_acquire_with_capabilities"));
+        assert!(names.contains(&"proxy_fetch_freelist"));
+        assert!(names.contains(&"proxy_fetch_freeapiproxies"));
         let _ = server;
         Ok(())
     }
@@ -756,6 +950,99 @@ mod tests {
         assert!(
             resp.get("error").is_some_and(Value::is_object),
             "empty pool should return error"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn acquire_with_capabilities_on_empty_pool_returns_error()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let server = McpProxyServer::new()?;
+        let id = json!(1);
+        let resp = server
+            .tool_proxy_acquire_with_capabilities(&id, &json!({}))
+            .await;
+        assert!(
+            resp.get("error").is_some_and(Value::is_object),
+            "empty pool should return error for capability-aware acquire"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proxy_fetch_freelist_missing_sources_returns_error()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let server = McpProxyServer::new()?;
+        let id = json!(1);
+        let resp = server
+            .tool_proxy_fetch_freelist(&id, &json!({}))
+            .await;
+        assert!(
+            resp.get("error").is_some_and(Value::is_object),
+            "missing sources should return error"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proxy_fetch_freelist_empty_sources_returns_error()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let server = McpProxyServer::new()?;
+        let id = json!(1);
+        let resp = server
+            .tool_proxy_fetch_freelist(&id, &json!({ "sources": [] }))
+            .await;
+        assert!(
+            resp.get("error").is_some_and(Value::is_object),
+            "empty sources array should return error"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proxy_fetch_freelist_unknown_source_returns_error()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let server = McpProxyServer::new()?;
+        let id = json!(1);
+        let resp = server
+            .tool_proxy_fetch_freelist(
+                &id,
+                &json!({ "sources": ["not_a_real_source"] }),
+            )
+            .await;
+        assert!(
+            resp.get("error").is_some_and(Value::is_object),
+            "unknown source name should return error"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn proxy_fetch_freeapiproxies_accepts_limit_and_protocol()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // This test does not make a real HTTP call; it only checks that building
+        // the tool returns an error from the (unreachable) test endpoint rather
+        // than a parse/config error.
+        let server = McpProxyServer::new()?;
+        let id = json!(1);
+        // Use a local non-routable address so the fetch fails fast without
+        // waiting on a real network timeout.
+        let resp = server
+            .tool_proxy_fetch_freeapiproxies(
+                &id,
+                &json!({
+                    "endpoint": "http://127.0.0.1:1",
+                    "limit": 50,
+                    "protocol": "http"
+                }),
+            )
+            .await;
+        // Fetch must either succeed (unlikely in CI) or return an error —
+        // the important thing is that it does not panic.
+        assert!(
+            resp.get("error").is_some_and(Value::is_object)
+                || resp.get("result").is_some_and(Value::is_object),
+            "fetch_freeapiproxies should return either an error or result"
         );
         Ok(())
     }

--- a/crates/stygian-proxy/src/mcp.rs
+++ b/crates/stygian-proxy/src/mcp.rs
@@ -409,11 +409,12 @@ impl McpProxyServer {
             "proxy_acquire" => self.tool_proxy_acquire(id).await,
             "proxy_acquire_for_domain" => self.tool_proxy_acquire_for_domain(id, args).await,
             "proxy_release" => self.tool_proxy_release(id, args).await,
-            "proxy_acquire_with_capabilities" => self.tool_proxy_acquire_with_capabilities(id, args).await,
+            "proxy_acquire_with_capabilities" => {
+                self.tool_proxy_acquire_with_capabilities(id, args).await
+            }
             "proxy_fetch_freelist" => self.tool_proxy_fetch_freelist(id, args).await,
             "proxy_fetch_freeapiproxies" => self.tool_proxy_fetch_freeapiproxies(id, args).await,
             _ => error_response(id, -32602, &format!("Unknown tool: {name}")),
-
         }
     }
 
@@ -741,7 +742,11 @@ impl McpProxyServer {
                     }),
                 )
             }
-            Err(e) => error_response(id, -32603, &format!("Acquire with capabilities failed: {e}")),
+            Err(e) => error_response(
+                id,
+                -32603,
+                &format!("Acquire with capabilities failed: {e}"),
+            ),
         }
     }
 
@@ -772,7 +777,9 @@ impl McpProxyServer {
                     return error_response(
                         id,
                         -32602,
-                        &format!("Unknown source: {other}. Valid values: the_speedx_http, the_speedx_socks4, the_speedx_socks5, clarketm_http, open_proxy_list_http"),
+                        &format!(
+                            "Unknown source: {other}. Valid values: the_speedx_http, the_speedx_socks4, the_speedx_socks5, clarketm_http, open_proxy_list_http"
+                        ),
                     );
                 }
             }
@@ -974,9 +981,7 @@ mod tests {
     -> std::result::Result<(), Box<dyn std::error::Error>> {
         let server = McpProxyServer::new()?;
         let id = json!(1);
-        let resp = server
-            .tool_proxy_fetch_freelist(&id, &json!({}))
-            .await;
+        let resp = server.tool_proxy_fetch_freelist(&id, &json!({})).await;
         assert!(
             resp.get("error").is_some_and(Value::is_object),
             "missing sources should return error"
@@ -1005,10 +1010,7 @@ mod tests {
         let server = McpProxyServer::new()?;
         let id = json!(1);
         let resp = server
-            .tool_proxy_fetch_freelist(
-                &id,
-                &json!({ "sources": ["not_a_real_source"] }),
-            )
+            .tool_proxy_fetch_freelist(&id, &json!({ "sources": ["not_a_real_source"] }))
             .await;
         assert!(
             resp.get("error").is_some_and(Value::is_object),

--- a/crates/stygian-proxy/src/mcp.rs
+++ b/crates/stygian-proxy/src/mcp.rs
@@ -34,6 +34,9 @@
 //! | `proxy_acquire` | – | `handle_token`, `proxy_url` |
 //! | `proxy_acquire_for_domain` | `domain` | `handle_token`, `proxy_url` |
 //! | `proxy_release` | `handle_token`, `success?` | success |
+//! | `proxy_acquire_with_capabilities` | `require_https_connect?`, `require_socks5_udp?`, `require_http3_tunnel?`, `require_geo_country?` | `handle_token`, `proxy_url` |
+//! | `proxy_fetch_freelist` | `sources`, `tags?` | `loaded` |
+//! | `proxy_fetch_freeapiproxies` | `endpoint?`, `tags?` | `loaded` |
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/crates/stygian-proxy/src/mcp.rs
+++ b/crates/stygian-proxy/src/mcp.rs
@@ -275,126 +275,161 @@ impl McpProxyServer {
     }
 
     fn handle_tools_list(id: &Value) -> Value {
-        ok_response(
-            id,
-            json!({
-                "tools": [
-                    {
-                        "name": "proxy_add",
-                        "description": "Add a proxy to the pool. Returns a stable UUID that identifies the proxy for future removal.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "url":        { "type": "string", "description": "Proxy URL (e.g. http://host:port, socks5://user:pass@host:port)" },
-                                "proxy_type": { "type": "string", "description": "Protocol: http | https | socks4 | socks5 (default: inferred from URL scheme, falling back to http)" },
-                                "username":   { "type": "string", "description": "Optional proxy username" },
-                                "password":   { "type": "string", "description": "Optional proxy password" },
-                                "weight":     { "type": "integer", "description": "Relative selection weight for weighted rotation (default: 1)" },
-                                "tags":       { "type": "array", "items": { "type": "string" }, "description": "Optional user-defined tags" }
-                            },
-                            "required": ["url"]
-                        }
+        ok_response(id, json!({ "tools": Self::tool_definitions() }))
+    }
+
+    fn tool_definitions() -> Vec<Value> {
+        vec![
+            Self::tool_def_proxy_add(),
+            Self::tool_def_proxy_remove(),
+            Self::tool_def_proxy_pool_stats(),
+            Self::tool_def_proxy_acquire(),
+            Self::tool_def_proxy_acquire_for_domain(),
+            Self::tool_def_proxy_release(),
+            Self::tool_def_proxy_acquire_with_capabilities(),
+            Self::tool_def_proxy_fetch_freelist(),
+            Self::tool_def_proxy_fetch_freeapiproxies(),
+        ]
+    }
+
+    fn tool_def_proxy_add() -> Value {
+        json!({
+            "name": "proxy_add",
+            "description": "Add a proxy to the pool. Returns a stable UUID that identifies the proxy for future removal.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "url":        { "type": "string", "description": "Proxy URL (e.g. http://host:port, socks5://user:pass@host:port)" },
+                    "proxy_type": { "type": "string", "description": "Protocol: http | https | socks4 | socks5 (default: inferred from URL scheme, falling back to http)" },
+                    "username":   { "type": "string", "description": "Optional proxy username" },
+                    "password":   { "type": "string", "description": "Optional proxy password" },
+                    "weight":     { "type": "integer", "description": "Relative selection weight for weighted rotation (default: 1)" },
+                    "tags":       { "type": "array", "items": { "type": "string" }, "description": "Optional user-defined tags" }
+                },
+                "required": ["url"]
+            }
+        })
+    }
+
+    fn tool_def_proxy_remove() -> Value {
+        json!({
+            "name": "proxy_remove",
+            "description": "Remove a proxy from the pool by its UUID.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "proxy_id": { "type": "string", "description": "UUID of the proxy to remove (returned by proxy_add)" }
+                },
+                "required": ["proxy_id"]
+            }
+        })
+    }
+
+    fn tool_def_proxy_pool_stats() -> Value {
+        json!({
+            "name": "proxy_pool_stats",
+            "description": "Return a health snapshot of the proxy pool: total count, healthy count, open circuit-breaker count, and active sticky-session count.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            }
+        })
+    }
+
+    fn tool_def_proxy_acquire() -> Value {
+        json!({
+            "name": "proxy_acquire",
+            "description": "Lease one proxy from the pool using the configured rotation strategy. Returns a handle_token (opaque string) and the proxy URL. Call proxy_release when done.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            }
+        })
+    }
+
+    fn tool_def_proxy_acquire_for_domain() -> Value {
+        json!({
+            "name": "proxy_acquire_for_domain",
+            "description": "Lease a proxy for a specific domain, honouring sticky-session policy. The same proxy is returned for repeated calls with the same domain during the TTL. Returns handle_token and proxy_url.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "domain": { "type": "string", "description": "Target domain (e.g. example.com)" }
+                },
+                "required": ["domain"]
+            }
+        })
+    }
+
+    fn tool_def_proxy_release() -> Value {
+        json!({
+            "name": "proxy_release",
+            "description": "Release a previously acquired proxy handle. Pass success=true if the request succeeded (updates circuit-breaker health), false to mark failure.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "handle_token": { "type": "string", "description": "Token returned by proxy_acquire or proxy_acquire_for_domain" },
+                    "success":      { "type": "boolean", "description": "Whether the request using this proxy succeeded (default: true)" }
+                },
+                "required": ["handle_token"]
+            }
+        })
+    }
+
+    fn tool_def_proxy_acquire_with_capabilities() -> Value {
+        json!({
+            "name": "proxy_acquire_with_capabilities",
+            "description": "Lease one proxy from the pool that satisfies all specified capability requirements. Returns handle_token and proxy_url. Call proxy_release when done.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "require_https_connect": { "type": "boolean", "description": "Require the proxy to support HTTPS CONNECT tunnelling (default: false)" },
+                    "require_socks5_udp":    { "type": "boolean", "description": "Require SOCKS5 UDP relay support (default: false)" },
+                    "require_http3_tunnel":  { "type": "boolean", "description": "Require HTTP/3 QUIC tunnel support (default: false)" },
+                    "require_geo_country":   { "type": "string",  "description": "ISO-3166-1 alpha-2 country code the egress IP must match (e.g. \"US\")" }
+                }
+            }
+        })
+    }
+
+    fn tool_def_proxy_fetch_freelist() -> Value {
+        json!({
+            "name": "proxy_fetch_freelist",
+            "description": "Fetch proxies from one or more well-known free proxy list feeds (plain host:port format) and add them to the pool. Returns the number of proxies loaded.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "sources": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": ["the_speedx_http", "the_speedx_socks4", "the_speedx_socks5", "clarketm_http", "open_proxy_list_http"]
+                        },
+                        "description": "List of feed names to fetch. the_speedx_socks4/socks5 require the 'socks' feature.",
+                        "minItems": 1
                     },
-                    {
-                        "name": "proxy_remove",
-                        "description": "Remove a proxy from the pool by its UUID.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "proxy_id": { "type": "string", "description": "UUID of the proxy to remove (returned by proxy_add)" }
-                            },
-                            "required": ["proxy_id"]
-                        }
-                    },
-                    {
-                        "name": "proxy_pool_stats",
-                        "description": "Return a health snapshot of the proxy pool: total count, healthy count, open circuit-breaker count, and active sticky-session count.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {}
-                        }
-                    },
-                    {
-                        "name": "proxy_acquire",
-                        "description": "Lease one proxy from the pool using the configured rotation strategy. Returns a handle_token (opaque string) and the proxy URL. Call proxy_release when done.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {}
-                        }
-                    },
-                    {
-                        "name": "proxy_acquire_for_domain",
-                        "description": "Lease a proxy for a specific domain, honouring sticky-session policy. The same proxy is returned for repeated calls with the same domain during the TTL. Returns handle_token and proxy_url.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "domain": { "type": "string", "description": "Target domain (e.g. example.com)" }
-                            },
-                            "required": ["domain"]
-                        }
-                    },
-                    {
-                        "name": "proxy_release",
-                        "description": "Release a previously acquired proxy handle. Pass success=true if the request succeeded (updates circuit-breaker health), false to mark failure.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "handle_token": { "type": "string", "description": "Token returned by proxy_acquire or proxy_acquire_for_domain" },
-                                "success":      { "type": "boolean", "description": "Whether the request using this proxy succeeded (default: true)" }
-                            },
-                            "required": ["handle_token"]
-                        }
-                    },
-                    {
-                        "name": "proxy_acquire_with_capabilities",
-                        "description": "Lease one proxy from the pool that satisfies all specified capability requirements. Returns handle_token and proxy_url. Call proxy_release when done.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "require_https_connect": { "type": "boolean", "description": "Require the proxy to support HTTPS CONNECT tunnelling (default: false)" },
-                                "require_socks5_udp":    { "type": "boolean", "description": "Require SOCKS5 UDP relay support (default: false)" },
-                                "require_http3_tunnel":  { "type": "boolean", "description": "Require HTTP/3 QUIC tunnel support (default: false)" },
-                                "require_geo_country":   { "type": "string",  "description": "ISO-3166-1 alpha-2 country code the egress IP must match (e.g. \"US\")" }
-                            }
-                        }
-                    },
-                    {
-                        "name": "proxy_fetch_freelist",
-                        "description": "Fetch proxies from one or more well-known free proxy list feeds (plain host:port format) and add them to the pool. Returns the number of proxies loaded.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "sources": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string",
-                                        "enum": ["the_speedx_http", "the_speedx_socks4", "the_speedx_socks5", "clarketm_http", "open_proxy_list_http"]
-                                    },
-                                    "description": "List of feed names to fetch. the_speedx_socks4/socks5 require the 'socks' feature.",
-                                    "minItems": 1
-                                },
-                                "tags": { "type": "array", "items": { "type": "string" }, "description": "Extra tags attached to every loaded proxy" }
-                            },
-                            "required": ["sources"]
-                        }
-                    },
-                    {
-                        "name": "proxy_fetch_freeapiproxies",
-                        "description": "Fetch proxies from a FreeAPIProxies-compatible JSON endpoint and add them to the pool. Returns the number of proxies loaded.",
-                        "inputSchema": {
-                            "type": "object",
-                            "properties": {
-                                "limit":    { "type": "integer", "description": "Maximum number of proxies to request (default: API default)" },
-                                "protocol": { "type": "string",  "description": "Protocol filter (e.g. \"http\", \"socks5\")" },
-                                "country":  { "type": "string",  "description": "ISO-3166-1 alpha-2 country filter (e.g. \"US\")" },
-                                "endpoint": { "type": "string",  "description": "Custom API endpoint URL (defaults to the public FreeAPIProxies endpoint)" },
-                                "tags":     { "type": "array", "items": { "type": "string" }, "description": "Extra tags attached to every loaded proxy" }
-                            }
-                        }
-                    }
-                ]
-            }),
-        )
+                    "tags": { "type": "array", "items": { "type": "string" }, "description": "Extra tags attached to every loaded proxy" }
+                },
+                "required": ["sources"]
+            }
+        })
+    }
+
+    fn tool_def_proxy_fetch_freeapiproxies() -> Value {
+        json!({
+            "name": "proxy_fetch_freeapiproxies",
+            "description": "Fetch proxies from a FreeAPIProxies-compatible JSON endpoint and add them to the pool. Returns the number of proxies loaded.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit":    { "type": "integer", "description": "Maximum number of proxies to request (default: API default)" },
+                    "protocol": { "type": "string",  "description": "Protocol filter (e.g. \"http\", \"socks5\")" },
+                    "country":  { "type": "string",  "description": "ISO-3166-1 alpha-2 country filter (e.g. \"US\")" },
+                    "endpoint": { "type": "string",  "description": "Custom API endpoint URL (defaults to the public FreeAPIProxies endpoint)" },
+                    "tags":     { "type": "array", "items": { "type": "string" }, "description": "Extra tags attached to every loaded proxy" }
+                }
+            }
+        })
     }
 
     async fn handle_tools_call(&self, id: &Value, req: &Value) -> Value {
@@ -813,11 +848,10 @@ impl McpProxyServer {
 
     /// Fetch proxies from a FreeAPIProxies-compatible JSON API and populate the pool.
     async fn tool_proxy_fetch_freeapiproxies(&self, id: &Value, args: &Value) -> Value {
-        let mut fetcher = if let Some(endpoint) = args.get("endpoint").and_then(Value::as_str) {
-            FreeApiProxiesFetcher::with_endpoint(endpoint)
-        } else {
-            FreeApiProxiesFetcher::new()
-        };
+        let mut fetcher = args.get("endpoint").and_then(Value::as_str).map_or_else(
+            FreeApiProxiesFetcher::new,
+            FreeApiProxiesFetcher::with_endpoint,
+        );
         if let Some(tags) = args.get("tags").and_then(Value::as_array) {
             let tag_vec: Vec<String> = tags
                 .iter()

--- a/crates/stygian-proxy/src/mcp.rs
+++ b/crates/stygian-proxy/src/mcp.rs
@@ -396,6 +396,11 @@ impl McpProxyServer {
     }
 
     fn tool_def_proxy_fetch_freelist() -> Value {
+        let description = if cfg!(feature = "socks") {
+            "List of feed names to fetch."
+        } else {
+            "List of feed names to fetch. SOCKS feeds are available only when built with the 'socks' feature."
+        };
         json!({
             "name": "proxy_fetch_freelist",
             "description": "Fetch proxies from one or more well-known free proxy list feeds (plain host:port format) and add them to the pool. Returns the number of proxies loaded.",
@@ -406,9 +411,9 @@ impl McpProxyServer {
                         "type": "array",
                         "items": {
                             "type": "string",
-                            "enum": ["the_speedx_http", "the_speedx_socks4", "the_speedx_socks5", "clarketm_http", "open_proxy_list_http"]
+                            "enum": Self::freelist_source_enum_values()
                         },
-                        "description": "List of feed names to fetch. the_speedx_socks4/socks5 require the 'socks' feature.",
+                        "description": description,
                         "minItems": 1
                     },
                     "tags": { "type": "array", "items": { "type": "string" }, "description": "Extra tags attached to every loaded proxy" }
@@ -416,6 +421,24 @@ impl McpProxyServer {
                 "required": ["sources"]
             }
         })
+    }
+
+    fn freelist_source_enum_values() -> Vec<&'static str> {
+        #[cfg(feature = "socks")]
+        {
+            vec![
+                "the_speedx_http",
+                "the_speedx_socks4",
+                "the_speedx_socks5",
+                "clarketm_http",
+                "open_proxy_list_http",
+            ]
+        }
+
+        #[cfg(not(feature = "socks"))]
+        {
+            vec!["the_speedx_http", "clarketm_http", "open_proxy_list_http"]
+        }
     }
 
     fn tool_def_proxy_fetch_freeapiproxies() -> Value {


### PR DESCRIPTION
## Summary
- add `proxy_acquire_with_capabilities` MCP tool for capability-aware proxy leasing
- add `proxy_fetch_freelist` and `proxy_fetch_freeapiproxies` MCP tools for pool bootstrap from public feeds
- add `browser_extract_with_fallback` and `browser_extract_resilient` MCP tools for robust extraction behavior
- add/expand tests covering new MCP tool definitions and behavior
- include follow-up validation and lint cleanup

## Validation
- cargo test --workspace --all-features --lib
- cargo clippy --workspace --all-targets -- -D warnings

## Notes
- local uncommitted workspace edits are intentionally not included in this PR.
