### PR TITLE
feat(browser): add polymorphic behavior adapter and stygian-charon crate

### DIFF
--- a/.github/workflows/stealth-canary.yml
+++ b/.github/workflows/stealth-canary.yml
@@ -82,22 +82,25 @@ jobs:
           DATE="$(date -u +%Y-%m-%d)"
           TITLE="Stealth regression detected ${DATE}"
           RUN_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          ISSUE_BODY_FILE="/tmp/stealth-regression-issue.md"
 
           FAILED_CHECKS="$(jq -r '.failed_checks[]?' probe-report.json 2>/dev/null | head -20 | sed 's/^/- /' || echo "_(see uploaded probe report)_")"
 
-          BODY="## Stealth regression detected
+          cat > "${ISSUE_BODY_FILE}" <<EOF
+          ## Stealth regression detected
 
-**Date**: ${DATE}
+          **Date**: ${DATE}
 
-The daily stealth canary detected failing checks against \`about:blank\`.
+          The daily stealth canary detected failing checks against \`about:blank\`.
 
-### Failed checks
-${FAILED_CHECKS}
+          ### Failed checks
+          ${FAILED_CHECKS}
 
-### Details
-Run: ${RUN_URL}
+          ### Details
+          Run: ${RUN_URL}
 
-Download the \`probe-report\` artifact from the run above for the full JSON report and stderr output."
+          Download the \`probe-report\` artifact from the run above for the full JSON report and stderr output.
+          EOF
 
           EXISTING=$(gh issue list \
             --state open \
@@ -110,6 +113,6 @@ Download the \`probe-report\` artifact from the run above for the full JSON repo
               --body "Another regression detected on ${DATE}. Run: ${RUN_URL}"
             echo "Commented on existing issue #${EXISTING}"
           else
-            gh issue create --title "${TITLE}" --body "${BODY}"
+            gh issue create --title "${TITLE}" --body-file "${ISSUE_BODY_FILE}"
           fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,8 @@ Temporary Items
 *.swo
 *~
 
+
+*.har
 tasks/
 .vscode/
 

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ PROGRESS-*.md
 docs/spider-gap-analysis.md
 .papertowelignore
 reference_projects/
+stygian-technical-assessment.md
+docs/stygian-local-refactor-plan.md
+docs/technical-assessment.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4193,6 +4193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "stygian-charon"
+version = "0.9.6"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "stygian-extract-derive"
 version = "0.9.6"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/stygian-extract-derive",
     "crates/stygian-proxy",
     "crates/stygian-mcp",
+    "crates/stygian-charon",
 ]
 
 [workspace.package]

--- a/crates/stygian-browser/README.md
+++ b/crates/stygian-browser/README.md
@@ -346,6 +346,138 @@ any IP addresses from leaking via WebRTC peer connections.
 
 ---
 
+## MCP Behavior Policy Usage
+
+When compiled with the `mcp` feature, you can apply structured anti-bot behavior
+plans at runtime using `browser_apply_behavior_json`.
+
+Accepted `behavior` shapes:
+
+- `RuntimePolicy` object (direct policy payload)
+- `InvestigationBundle` object (uses nested `policy`)
+- `Direct override` object (for simple `headless` / `stealth_level` tuning)
+
+Example: `RuntimePolicy` payload
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {
+        "name": "browser_apply_behavior_json",
+        "arguments": {
+            "behavior": {
+                "execution_mode": "Browser",
+                "session_mode": "Sticky",
+                "telemetry_level": "Deep",
+                "rate_limit_rps": 0.8,
+                "max_retries": 4,
+                "backoff_base_ms": 1200,
+                "enable_warmup": true,
+                "enforce_webrtc_proxy_only": true,
+                "sticky_session_ttl_secs": 1800,
+                "required_stygian_features": ["browser", "stealth"],
+                "config_hints": {
+                    "proxy_url": "http://127.0.0.1:8080",
+                    "viewport_width": "1366",
+                    "viewport_height": "768"
+                },
+                "risk_score": 0.92
+            }
+        }
+    }
+}
+```
+
+Example: `InvestigationBundle` payload
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/call",
+    "params": {
+        "name": "browser_apply_behavior_json",
+        "arguments": {
+            "behavior": {
+                "report": {
+                    "page_title": "example",
+                    "total_requests": 42,
+                    "blocked_requests": 4,
+                    "status_histogram": {"200": 38, "403": 4},
+                    "resource_type_histogram": {"document": 1, "script": 12},
+                    "provider_histogram": {"Cloudflare": 4},
+                    "top_markers": [],
+                    "hosts": [],
+                    "suspicious_requests": [],
+                    "aggregate": {
+                        "provider": "Cloudflare",
+                        "confidence": 0.87,
+                        "markers": ["turnstile"]
+                    }
+                },
+                "requirements": {
+                    "provider": "Cloudflare",
+                    "confidence": 0.87,
+                    "requirements": [],
+                    "recommendation": {
+                        "strategy": "StickyProxy",
+                        "rationale": "bot challenge observed",
+                        "required_stygian_features": ["browser", "stealth"],
+                        "config_hints": {"proxy_url": "http://127.0.0.1:8080"}
+                    }
+                },
+                "policy": {
+                    "execution_mode": "Browser",
+                    "session_mode": "Sticky",
+                    "telemetry_level": "Standard",
+                    "rate_limit_rps": 1.0,
+                    "max_retries": 3,
+                    "backoff_base_ms": 800,
+                    "enable_warmup": true,
+                    "enforce_webrtc_proxy_only": true,
+                    "sticky_session_ttl_secs": 1200,
+                    "required_stygian_features": ["browser", "stealth"],
+                    "config_hints": {"proxy_url": "http://127.0.0.1:8080"},
+                    "risk_score": 0.78
+                }
+            }
+        }
+    }
+}
+```
+
+Bind behavior to an active session by also passing `session_id`:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+        "name": "browser_apply_behavior_json",
+        "arguments": {
+            "session_id": "01JXYZ...",
+            "behavior": {
+                "headless": false,
+                "stealth_level": "basic",
+                "interaction_level": "medium"
+            }
+        }
+    }
+}
+```
+
+Response includes:
+
+- `adapter_kind` (`RuntimePolicy`, `InvestigationBundle`, or `DirectOverrides`)
+- `plan` (normalized behavior plan)
+- `effective_config` (resolved browser config view)
+- `session_updated` flag
+
+---
+
 ## FAQ
 
 **Q: Does this work on macOS / Linux / Windows?**  

--- a/crates/stygian-browser/README.md
+++ b/crates/stygian-browser/README.md
@@ -472,6 +472,7 @@ Bind behavior to an active session by also passing `session_id`:
 Response includes:
 
 - `adapter_kind` (`RuntimePolicy`, `InvestigationBundle`, or `DirectOverrides`)
+- `adapter_kind` (`runtime_policy`, `investigation_bundle`, or `direct_overrides`)
 - `plan` (normalized behavior plan)
 - `effective_config` (resolved browser config view)
 - `session_updated` flag

--- a/crates/stygian-browser/examples/g2_reviews.rs
+++ b/crates/stygian-browser/examples/g2_reviews.rs
@@ -1,0 +1,334 @@
+//! Example: Extract G2 reviews from the hydrated DOM
+//!
+//! This example uses the browser workflow rather than a direct HTTP fetch.
+//! It navigates to a G2 review page, waits for the Turbo Frame review section
+//! to hydrate, expands visible "Show More" panels, performs a few bounded
+//! scroll passes, and emits structured JSON for the currently loaded review
+//! page.
+//!
+//! ```sh
+//! cargo run --example g2_reviews -p stygian-browser
+//! cargo run --example g2_reviews -p stygian-browser -- https://www.g2.com/products/jira/reviews?page=2
+//! cargo run --example g2_reviews -p stygian-browser -- https://www.g2.com/products/jira/reviews | jq .
+//! ```
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde_json::{Value, json};
+use stygian_browser::config::{PoolConfig, StealthLevel};
+use stygian_browser::{BrowserConfig, BrowserPool, WaitUntil};
+use tokio::time::sleep;
+
+const DEFAULT_G2_URL: &str = "https://www.g2.com/products/jira/reviews";
+const REVIEWS_FRAME_SELECTOR: &str = "turbo-frame#reviews-and-filters";
+const REVIEW_BODY_SELECTOR: &str = "turbo-frame#reviews-and-filters [itemprop=\"reviewBody\"]";
+const EXPAND_SHOW_MORE_JS: &str = r"(() => {
+    const frame = document.querySelector('turbo-frame#reviews-and-filters');
+    if (!frame) {
+        return 0;
+    }
+
+    const buttons = Array.from(frame.querySelectorAll('button')).filter((button) => {
+        const label = button.textContent?.replace(/\s+/g, ' ').trim() ?? '';
+        return label.includes('Show More') && !button.disabled;
+    });
+
+    for (const button of buttons.slice(0, 12)) {
+        button.click();
+    }
+
+    return buttons.length;
+})()";
+const EXTRACT_REVIEWS_JS: &str = r#"(() => {
+    const frame = document.querySelector('turbo-frame#reviews-and-filters');
+    if (!frame) {
+        return {
+            frame_found: false,
+            frame_heading: null,
+            sort_options: [],
+            current_page: null,
+            pagination: [],
+            reviews: [],
+        };
+    }
+
+    const normalizeWhitespace = (value) =>
+        (value ?? '').replace(/\s+/g, ' ').trim();
+
+    const normalizeKey = (value) =>
+        normalizeWhitespace(value)
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '_')
+            .replace(/^_+|_+$/g, '');
+
+    const pickText = (root, selectors) => {
+        for (const selector of selectors) {
+            const node = root.querySelector(selector);
+            const text = normalizeWhitespace(node?.textContent);
+            if (text) {
+                return text;
+            }
+        }
+        return null;
+    };
+
+    const findRating = (body) => {
+        let current = body;
+        for (let depth = 0; current && depth < 6; depth += 1) {
+            const label = Array.from(current.querySelectorAll('label, span, div'))
+                .map((node) => normalizeWhitespace(node.textContent))
+                .find((text) => /^\d(?:\.\d)?\/5$/.test(text));
+            if (label) {
+                return label;
+            }
+            current = current.parentElement;
+        }
+        return null;
+    };
+
+    const reviewBodies = Array.from(frame.querySelectorAll('[itemprop="reviewBody"]'));
+    const reviews = reviewBodies.map((body, index) => {
+        const container =
+            body.closest('article, li, [class*="review"], [class*="Review"], [class*="paper"]')
+            || body.parentElement
+            || body;
+
+        const sections = Object.fromEntries(
+            Array.from(body.querySelectorAll('section')).map((section) => {
+                const heading = normalizeWhitespace(section.querySelector('div')?.textContent);
+                const paragraphs = Array.from(section.querySelectorAll('p'))
+                    .map((node) => normalizeWhitespace(node.textContent))
+                    .filter(Boolean)
+                    .map((text) => text.replace(/Review collected by and hosted on G2\.com\.?/g, '').trim())
+                    .filter(Boolean);
+                return [normalizeKey(heading), {
+                    heading,
+                    text: paragraphs.join('\n\n') || null,
+                }];
+            }).filter(([key, value]) => key && value.text)
+        );
+
+        return {
+            index: index + 1,
+            rating: findRating(body),
+            reviewer: pickText(container, [
+                'a[href*="/users/"]',
+                '[itemprop="author"] a',
+                '[itemprop="author"]',
+            ]),
+            date: pickText(container, ['time', '[datetime]']),
+            sections,
+        };
+    });
+
+    const pagination = Array.from(frame.querySelectorAll('a.pagination__page-number-link, a.pagination__named-link')).map((link) => ({
+        text: normalizeWhitespace(link.textContent),
+        href: link.href || link.getAttribute('href'),
+    }));
+
+    const currentPage = normalizeWhitespace(
+        frame.querySelector('.pagination__page-number--current')?.textContent
+    );
+
+    const sortOptions = Array.from(
+        frame.querySelectorAll('[data-elv--form--selectbox-controller-choices-value]')
+    ).flatMap((node) => {
+        try {
+            return JSON.parse(node.getAttribute('data-elv--form--selectbox-controller-choices-value') || '[]');
+        } catch {
+            return [];
+        }
+    });
+
+    return {
+        frame_found: true,
+        frame_heading: normalizeWhitespace(frame.querySelector('h3')?.textContent),
+        sort_options: sortOptions,
+        current_page: currentPage || null,
+        pagination,
+        review_count_on_page: reviews.length,
+        reviews,
+    };
+})()"#;
+
+fn epoch_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_secs())
+}
+
+async fn emit_missing_frame_result(
+    page: &stygian_browser::PageHandle,
+    url: &str,
+    wait_stage: &str,
+    wait_error: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let final_url = page.url().await.unwrap_or_else(|_| url.to_string());
+    let title = page.title().await.unwrap_or_default();
+    let status_code = page.status_code().unwrap_or(None).unwrap_or(0);
+    let text_excerpt: String = page
+        .eval("(document.body?.innerText || '').trim().replace(/\\s+/g, ' ').slice(0, 800)")
+        .await
+        .unwrap_or_default();
+    let html_excerpt = page
+        .content()
+        .await
+        .map(|html| html.chars().take(800).collect::<String>())
+        .unwrap_or_default();
+
+    let result = json!({
+        "url": url,
+        "final_url": final_url,
+        "status_code": status_code,
+        "title": title,
+        "extracted_at": epoch_secs(),
+        "extraction": {
+            "frame_found": false,
+            "wait_stage": wait_stage,
+            "wait_error": wait_error,
+            "text_excerpt": text_excerpt,
+            "html_excerpt": html_excerpt,
+        },
+    });
+
+    println!("{}", serde_json::to_string_pretty(&result)?);
+    Ok(())
+}
+
+async fn wait_for_reviews_or_emit(
+    page: &stygian_browser::PageHandle,
+    url: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    if let Err(error) = page
+        .wait_for_selector(REVIEWS_FRAME_SELECTOR, Duration::from_secs(45))
+        .await
+    {
+        emit_missing_frame_result(page, url, "reviews_frame", &error.to_string()).await?;
+        return Ok(false);
+    }
+
+    if let Err(error) = page
+        .wait_for_selector(REVIEW_BODY_SELECTOR, Duration::from_secs(45))
+        .await
+    {
+        emit_missing_frame_result(page, url, "review_bodies", &error.to_string()).await?;
+        return Ok(false);
+    }
+
+    Ok(true)
+}
+
+async fn expand_show_more_sections(page: &stygian_browser::PageHandle, phase: &str) -> u64 {
+    let expanded: u64 = page.eval(EXPAND_SHOW_MORE_JS).await.unwrap_or(0);
+    if expanded > 0 {
+        eprintln!("[g2] expanded {expanded} collapsed sections {phase}");
+        sleep(Duration::from_millis(1200)).await;
+    }
+    expanded
+}
+
+async fn perform_scroll_passes(page: &stygian_browser::PageHandle) {
+    for pass in 1..=4 {
+        let offset: i64 = page
+            .eval("Math.max(600, Math.round(window.innerHeight * 0.85))")
+            .await
+            .unwrap_or(800);
+
+        eprintln!("[g2] scroll pass {pass}/4 ({offset}px)");
+        let script = format!("window.scrollBy({{ top: {offset}, behavior: 'smooth' }});");
+        page.eval::<Value>(&script).await.ok();
+        sleep(Duration::from_millis(1200)).await;
+    }
+}
+
+async fn extract_reviews(page: &stygian_browser::PageHandle) -> Value {
+    page.eval(EXTRACT_REVIEWS_JS).await.unwrap_or_else(|_| {
+        json!({
+            "frame_found": false,
+            "frame_heading": null,
+            "sort_options": [],
+            "current_page": null,
+            "pagination": [],
+            "review_count_on_page": 0,
+            "reviews": [],
+        })
+    })
+}
+
+async fn build_result_payload(
+    page: &stygian_browser::PageHandle,
+    url: &str,
+    expanded_before_scroll: u64,
+    expanded_after_scroll: u64,
+) -> Value {
+    let final_url = page.url().await.unwrap_or_else(|_| url.to_string());
+    let title = page.title().await.unwrap_or_default();
+    let status_code = page.status_code().unwrap_or(None).unwrap_or(0);
+    let extracted = extract_reviews(page).await;
+
+    json!({
+        "url": url,
+        "final_url": final_url,
+        "status_code": status_code,
+        "title": title,
+        "expanded_before_scroll": expanded_before_scroll,
+        "expanded_after_scroll": expanded_after_scroll,
+        "extracted_at": epoch_secs(),
+        "extraction": extracted,
+    })
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| DEFAULT_G2_URL.to_string());
+
+    eprintln!("[g2] target : {url}");
+
+    let config = BrowserConfig::builder()
+        .headless(true)
+        .stealth_level(StealthLevel::Advanced)
+        .pool(PoolConfig {
+            min_size: 1,
+            max_size: 2,
+            idle_timeout: Duration::from_mins(1),
+            acquire_timeout: Duration::from_secs(30),
+        })
+        .build();
+
+    eprintln!("[g2] warming browser pool...");
+    let pool = BrowserPool::new(config).await?;
+    let handle = pool.acquire().await?;
+    let browser = handle
+        .browser()
+        .ok_or("browser pool returned an expired handle")?;
+    let mut page = browser.new_page().await?;
+
+    eprintln!("[g2] navigating to review page...");
+    page.navigate(&url, WaitUntil::DomContentLoaded, Duration::from_secs(75))
+        .await?;
+
+    if !wait_for_reviews_or_emit(&page, &url).await? {
+        page.close().await.ok();
+        handle.release().await;
+        eprintln!("[g2] review content unavailable; emitted diagnostic payload.");
+        return Ok(());
+    }
+
+    sleep(Duration::from_millis(1500)).await;
+    let expanded_before_scroll = expand_show_more_sections(&page, "before scrolling").await;
+    perform_scroll_passes(&page).await;
+    let expanded_after_scroll = expand_show_more_sections(&page, "after scrolling").await;
+
+    let result =
+        build_result_payload(&page, &url, expanded_before_scroll, expanded_after_scroll).await;
+
+    println!("{}", serde_json::to_string_pretty(&result)?);
+
+    page.close().await.ok();
+    handle.release().await;
+
+    eprintln!("[g2] done.");
+    Ok(())
+}

--- a/crates/stygian-browser/src/behavior_adapter.rs
+++ b/crates/stygian-browser/src/behavior_adapter.rs
@@ -1,0 +1,543 @@
+//! Polymorphic adapter for structured JSON-driven browser behavior tuning.
+//!
+//! This module accepts multiple JSON shapes and maps them into concrete
+//! `stygian-browser` runtime behavior by mutating [`crate::BrowserConfig`] and
+//! returning an [`AppliedBehaviorPlan`] for runtime orchestration.
+//!
+//! Supported input envelopes:
+//! - Direct runtime policy object (`execution_mode`, `session_mode`, ...)
+//! - Full investigation bundle object with nested `policy` field
+//! - Lightweight direct override object (`headless`, `stealth_level`, ...)
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{
+    BrowserConfig,
+    cdp_protection::CdpFixMode,
+    config::StealthLevel,
+    error::{BrowserError, Result},
+};
+
+#[cfg(feature = "stealth")]
+use crate::webrtc::WebRtcPolicy;
+
+/// Source JSON shape selected by the polymorphic adapter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AdapterKind {
+    /// A direct runtime policy object was provided.
+    RuntimePolicy,
+    /// A full investigation bundle object with nested `policy` was provided.
+    InvestigationBundle,
+    /// A direct override object was provided.
+    DirectOverrides,
+}
+
+/// Browser execution mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExecutionMode {
+    /// Lightweight HTTP-oriented mode.
+    Http,
+    /// Full browser automation mode.
+    Browser,
+}
+
+/// Session stickiness mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionMode {
+    /// Stateless sessions.
+    Stateless,
+    /// Sticky sessions.
+    Sticky,
+}
+
+/// Telemetry intensity level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TelemetryLevel {
+    /// Minimal telemetry.
+    Basic,
+    /// Balanced telemetry.
+    Standard,
+    /// Deep telemetry.
+    Deep,
+}
+
+/// Interaction intensity recommendation for runtime page humanization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BehaviorInteractionLevel {
+    /// No interaction simulation.
+    None,
+    /// Light interaction simulation.
+    Low,
+    /// Moderate interaction simulation.
+    Medium,
+    /// High interaction simulation.
+    High,
+}
+
+impl TelemetryLevel {
+    const fn to_interaction_level(self) -> BehaviorInteractionLevel {
+        match self {
+            Self::Basic => BehaviorInteractionLevel::Low,
+            Self::Standard => BehaviorInteractionLevel::Medium,
+            Self::Deep => BehaviorInteractionLevel::High,
+        }
+    }
+}
+
+/// Structured behavior plan produced after JSON adaptation.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AppliedBehaviorPlan {
+    /// Which adapter shape was selected.
+    pub adapter_kind: AdapterKind,
+    /// Effective execution mode.
+    pub execution_mode: ExecutionMode,
+    /// Effective session mode.
+    pub session_mode: SessionMode,
+    /// Effective interaction recommendation.
+    pub interaction_level: BehaviorInteractionLevel,
+    /// Effective request pacing budget (requests/second).
+    pub rate_limit_rps: f64,
+    /// Retry budget for request orchestration.
+    pub max_retries: u32,
+    /// Base backoff delay in milliseconds.
+    pub backoff_base_ms: u64,
+    /// Whether warmup routines should run before primary navigation.
+    pub enable_warmup: bool,
+    /// Sticky session TTL recommendation in seconds.
+    pub sticky_session_ttl_secs: Option<u64>,
+    /// Policy risk score in `[0.0, 1.0]`.
+    pub risk_score: f64,
+    /// Required feature labels inferred from policy.
+    pub required_stygian_features: Vec<String>,
+    /// Config hint passthrough map.
+    pub config_hints: BTreeMap<String, String>,
+}
+
+/// Trait for behavior adapters that can mutate a browser config.
+pub trait BrowserBehaviorAdapter {
+    /// Apply behavior to `config` and return the derived runtime plan.
+    fn apply(&self, config: &mut BrowserConfig) -> AppliedBehaviorPlan;
+}
+
+/// Runtime-policy input compatible with stygian-charon output.
+#[derive(Debug, Clone, Deserialize)]
+struct RuntimePolicyInput {
+    execution_mode: ExecutionMode,
+    session_mode: SessionMode,
+    telemetry_level: TelemetryLevel,
+    rate_limit_rps: f64,
+    max_retries: u32,
+    backoff_base_ms: u64,
+    enable_warmup: bool,
+    enforce_webrtc_proxy_only: bool,
+    sticky_session_ttl_secs: Option<u64>,
+    required_stygian_features: Vec<String>,
+    config_hints: BTreeMap<String, String>,
+    risk_score: f64,
+}
+
+/// Investigation-bundle input with nested runtime policy.
+#[derive(Debug, Clone, Deserialize)]
+struct InvestigationBundleInput {
+    policy: RuntimePolicyInput,
+}
+
+/// Direct JSON overrides for behavior tuning.
+#[derive(Debug, Clone, Default, Deserialize)]
+struct DirectOverridesInput {
+    execution_mode: Option<ExecutionMode>,
+    session_mode: Option<SessionMode>,
+    telemetry_level: Option<TelemetryLevel>,
+    interaction_level: Option<BehaviorInteractionLevel>,
+    stealth_level: Option<StealthLevel>,
+    headless: Option<bool>,
+    rate_limit_rps: Option<f64>,
+    max_retries: Option<u32>,
+    backoff_base_ms: Option<u64>,
+    enable_warmup: Option<bool>,
+    enforce_webrtc_proxy_only: Option<bool>,
+    sticky_session_ttl_secs: Option<u64>,
+    required_stygian_features: Option<Vec<String>>,
+    config_hints: Option<BTreeMap<String, String>>,
+    risk_score: Option<f64>,
+}
+
+/// Polymorphic adapter selected from structured JSON input.
+pub struct PolymorphicBehaviorAdapter {
+    kind: AdapterKind,
+    inner: Box<dyn BrowserBehaviorAdapter + Send + Sync>,
+}
+
+impl PolymorphicBehaviorAdapter {
+    /// Build an adapter from a JSON string.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BrowserError::ConfigError`] when JSON parsing fails or the
+    /// structure is invalid.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use stygian_browser::behavior_adapter::PolymorphicBehaviorAdapter;
+    /// use stygian_browser::BrowserConfig;
+    ///
+    /// let json = r#"{"execution_mode":"Browser","session_mode":"Sticky","telemetry_level":"Deep","rate_limit_rps":0.8,"max_retries":4,"backoff_base_ms":1200,"enable_warmup":true,"enforce_webrtc_proxy_only":true,"sticky_session_ttl_secs":1800,"required_stygian_features":["browser"],"config_hints":{},"risk_score":0.9}"#;
+    /// let adapter = PolymorphicBehaviorAdapter::from_json_str(json).expect("valid adapter");
+    /// let mut cfg = BrowserConfig::default();
+    /// let plan = adapter.apply(&mut cfg);
+    /// assert!(plan.enable_warmup);
+    /// ```
+    pub fn from_json_str(json: &str) -> Result<Self> {
+        let value: Value = serde_json::from_str(json)
+            .map_err(|e| BrowserError::ConfigError(format!("Invalid behavior JSON: {e}")))?;
+        Self::from_json_value(value)
+    }
+
+    /// Build an adapter from a JSON value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BrowserError::ConfigError`] when the value does not match any
+    /// supported input envelope.
+    pub fn from_json_value(value: Value) -> Result<Self> {
+        let obj = value.as_object().ok_or_else(|| {
+            BrowserError::ConfigError("Behavior input must be a JSON object".to_string())
+        })?;
+
+        if obj.contains_key("policy") {
+            let parsed: InvestigationBundleInput = serde_json::from_value(value).map_err(|e| {
+                BrowserError::ConfigError(format!(
+                    "Invalid investigation bundle behavior input: {e}"
+                ))
+            })?;
+            return Ok(Self {
+                kind: AdapterKind::InvestigationBundle,
+                inner: Box::new(RuntimePolicyAdapter {
+                    kind: AdapterKind::InvestigationBundle,
+                    policy: parsed.policy,
+                }),
+            });
+        }
+
+        if obj.contains_key("execution_mode")
+            && obj.contains_key("session_mode")
+            && obj.contains_key("telemetry_level")
+        {
+            let parsed: RuntimePolicyInput = serde_json::from_value(value).map_err(|e| {
+                BrowserError::ConfigError(format!("Invalid runtime policy behavior input: {e}"))
+            })?;
+            return Ok(Self {
+                kind: AdapterKind::RuntimePolicy,
+                inner: Box::new(RuntimePolicyAdapter {
+                    kind: AdapterKind::RuntimePolicy,
+                    policy: parsed,
+                }),
+            });
+        }
+
+        let parsed: DirectOverridesInput = serde_json::from_value(value).map_err(|e| {
+            BrowserError::ConfigError(format!("Invalid direct override behavior input: {e}"))
+        })?;
+
+        Ok(Self {
+            kind: AdapterKind::DirectOverrides,
+            inner: Box::new(DirectOverridesAdapter { overrides: parsed }),
+        })
+    }
+
+    /// Return the selected adapter kind.
+    pub const fn kind(&self) -> AdapterKind {
+        self.kind
+    }
+
+    /// Apply behavior mutations to `config` and return the resulting plan.
+    pub fn apply(&self, config: &mut BrowserConfig) -> AppliedBehaviorPlan {
+        self.inner.apply(config)
+    }
+}
+
+struct RuntimePolicyAdapter {
+    kind: AdapterKind,
+    policy: RuntimePolicyInput,
+}
+
+impl BrowserBehaviorAdapter for RuntimePolicyAdapter {
+    fn apply(&self, config: &mut BrowserConfig) -> AppliedBehaviorPlan {
+        let interaction = self.policy.telemetry_level.to_interaction_level();
+        let stealth_level = stealth_level_for_policy(&self.policy);
+
+        config.stealth_level = stealth_level;
+        config.cdp_fix_mode = if matches!(self.policy.execution_mode, ExecutionMode::Browser) {
+            CdpFixMode::AddBinding
+        } else {
+            CdpFixMode::None
+        };
+
+        #[cfg(feature = "stealth")]
+        {
+            if self.policy.enforce_webrtc_proxy_only {
+                config.webrtc.policy = WebRtcPolicy::DisableNonProxied;
+            }
+        }
+
+        apply_config_hints(config, &self.policy.config_hints);
+
+        AppliedBehaviorPlan {
+            adapter_kind: self.kind,
+            execution_mode: self.policy.execution_mode,
+            session_mode: self.policy.session_mode,
+            interaction_level: interaction,
+            rate_limit_rps: self.policy.rate_limit_rps,
+            max_retries: self.policy.max_retries,
+            backoff_base_ms: self.policy.backoff_base_ms,
+            enable_warmup: self.policy.enable_warmup,
+            sticky_session_ttl_secs: self.policy.sticky_session_ttl_secs,
+            risk_score: clamp_unit(self.policy.risk_score),
+            required_stygian_features: self.policy.required_stygian_features.clone(),
+            config_hints: self.policy.config_hints.clone(),
+        }
+    }
+}
+
+struct DirectOverridesAdapter {
+    overrides: DirectOverridesInput,
+}
+
+impl BrowserBehaviorAdapter for DirectOverridesAdapter {
+    fn apply(&self, config: &mut BrowserConfig) -> AppliedBehaviorPlan {
+        if let Some(headless) = self.overrides.headless {
+            config.headless = headless;
+        }
+        if let Some(stealth) = self.overrides.stealth_level {
+            config.stealth_level = stealth;
+        }
+
+        #[cfg(feature = "stealth")]
+        {
+            if self.overrides.enforce_webrtc_proxy_only == Some(true) {
+                config.webrtc.policy = WebRtcPolicy::DisableNonProxied;
+            }
+        }
+
+        let hints = self.overrides.config_hints.clone().unwrap_or_default();
+        apply_config_hints(config, &hints);
+
+        let execution_mode = self
+            .overrides
+            .execution_mode
+            .unwrap_or(ExecutionMode::Browser);
+        let session_mode = self
+            .overrides
+            .session_mode
+            .unwrap_or(SessionMode::Stateless);
+        let telemetry = self
+            .overrides
+            .telemetry_level
+            .unwrap_or(TelemetryLevel::Standard);
+        let interaction = self
+            .overrides
+            .interaction_level
+            .unwrap_or_else(|| telemetry.to_interaction_level());
+
+        AppliedBehaviorPlan {
+            adapter_kind: AdapterKind::DirectOverrides,
+            execution_mode,
+            session_mode,
+            interaction_level: interaction,
+            rate_limit_rps: self.overrides.rate_limit_rps.unwrap_or(1.0),
+            max_retries: self.overrides.max_retries.unwrap_or(2),
+            backoff_base_ms: self.overrides.backoff_base_ms.unwrap_or(500),
+            enable_warmup: self.overrides.enable_warmup.unwrap_or(false),
+            sticky_session_ttl_secs: self.overrides.sticky_session_ttl_secs,
+            risk_score: clamp_unit(self.overrides.risk_score.unwrap_or(0.5)),
+            required_stygian_features: self
+                .overrides
+                .required_stygian_features
+                .clone()
+                .unwrap_or_default(),
+            config_hints: hints,
+        }
+    }
+}
+
+fn stealth_level_for_policy(policy: &RuntimePolicyInput) -> StealthLevel {
+    if matches!(policy.execution_mode, ExecutionMode::Http) {
+        return StealthLevel::None;
+    }
+
+    if policy
+        .required_stygian_features
+        .iter()
+        .any(|f| f.contains("stealth") || f.contains("browser"))
+        || policy.risk_score >= 0.65
+    {
+        StealthLevel::Advanced
+    } else if policy.risk_score >= 0.25 {
+        StealthLevel::Basic
+    } else {
+        StealthLevel::None
+    }
+}
+
+fn apply_config_hints(config: &mut BrowserConfig, hints: &BTreeMap<String, String>) {
+    if let Some(proxy) = hints.get("proxy_url").or_else(|| hints.get("proxy")) {
+        config.proxy = Some(proxy.clone());
+    }
+
+    if let Some(headless_raw) = hints.get("headless")
+        && let Ok(headless) = headless_raw.parse::<bool>()
+    {
+        config.headless = headless;
+    }
+
+    if let (Some(width_raw), Some(height_raw)) =
+        (hints.get("viewport_width"), hints.get("viewport_height"))
+        && let (Ok(width), Ok(height)) = (width_raw.parse::<u32>(), height_raw.parse::<u32>())
+    {
+        config.window_size = Some((width, height));
+    }
+
+    if let Some(mode_raw) = hints.get("cdp_fix_mode") {
+        config.cdp_fix_mode = parse_cdp_fix_mode(mode_raw);
+    }
+
+    if let Some(user_agent) = hints.get("user_agent") {
+        let arg = format!("--user-agent={user_agent}");
+        if !config.args.iter().any(|existing| existing == &arg) {
+            config.args.push(arg);
+        }
+    }
+}
+
+fn parse_cdp_fix_mode(raw: &str) -> CdpFixMode {
+    match raw.to_ascii_lowercase().as_str() {
+        "none" | "0" => CdpFixMode::None,
+        "isolatedworld" | "isolated_world" | "isolated" => CdpFixMode::IsolatedWorld,
+        "enabledisable" | "enable_disable" => CdpFixMode::EnableDisable,
+        _ => CdpFixMode::AddBinding,
+    }
+}
+
+const fn clamp_unit(value: f64) -> f64 {
+    if value < 0.0 {
+        0.0
+    } else if value > 1.0 {
+        1.0
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn selects_runtime_policy_shape() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let value = json!({
+            "execution_mode": "Browser",
+            "session_mode": "Sticky",
+            "telemetry_level": "Deep",
+            "rate_limit_rps": 0.5,
+            "max_retries": 3,
+            "backoff_base_ms": 1200,
+            "enable_warmup": true,
+            "enforce_webrtc_proxy_only": true,
+            "sticky_session_ttl_secs": 1800,
+            "required_stygian_features": ["browser", "stealth"],
+            "config_hints": {"proxy_url": "http://127.0.0.1:8080"},
+            "risk_score": 0.9
+        });
+
+        let adapter = PolymorphicBehaviorAdapter::from_json_value(value)
+            .map_err(|e| format!("adapter parse failed: {e}"))?;
+        assert_eq!(adapter.kind(), AdapterKind::RuntimePolicy);
+
+        let mut cfg = BrowserConfig::default();
+        let plan = adapter.apply(&mut cfg);
+        assert_eq!(plan.interaction_level, BehaviorInteractionLevel::High);
+        assert_eq!(cfg.proxy.as_deref(), Some("http://127.0.0.1:8080"));
+        assert_eq!(cfg.stealth_level, StealthLevel::Advanced);
+        Ok(())
+    }
+
+    #[test]
+    fn selects_investigation_bundle_shape() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let value = json!({
+            "report": {},
+            "requirements": {},
+            "policy": {
+                "execution_mode": "Browser",
+                "session_mode": "Stateless",
+                "telemetry_level": "Standard",
+                "rate_limit_rps": 1.2,
+                "max_retries": 2,
+                "backoff_base_ms": 400,
+                "enable_warmup": false,
+                "enforce_webrtc_proxy_only": false,
+                "sticky_session_ttl_secs": null,
+                "required_stygian_features": [],
+                "config_hints": {},
+                "risk_score": 0.2
+            }
+        });
+
+        let adapter = PolymorphicBehaviorAdapter::from_json_value(value)
+            .map_err(|e| format!("adapter parse failed: {e}"))?;
+        assert_eq!(adapter.kind(), AdapterKind::InvestigationBundle);
+
+        let mut cfg = BrowserConfig::default();
+        let plan = adapter.apply(&mut cfg);
+        assert_eq!(plan.execution_mode, ExecutionMode::Browser);
+        assert_eq!(plan.session_mode, SessionMode::Stateless);
+        Ok(())
+    }
+
+    #[test]
+    fn direct_overrides_apply_to_config() -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let value = json!({
+            "headless": false,
+            "stealth_level": "basic",
+            "interaction_level": "medium",
+            "config_hints": {
+                "viewport_width": "1366",
+                "viewport_height": "768",
+                "user_agent": "Mozilla/5.0 test"
+            }
+        });
+
+        let adapter = PolymorphicBehaviorAdapter::from_json_value(value)
+            .map_err(|e| format!("adapter parse failed: {e}"))?;
+        assert_eq!(adapter.kind(), AdapterKind::DirectOverrides);
+
+        let mut cfg = BrowserConfig::default();
+        let plan = adapter.apply(&mut cfg);
+
+        assert!(!cfg.headless);
+        assert_eq!(cfg.stealth_level, StealthLevel::Basic);
+        assert_eq!(plan.interaction_level, BehaviorInteractionLevel::Medium);
+        assert_eq!(cfg.window_size, Some((1366, 768)));
+        assert!(
+            cfg.args
+                .iter()
+                .any(|arg| arg.contains("--user-agent=Mozilla/5.0 test"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn invalid_non_object_input_is_rejected() {
+        let err = PolymorphicBehaviorAdapter::from_json_value(json!("not-object"))
+            .err()
+            .map(|e| e.to_string())
+            .unwrap_or_default();
+        assert!(err.contains("must be a JSON object"));
+    }
+}

--- a/crates/stygian-browser/src/config.rs
+++ b/crates/stygian-browser/src/config.rs
@@ -1040,8 +1040,19 @@ mod tests {
 
     #[test]
     fn validate_default_config_is_valid() {
-        let cfg = BrowserConfig::default();
-        assert!(cfg.validate().is_ok(), "default config must be valid");
+        temp_env::with_vars(
+            [
+                ("STYGIAN_POOL_MIN", None::<&str>),
+                ("STYGIAN_POOL_MAX", None::<&str>),
+                ("STYGIAN_LAUNCH_TIMEOUT_SECS", None::<&str>),
+                ("STYGIAN_CDP_TIMEOUT_SECS", None::<&str>),
+                ("STYGIAN_PROXY", None::<&str>),
+            ],
+            || {
+                let cfg = BrowserConfig::default();
+                assert!(cfg.validate().is_ok(), "default config must be valid");
+            },
+        );
     }
 
     #[test]
@@ -1079,16 +1090,27 @@ mod tests {
 
     #[test]
     fn validate_detects_zero_timeouts() {
-        let cfg = BrowserConfig {
-            launch_timeout: std::time::Duration::ZERO,
-            cdp_timeout: std::time::Duration::ZERO,
-            ..BrowserConfig::default()
-        };
-        let result = cfg.validate();
-        assert!(result.is_err());
-        if let Err(errors) = result {
-            assert_eq!(errors.len(), 2);
-        }
+        temp_env::with_vars(
+            [
+                ("STYGIAN_POOL_MIN", None::<&str>),
+                ("STYGIAN_POOL_MAX", None::<&str>),
+                ("STYGIAN_LAUNCH_TIMEOUT_SECS", None::<&str>),
+                ("STYGIAN_CDP_TIMEOUT_SECS", None::<&str>),
+                ("STYGIAN_PROXY", None::<&str>),
+            ],
+            || {
+                let cfg = BrowserConfig {
+                    launch_timeout: std::time::Duration::ZERO,
+                    cdp_timeout: std::time::Duration::ZERO,
+                    ..BrowserConfig::default()
+                };
+                let result = cfg.validate();
+                assert!(result.is_err());
+                if let Err(errors) = result {
+                    assert_eq!(errors.len(), 2);
+                }
+            },
+        );
     }
 
     #[test]

--- a/crates/stygian-browser/src/lib.rs
+++ b/crates/stygian-browser/src/lib.rs
@@ -67,6 +67,7 @@
 //! | [`webrtc`] | [`WebRtcConfig`], [`WebRtcPolicy`], [`ProxyLocation`] |
 //! | [`cdp_protection`] | CDP leak protection modes |
 
+pub mod behavior_adapter;
 pub mod browser;
 pub mod cdp_protection;
 pub mod config;
@@ -150,6 +151,10 @@ pub mod session;
 
 pub mod recorder;
 
+pub use behavior_adapter::{
+    AdapterKind, AppliedBehaviorPlan, BehaviorInteractionLevel, BrowserBehaviorAdapter,
+    ExecutionMode, PolymorphicBehaviorAdapter, SessionMode, TelemetryLevel,
+};
 pub use browser::BrowserInstance;
 pub use config::{BrowserConfig, HeadlessMode, StealthLevel};
 pub use error::{BrowserError, Result};

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -1657,8 +1657,10 @@ impl McpBrowserServer {
             Some("none") => InteractionLevel::None,
             Some("medium") => InteractionLevel::Medium,
             Some("high") => InteractionLevel::High,
-            Some("low") => InteractionLevel::Low,
-            Some(_) => InteractionLevel::Low,
+            Some(level) => match level {
+                "low" => InteractionLevel::Low,
+                _ => InteractionLevel::Low,
+            },
             None => default_level,
         };
         let viewport_width = args

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -51,6 +51,7 @@
 //! | `browser_auth_session` | `session_id, mode, file_path?, ttl_secs?, navigate_to_origin?, interaction_level?` | auth/session workflow result |
 //! | `browser_session_save` | `session_id, ttl_secs?, file_path?, include_snapshot?` | saved session state metadata |
 //! | `browser_session_restore` | `session_id, snapshot?, file_path?, use_saved?, navigate_to_origin?` | restored session state metadata |
+//! | `browser_apply_behavior_json` | `behavior, session_id?` | applied behavior plan + effective config |
 //! | `browser_humanize` | `session_id, level?, viewport_width?, viewport_height?` | humanization result |
 //! | `browser_verify_stealth` | `session_id, url, timeout_secs?` | `DiagnosticReport` JSON |
 //! | `browser_release` | `session_id` | success |
@@ -85,8 +86,9 @@ use ulid::Ulid;
 use futures::StreamExt;
 
 use crate::{
-    BrowserHandle, BrowserPool,
+    BrowserConfig, BrowserHandle, BrowserPool,
     behavior::{InteractionLevel, InteractionSimulator},
+    behavior_adapter::{BehaviorInteractionLevel, PolymorphicBehaviorAdapter},
     config::StealthLevel,
     error::{BrowserError, Result},
     page::WaitUntil,
@@ -192,6 +194,8 @@ struct McpSession {
     saved_snapshot: Option<SessionSnapshot>,
     /// Endpoint used by an attached browser session.
     attach_endpoint: Option<String>,
+    /// Optional behavior plan applied via `browser_apply_behavior_json`.
+    behavior_plan: Option<crate::behavior_adapter::AppliedBehaviorPlan>,
 }
 
 // ─── MCP server ──────────────────────────────────────────────────────────────
@@ -617,6 +621,24 @@ static TOOL_DEFINITIONS: LazyLock<Vec<Value>> = LazyLock::new(|| {
                 "required": ["session_id"]
             }
         }));
+    tools.push(json!({
+            "name": "browser_apply_behavior_json",
+            "description": "Apply structured behavior JSON (runtime policy, investigation bundle, or direct overrides) using the polymorphic behavior adapter. Returns an applied plan and effective browser config. If session_id is provided, session metadata is updated for downstream tools.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "behavior": {
+                        "type": "object",
+                        "description": "Structured behavior input: RuntimePolicy object, InvestigationBundle object with nested policy, or direct override object."
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": "Optional active session to annotate with the applied behavior plan."
+                    }
+                },
+                "required": ["behavior"]
+            }
+        }));
     tools
 });
 
@@ -807,6 +829,7 @@ impl McpBrowserServer {
             "browser_auth_session" => self.tool_browser_auth_session(&args).await,
             "browser_session_save" => self.tool_browser_session_save(&args).await,
             "browser_session_restore" => self.tool_browser_session_restore(&args).await,
+            "browser_apply_behavior_json" => self.tool_browser_apply_behavior_json(&args).await,
             "browser_humanize" => self.tool_browser_humanize(&args).await,
             #[cfg(feature = "stealth")]
             "browser_verify_stealth" => self.tool_browser_verify_stealth(&args).await,
@@ -906,6 +929,7 @@ impl McpBrowserServer {
                 current_url: None,
                 saved_snapshot: None,
                 attach_endpoint: None,
+                behavior_plan: None,
             },
         );
 
@@ -1266,6 +1290,7 @@ impl McpBrowserServer {
                         current_url: None,
                         saved_snapshot: None,
                         attach_endpoint: Some(endpoint.clone()),
+                        behavior_plan: None,
                     },
                 );
 
@@ -1549,13 +1574,87 @@ impl McpBrowserServer {
         }))
     }
 
+    async fn tool_browser_apply_behavior_json(&self, args: &Value) -> Result<Value> {
+        let behavior = args.get("behavior").cloned().ok_or_else(|| {
+            BrowserError::ConfigError("Missing required 'behavior' object".to_string())
+        })?;
+
+        if !behavior.is_object() {
+            return Err(BrowserError::ConfigError(
+                "'behavior' must be a JSON object".to_string(),
+            ));
+        }
+
+        let adapter = PolymorphicBehaviorAdapter::from_json_value(behavior)?;
+        let mut effective_config = BrowserConfig::default();
+        let plan = adapter.apply(&mut effective_config);
+        let adapter_kind = adapter.kind();
+
+        let session_id = args
+            .get("session_id")
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+
+        let session_updated = if let Some(sid) = &session_id {
+            let mut sessions = self.sessions.lock().await;
+            let session = sessions
+                .get_mut(sid)
+                .ok_or_else(|| BrowserError::ConfigError(format!("Unknown session_id: {sid}")))?;
+
+            session.behavior_plan = Some(plan.clone());
+            session.stealth_level = effective_config.stealth_level;
+            session.cdp_fix_mode = Some(format!("{:?}", effective_config.cdp_fix_mode));
+            session.proxy.clone_from(&effective_config.proxy);
+
+            #[cfg(feature = "stealth")]
+            {
+                session.webrtc_policy = Some(format!("{:?}", effective_config.webrtc.policy));
+            }
+
+            drop(sessions);
+            true
+        } else {
+            false
+        };
+
+        let effective_view = json!({
+            "headless": effective_config.headless,
+            "stealth_level": effective_config.stealth_level,
+            "proxy": effective_config.proxy,
+            "window_size": effective_config.window_size,
+            "cdp_fix_mode": effective_config.cdp_fix_mode,
+            "args": effective_config.args
+        });
+
+        Ok(json!({
+            "adapter_kind": adapter_kind,
+            "plan": plan,
+            "effective_config": effective_view,
+            "session_id": session_id,
+            "session_updated": session_updated
+        }))
+    }
+
     async fn tool_browser_humanize(&self, args: &Value) -> Result<Value> {
         let session_id = Self::require_str(args, "session_id")?;
-        let level = match args.get("level").and_then(Value::as_str).unwrap_or("low") {
-            "none" => InteractionLevel::None,
-            "medium" => InteractionLevel::Medium,
-            "high" => InteractionLevel::High,
-            _ => InteractionLevel::Low,
+        let default_level = {
+            let sessions = self.sessions.lock().await;
+            sessions
+                .get(&session_id)
+                .and_then(|s| s.behavior_plan.as_ref())
+                .map_or(InteractionLevel::Low, |plan| match plan.interaction_level {
+                    BehaviorInteractionLevel::None => InteractionLevel::None,
+                    BehaviorInteractionLevel::Low => InteractionLevel::Low,
+                    BehaviorInteractionLevel::Medium => InteractionLevel::Medium,
+                    BehaviorInteractionLevel::High => InteractionLevel::High,
+                })
+        };
+        let level = match args.get("level").and_then(Value::as_str) {
+            Some("none") => InteractionLevel::None,
+            Some("medium") => InteractionLevel::Medium,
+            Some("high") => InteractionLevel::High,
+            Some("low" | _) => InteractionLevel::Low,
+            None => default_level,
         };
         let viewport_width = args
             .get("viewport_width")
@@ -2169,7 +2268,9 @@ impl McpBrowserServer {
                     "target_profile": s.target_profile,
                     "current_url": s.current_url,
                     "has_saved_snapshot": s.saved_snapshot.is_some(),
-                    "attach_endpoint": s.attach_endpoint
+                    "attach_endpoint": s.attach_endpoint,
+                    "has_behavior_plan": s.behavior_plan.is_some(),
+                    "behavior_plan": s.behavior_plan.as_ref()
                 })
             })
         };
@@ -2968,6 +3069,37 @@ mod tests {
                 .any(|t| t.get("name").and_then(|n| n.as_str()) == Some("browser_humanize")),
             "TOOL_DEFINITIONS must contain browser_humanize"
         );
+    }
+
+    #[test]
+    fn tool_defs_include_browser_apply_behavior_json() {
+        let defs = &*TOOL_DEFINITIONS;
+        assert!(
+            defs.iter()
+                .any(|t| t.get("name").and_then(|n| n.as_str())
+                    == Some("browser_apply_behavior_json")),
+            "TOOL_DEFINITIONS must contain browser_apply_behavior_json"
+        );
+    }
+
+    #[test]
+    fn browser_apply_behavior_json_requires_behavior()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let defs = &*TOOL_DEFINITIONS;
+        let def = defs
+            .iter()
+            .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("browser_apply_behavior_json"))
+            .ok_or("browser_apply_behavior_json must be in TOOL_DEFINITIONS")?;
+        let required = def
+            .get("inputSchema")
+            .and_then(|s| s.get("required"))
+            .and_then(Value::as_array)
+            .ok_or("browser_apply_behavior_json inputSchema missing required array")?;
+        assert!(
+            required.iter().any(|v| v == "behavior"),
+            "behavior must be required in browser_apply_behavior_json"
+        );
+        Ok(())
     }
 
     #[cfg(feature = "mcp-attach")]

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -1653,7 +1653,8 @@ impl McpBrowserServer {
             Some("none") => InteractionLevel::None,
             Some("medium") => InteractionLevel::Medium,
             Some("high") => InteractionLevel::High,
-            Some("low" | _) => InteractionLevel::Low,
+            Some("low") => InteractionLevel::Low,
+            Some(_) => InteractionLevel::Low,
             None => default_level,
         };
         let viewport_width = args

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -1657,10 +1657,7 @@ impl McpBrowserServer {
             Some("none") => InteractionLevel::None,
             Some("medium") => InteractionLevel::Medium,
             Some("high") => InteractionLevel::High,
-            Some(level) => match level {
-                "low" => InteractionLevel::Low,
-                _ => InteractionLevel::Low,
-            },
+            Some(_) => InteractionLevel::Low,
             None => default_level,
         };
         let viewport_width = args

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -1601,9 +1601,13 @@ impl McpBrowserServer {
                 .get_mut(sid)
                 .ok_or_else(|| BrowserError::ConfigError(format!("Unknown session_id: {sid}")))?;
 
+            let cdp_fix_mode = serde_json::to_value(effective_config.cdp_fix_mode)
+                .ok()
+                .and_then(|value| value.as_str().map(ToString::to_string));
+
             session.behavior_plan = Some(plan.clone());
             session.stealth_level = effective_config.stealth_level;
-            session.cdp_fix_mode = Some(format!("{:?}", effective_config.cdp_fix_mode));
+            session.cdp_fix_mode = cdp_fix_mode;
             session.proxy.clone_from(&effective_config.proxy);
 
             #[cfg(feature = "stealth")]

--- a/crates/stygian-charon/Cargo.toml
+++ b/crates/stygian-charon/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "stygian-charon"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+description = "Anti-bot provider fingerprinting and HAR forensics for Stygian"
+keywords = ["antibot", "forensics", "har", "scraping", "security"]
+categories = ["web-programming", "network-programming"]
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/stygian-charon/docs/investigation-bundle.schema.json
+++ b/crates/stygian-charon/docs/investigation-bundle.schema.json
@@ -20,13 +20,12 @@
     "AntiBotProvider": {
       "type": "string",
       "enum": [
-        "None",
+        "DataDome",
         "Cloudflare",
         "Akamai",
-        "DataDome",
         "PerimeterX",
         "Kasada",
-        "Fingerprint",
+        "FingerprintCom",
         "Unknown"
       ]
     },

--- a/crates/stygian-charon/docs/investigation-bundle.schema.json
+++ b/crates/stygian-charon/docs/investigation-bundle.schema.json
@@ -1,0 +1,414 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://stygian.dev/schemas/stygian-charon/investigation-bundle.schema.json",
+  "title": "InvestigationBundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["report", "requirements", "policy"],
+  "properties": {
+    "report": {
+      "$ref": "#/$defs/InvestigationReport"
+    },
+    "requirements": {
+      "$ref": "#/$defs/RequirementsProfile"
+    },
+    "policy": {
+      "$ref": "#/$defs/RuntimePolicy"
+    }
+  },
+  "$defs": {
+    "AntiBotProvider": {
+      "type": "string",
+      "enum": [
+        "None",
+        "Cloudflare",
+        "Akamai",
+        "DataDome",
+        "PerimeterX",
+        "Kasada",
+        "Fingerprint",
+        "Unknown"
+      ]
+    },
+    "AdapterStrategy": {
+      "type": "string",
+      "enum": [
+        "DirectHttp",
+        "BrowserStealth",
+        "StickyProxy",
+        "SessionWarmup",
+        "InvestigateOnly"
+      ]
+    },
+    "RequirementLevel": {
+      "type": "string",
+      "enum": ["Low", "Medium", "High"]
+    },
+    "ExecutionMode": {
+      "type": "string",
+      "enum": ["Http", "Browser"]
+    },
+    "SessionMode": {
+      "type": "string",
+      "enum": ["Stateless", "Sticky"]
+    },
+    "TelemetryLevel": {
+      "type": "string",
+      "enum": ["Basic", "Standard", "Deep"]
+    },
+    "Detection": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "confidence", "markers"],
+      "properties": {
+        "provider": {
+          "$ref": "#/$defs/AntiBotProvider"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "markers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MarkerCount": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["marker", "count"],
+      "properties": {
+        "marker": {
+          "type": "string"
+        },
+        "count": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "HostSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["host", "total_requests", "blocked_requests"],
+      "properties": {
+        "host": {
+          "type": "string"
+        },
+        "total_requests": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "blocked_requests": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "HarRequestSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "status", "resource_type", "detection"],
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "status": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535
+        },
+        "resource_type": {
+          "type": ["string", "null"]
+        },
+        "detection": {
+          "$ref": "#/$defs/Detection"
+        }
+      }
+    },
+    "InvestigationReport": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "page_title",
+        "total_requests",
+        "blocked_requests",
+        "status_histogram",
+        "resource_type_histogram",
+        "provider_histogram",
+        "top_markers",
+        "hosts",
+        "suspicious_requests",
+        "aggregate"
+      ],
+      "properties": {
+        "page_title": {
+          "type": ["string", "null"]
+        },
+        "total_requests": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "blocked_requests": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "status_histogram": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "patternProperties": {
+            "^[0-9]+$": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        },
+        "resource_type_histogram": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "provider_histogram": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/AntiBotProvider"
+          }
+        },
+        "top_markers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/MarkerCount"
+          }
+        },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/HostSummary"
+          }
+        },
+        "suspicious_requests": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/HarRequestSummary"
+          }
+        },
+        "aggregate": {
+          "$ref": "#/$defs/Detection"
+        }
+      }
+    },
+    "InvestigationDiff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "baseline_total_requests",
+        "candidate_total_requests",
+        "baseline_blocked_requests",
+        "candidate_blocked_requests",
+        "blocked_ratio_delta",
+        "likely_regression",
+        "provider_delta",
+        "new_markers"
+      ],
+      "properties": {
+        "baseline_total_requests": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "candidate_total_requests": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "baseline_blocked_requests": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "candidate_blocked_requests": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "blocked_ratio_delta": {
+          "type": "number"
+        },
+        "likely_regression": {
+          "type": "boolean"
+        },
+        "provider_delta": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "propertyNames": {
+            "$ref": "#/$defs/AntiBotProvider"
+          }
+        },
+        "new_markers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "AntiBotRequirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "why", "evidence", "level"],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "why": {
+          "type": "string"
+        },
+        "evidence": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "level": {
+          "$ref": "#/$defs/RequirementLevel"
+        }
+      }
+    },
+    "IntegrationRecommendation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "strategy",
+        "rationale",
+        "required_stygian_features",
+        "config_hints"
+      ],
+      "properties": {
+        "strategy": {
+          "$ref": "#/$defs/AdapterStrategy"
+        },
+        "rationale": {
+          "type": "string"
+        },
+        "required_stygian_features": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "config_hints": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RequirementsProfile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "confidence", "requirements", "recommendation"],
+      "properties": {
+        "provider": {
+          "$ref": "#/$defs/AntiBotProvider"
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AntiBotRequirement"
+          }
+        },
+        "recommendation": {
+          "$ref": "#/$defs/IntegrationRecommendation"
+        }
+      }
+    },
+    "RuntimePolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "execution_mode",
+        "session_mode",
+        "telemetry_level",
+        "rate_limit_rps",
+        "max_retries",
+        "backoff_base_ms",
+        "enable_warmup",
+        "enforce_webrtc_proxy_only",
+        "sticky_session_ttl_secs",
+        "required_stygian_features",
+        "config_hints",
+        "risk_score"
+      ],
+      "properties": {
+        "execution_mode": {
+          "$ref": "#/$defs/ExecutionMode"
+        },
+        "session_mode": {
+          "$ref": "#/$defs/SessionMode"
+        },
+        "telemetry_level": {
+          "$ref": "#/$defs/TelemetryLevel"
+        },
+        "rate_limit_rps": {
+          "type": "number"
+        },
+        "max_retries": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 4294967295
+        },
+        "backoff_base_ms": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "enable_warmup": {
+          "type": "boolean"
+        },
+        "enforce_webrtc_proxy_only": {
+          "type": "boolean"
+        },
+        "sticky_session_ttl_secs": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "required_stygian_features": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "config_hints": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "risk_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    }
+  }
+}

--- a/crates/stygian-charon/docs/investigation-bundle.schema.json
+++ b/crates/stygian-charon/docs/investigation-bundle.schema.json
@@ -139,6 +139,7 @@
         "status_histogram",
         "resource_type_histogram",
         "provider_histogram",
+        "marker_histogram",
         "top_markers",
         "hosts",
         "suspicious_requests",
@@ -158,15 +159,12 @@
         },
         "status_histogram": {
           "type": "object",
+          "propertyNames": {
+            "pattern": "^[0-9]+$"
+          },
           "additionalProperties": {
             "type": "integer",
             "minimum": 0
-          },
-          "patternProperties": {
-            "^[0-9]+$": {
-              "type": "integer",
-              "minimum": 0
-            }
           }
         },
         "resource_type_histogram": {
@@ -184,6 +182,13 @@
           },
           "propertyNames": {
             "$ref": "#/$defs/AntiBotProvider"
+          }
+        },
+        "marker_histogram": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 0
           }
         },
         "top_markers": {

--- a/crates/stygian-charon/docs/output-structure.md
+++ b/crates/stygian-charon/docs/output-structure.md
@@ -1,0 +1,213 @@
+# stygian-charon Output Structure
+
+This document specifies the full output contract for Charon's analysis and planning pipeline.
+
+## Primary entrypoint
+
+- Function: `analyze_and_plan(har_json: &str) -> Result<InvestigationBundle, HarError>`
+- Module: `src/policy.rs`
+
+`InvestigationBundle` is the canonical top-level output.
+
+## Top-level type
+
+### InvestigationBundle
+
+Fields:
+
+- `report: InvestigationReport`
+- `requirements: RequirementsProfile`
+- `policy: RuntimePolicy`
+
+---
+
+## Report layer
+
+### InvestigationReport
+
+Raw and aggregated telemetry from HAR parsing plus provider classification.
+
+Fields:
+
+- `page_title: Option<String>`
+- `total_requests: u64`
+- `blocked_requests: u64`
+- `status_histogram: BTreeMap<u16, u64>`
+- `resource_type_histogram: BTreeMap<String, u64>`
+- `provider_histogram: BTreeMap<AntiBotProvider, u64>`
+- `top_markers: Vec<MarkerCount>`
+- `hosts: Vec<HostSummary>`
+- `suspicious_requests: Vec<HarRequestSummary>`
+- `aggregate: Detection`
+
+Operational semantics:
+
+- `blocked_requests` counts HTTP 403 and 429.
+- `top_markers` is sorted by descending frequency and truncated to a bounded list.
+- `suspicious_requests` includes blocked requests and requests with recognized provider signals.
+
+### HarRequestSummary
+
+Per-request projection used in both report and suspicious subsets.
+
+Fields:
+
+- `url: String`
+- `status: u16`
+- `resource_type: Option<String>`
+- `detection: Detection`
+
+### Detection
+
+Provider detection output.
+
+Fields:
+
+- `provider: AntiBotProvider`
+- `confidence: f64` in `[0.0, 1.0]`
+- `markers: Vec<String>`
+
+### MarkerCount
+
+Fields:
+
+- `marker: String`
+- `count: u64`
+
+### HostSummary
+
+Fields:
+
+- `host: String`
+- `total_requests: u64`
+- `blocked_requests: u64`
+
+---
+
+## Requirements layer
+
+### RequirementsProfile
+
+Inferred operational requirements and strategic recommendation.
+
+Fields:
+
+- `provider: AntiBotProvider`
+- `confidence: f64`
+- `requirements: Vec<AntiBotRequirement>`
+- `recommendation: IntegrationRecommendation`
+
+### AntiBotRequirement
+
+Fields:
+
+- `id: String`
+- `title: String`
+- `why: String`
+- `evidence: Vec<String>`
+- `level: RequirementLevel`
+
+### RequirementLevel
+
+Enum values:
+
+- `Low`
+- `Medium`
+- `High`
+
+### IntegrationRecommendation
+
+Fields:
+
+- `strategy: AdapterStrategy`
+- `rationale: String`
+- `required_stygian_features: Vec<String>`
+- `config_hints: BTreeMap<String, String>`
+
+### AdapterStrategy
+
+Enum values:
+
+- `DirectHttp`
+- `BrowserStealth`
+- `StickyProxy`
+- `SessionWarmup`
+- `InvestigateOnly`
+
+---
+
+## Policy layer
+
+### RuntimePolicy
+
+Concrete planning output intended for adapter/runtime wiring.
+
+Fields:
+
+- `execution_mode: ExecutionMode`
+- `session_mode: SessionMode`
+- `telemetry_level: TelemetryLevel`
+- `rate_limit_rps: f64`
+- `max_retries: u32`
+- `backoff_base_ms: u64`
+- `enable_warmup: bool`
+- `enforce_webrtc_proxy_only: bool`
+- `sticky_session_ttl_secs: Option<u64>`
+- `required_stygian_features: Vec<String>`
+- `config_hints: BTreeMap<String, String>`
+- `risk_score: f64` in `[0.0, 1.0]`
+
+### ExecutionMode
+
+Enum values:
+
+- `Http`
+- `Browser`
+
+### SessionMode
+
+Enum values:
+
+- `Stateless`
+- `Sticky`
+
+### TelemetryLevel
+
+Enum values:
+
+- `Basic`
+- `Standard`
+- `Deep`
+
+---
+
+## Diff output (related API)
+
+`compare_reports` returns `InvestigationDiff`.
+
+### InvestigationDiff
+
+Fields:
+
+- `baseline_total_requests: u64`
+- `candidate_total_requests: u64`
+- `baseline_blocked_requests: u64`
+- `candidate_blocked_requests: u64`
+- `blocked_ratio_delta: f64`
+- `likely_regression: bool`
+- `provider_delta: BTreeMap<AntiBotProvider, i64>`
+- `new_markers: Vec<String>`
+
+---
+
+## Serialization details
+
+All output types derive `Serialize` and `Deserialize`.
+
+Notes for JSON consumers:
+
+- Enum values are serialized as strings matching Rust variant names.
+- Map keys are JSON strings.
+  - For numeric-key maps (for example `status_histogram`), keys appear as strings in JSON objects.
+  - For enum-key maps (for example `provider_histogram`), keys appear as enum variant strings.
+- Optional fields are nullable in schema terms.

--- a/crates/stygian-charon/examples/recon.rs
+++ b/crates/stygian-charon/examples/recon.rs
@@ -19,6 +19,23 @@ fn print_bundle(bundle: &InvestigationBundle) {
         bundle.requirements.recommendation.strategy
     );
     println!("risk_score={:.3}", bundle.policy.risk_score);
+    println!("provider_histogram={:?}", bundle.report.provider_histogram);
+
+    println!("top_markers_count={}", bundle.report.top_markers.len());
+    for marker in bundle.report.top_markers.iter().take(10) {
+        println!("top_marker.{}={}", marker.marker, marker.count);
+    }
+
+    println!(
+        "suspicious_requests_count={}",
+        bundle.report.suspicious_requests.len()
+    );
+    for request in bundle.report.suspicious_requests.iter().take(5) {
+        println!(
+            "suspicious_request.status={} provider={:?} url={}",
+            request.status, request.detection.provider, request.url
+        );
+    }
 
     for (key, value) in &bundle.requirements.recommendation.config_hints {
         println!("config_hint.{key}={value}");

--- a/crates/stygian-charon/examples/recon.rs
+++ b/crates/stygian-charon/examples/recon.rs
@@ -1,0 +1,49 @@
+use std::{env, fs};
+
+use stygian_charon::{InvestigationBundle, analyze_and_plan, investigate_har, plan_from_report};
+
+fn print_bundle(bundle: &InvestigationBundle) {
+    println!(
+        "page_title={}",
+        bundle.report.page_title.as_deref().unwrap_or("<none>")
+    );
+    println!("total_requests={}", bundle.report.total_requests);
+    println!("blocked_requests={}", bundle.report.blocked_requests);
+    println!("aggregate_provider={:?}", bundle.report.aggregate.provider);
+    println!(
+        "aggregate_confidence={:.3}",
+        bundle.report.aggregate.confidence
+    );
+    println!(
+        "recommendation_strategy={:?}",
+        bundle.requirements.recommendation.strategy
+    );
+    println!("risk_score={:.3}", bundle.policy.risk_score);
+
+    for (key, value) in &bundle.requirements.recommendation.config_hints {
+        println!("config_hint.{key}={value}");
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args();
+    let _bin = args.next();
+    let Some(har_path) = args.next() else {
+        eprintln!("usage: cargo run --example recon -p stygian-charon -- <path-to.har>");
+        std::process::exit(2);
+    };
+
+    let har_json = fs::read_to_string(&har_path)?;
+
+    let bundle = analyze_and_plan(&har_json)?;
+    print_bundle(&bundle);
+
+    let report = investigate_har(&har_json)?;
+    let bundle_from_report = plan_from_report(report);
+    eprintln!(
+        "verified plan_from_report strategy={:?}",
+        bundle_from_report.requirements.recommendation.strategy
+    );
+
+    Ok(())
+}

--- a/crates/stygian-charon/src/classifier.rs
+++ b/crates/stygian-charon/src/classifier.rs
@@ -41,7 +41,7 @@ const SIGNATURES: &[Signature] = &[
         weight: 4,
     },
     Signature {
-        needle: "server: cloudflare",
+        needle: "server:cloudflare",
         provider: AntiBotProvider::Cloudflare,
         weight: 3,
     },

--- a/crates/stygian-charon/src/classifier.rs
+++ b/crates/stygian-charon/src/classifier.rs
@@ -1,0 +1,339 @@
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
+
+use crate::har;
+use crate::types::{
+    AntiBotProvider, Detection, HarClassificationReport, HarRequestSummary, ProviderScore,
+    TransactionView,
+};
+
+#[derive(Debug, Clone, Copy)]
+struct Signature {
+    needle: &'static str,
+    provider: AntiBotProvider,
+    weight: u32,
+}
+
+const SIGNATURES: &[Signature] = &[
+    Signature {
+        needle: "x-datadome",
+        provider: AntiBotProvider::DataDome,
+        weight: 5,
+    },
+    Signature {
+        needle: "x-datadome-cid",
+        provider: AntiBotProvider::DataDome,
+        weight: 5,
+    },
+    Signature {
+        needle: "x-dd-b",
+        provider: AntiBotProvider::DataDome,
+        weight: 4,
+    },
+    Signature {
+        needle: "datadome=",
+        provider: AntiBotProvider::DataDome,
+        weight: 4,
+    },
+    Signature {
+        needle: "captcha-delivery.com",
+        provider: AntiBotProvider::DataDome,
+        weight: 4,
+    },
+    Signature {
+        needle: "server: cloudflare",
+        provider: AntiBotProvider::Cloudflare,
+        weight: 3,
+    },
+    Signature {
+        needle: "cf-ray",
+        provider: AntiBotProvider::Cloudflare,
+        weight: 5,
+    },
+    Signature {
+        needle: "__cf_bm",
+        provider: AntiBotProvider::Cloudflare,
+        weight: 4,
+    },
+    Signature {
+        needle: "cdn-cgi/challenge-platform",
+        provider: AntiBotProvider::Cloudflare,
+        weight: 4,
+    },
+    Signature {
+        needle: "attention required! | cloudflare",
+        provider: AntiBotProvider::Cloudflare,
+        weight: 4,
+    },
+    Signature {
+        needle: "_abck",
+        provider: AntiBotProvider::Akamai,
+        weight: 5,
+    },
+    Signature {
+        needle: "bm_sv",
+        provider: AntiBotProvider::Akamai,
+        weight: 5,
+    },
+    Signature {
+        needle: "akamai",
+        provider: AntiBotProvider::Akamai,
+        weight: 2,
+    },
+    Signature {
+        needle: "_px",
+        provider: AntiBotProvider::PerimeterX,
+        weight: 5,
+    },
+    Signature {
+        needle: "perimeterx",
+        provider: AntiBotProvider::PerimeterX,
+        weight: 4,
+    },
+    Signature {
+        needle: "humansecurity",
+        provider: AntiBotProvider::PerimeterX,
+        weight: 3,
+    },
+    Signature {
+        needle: "x-kpsdk",
+        provider: AntiBotProvider::Kasada,
+        weight: 5,
+    },
+    Signature {
+        needle: "kasada",
+        provider: AntiBotProvider::Kasada,
+        weight: 4,
+    },
+    Signature {
+        needle: "x-fpjs",
+        provider: AntiBotProvider::FingerprintCom,
+        weight: 4,
+    },
+    Signature {
+        needle: "fingerprint.com",
+        provider: AntiBotProvider::FingerprintCom,
+        weight: 3,
+    },
+];
+
+/// Classify a transaction view into a likely anti-bot provider.
+#[must_use]
+pub fn classify_transaction(tx: &TransactionView) -> Detection {
+    let mut scores: BTreeMap<AntiBotProvider, ProviderScore> = BTreeMap::new();
+
+    for provider in [
+        AntiBotProvider::DataDome,
+        AntiBotProvider::Cloudflare,
+        AntiBotProvider::Akamai,
+        AntiBotProvider::PerimeterX,
+        AntiBotProvider::Kasada,
+        AntiBotProvider::FingerprintCom,
+    ] {
+        let _prev = scores.insert(
+            provider,
+            ProviderScore {
+                provider,
+                score: 0,
+                markers: Vec::new(),
+            },
+        );
+    }
+
+    let normalized_headers = normalize_headers(&tx.response_headers);
+    let body = tx
+        .response_body_snippet
+        .as_ref()
+        .map_or_else(String::new, |s| s.to_lowercase());
+
+    let mut haystacks = String::new();
+    haystacks.push_str(&tx.url.to_lowercase());
+    haystacks.push('\n');
+    haystacks.push_str(&normalized_headers);
+    haystacks.push('\n');
+    haystacks.push_str(&body);
+
+    for sig in SIGNATURES {
+        if haystacks.contains(sig.needle)
+            && let Some(score) = scores.get_mut(&sig.provider)
+        {
+            score.score = score.score.saturating_add(sig.weight);
+            score.markers.push(sig.needle.to_string());
+        }
+    }
+
+    // 403/429 can increase confidence but does not imply a specific vendor.
+    if tx.status == 403 || tx.status == 429 {
+        for provider in [AntiBotProvider::DataDome, AntiBotProvider::Cloudflare] {
+            if let Some(score) = scores.get_mut(&provider)
+                && score.score > 0
+            {
+                score.score = score.score.saturating_add(1);
+                score.markers.push(format!("status:{}", tx.status));
+            }
+        }
+    }
+
+    let mut ordered: Vec<ProviderScore> = scores.into_values().collect();
+    ordered.sort_by_key(|score| Reverse(score.score));
+
+    let top = ordered.first();
+    let second = ordered.get(1);
+
+    match (top, second) {
+        (Some(primary), Some(secondary)) if primary.score > 0 => {
+            let denom = primary.score + secondary.score;
+            let confidence = if denom == 0 {
+                0.0
+            } else {
+                f64::from(primary.score) / f64::from(denom)
+            };
+            Detection {
+                provider: primary.provider,
+                confidence,
+                markers: primary.markers.clone(),
+            }
+        }
+        (Some(primary), _) if primary.score > 0 => Detection {
+            provider: primary.provider,
+            confidence: 1.0,
+            markers: primary.markers.clone(),
+        },
+        _ => Detection {
+            provider: AntiBotProvider::Unknown,
+            confidence: 0.0,
+            markers: Vec::new(),
+        },
+    }
+}
+
+/// Classify all entries in a HAR JSON payload.
+///
+/// # Errors
+///
+/// Returns [`har::HarError`] when the input is not valid HAR JSON
+/// or is missing required HAR fields.
+pub fn classify_har(har_json: &str) -> Result<HarClassificationReport, har::HarError> {
+    let parsed = har::parse_har_transactions(har_json)?;
+
+    let requests = parsed
+        .requests
+        .into_iter()
+        .map(|req| HarRequestSummary {
+            url: req.transaction.url.clone(),
+            status: req.transaction.status,
+            resource_type: req.resource_type,
+            detection: classify_transaction(&req.transaction),
+        })
+        .collect::<Vec<_>>();
+
+    let aggregate = aggregate_detection(&requests);
+
+    Ok(HarClassificationReport {
+        page_title: parsed.page_title,
+        aggregate,
+        requests,
+    })
+}
+
+fn aggregate_detection(requests: &[HarRequestSummary]) -> Detection {
+    let mut provider_counts: BTreeMap<AntiBotProvider, u32> = BTreeMap::new();
+    let mut markers: Vec<String> = Vec::new();
+
+    for req in requests {
+        if req.detection.provider != AntiBotProvider::Unknown {
+            let entry = provider_counts.entry(req.detection.provider).or_insert(0);
+            *entry = entry.saturating_add(1);
+        }
+        markers.extend(req.detection.markers.iter().cloned());
+    }
+
+    if provider_counts.is_empty() {
+        return Detection {
+            provider: AntiBotProvider::Unknown,
+            confidence: 0.0,
+            markers: Vec::new(),
+        };
+    }
+
+    let mut ordered: Vec<(AntiBotProvider, u32)> = provider_counts.into_iter().collect();
+    ordered.sort_by_key(|(_, count)| Reverse(*count));
+
+    if let Some((provider, top_count)) = ordered.first().copied() {
+        let second_count = ordered.get(1).map_or(0, |x| x.1);
+        let confidence = if top_count + second_count == 0 {
+            0.0
+        } else {
+            f64::from(top_count) / f64::from(top_count + second_count)
+        };
+
+        Detection {
+            provider,
+            confidence,
+            markers,
+        }
+    } else {
+        Detection {
+            provider: AntiBotProvider::Unknown,
+            confidence: 0.0,
+            markers,
+        }
+    }
+}
+
+fn normalize_headers(headers: &BTreeMap<String, String>) -> String {
+    let mut normalized = String::new();
+    for (key, value) in headers {
+        normalized.push_str(&key.to_lowercase());
+        normalized.push(':');
+        normalized.push_str(&value.to_lowercase());
+        normalized.push('\n');
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn classifies_datadome_from_headers() {
+        let mut headers = BTreeMap::new();
+        let _ = headers.insert("x-datadome".to_string(), "protected".to_string());
+        let _ = headers.insert("x-datadome-cid".to_string(), "abc".to_string());
+        let _ = headers.insert("set-cookie".to_string(), "datadome=xyz; Path=/".to_string());
+
+        let tx = TransactionView {
+            url: "https://www.g2.com/".to_string(),
+            status: 403,
+            response_headers: headers,
+            response_body_snippet: Some("Please enable JS".to_string()),
+        };
+
+        let detection = classify_transaction(&tx);
+
+        assert_eq!(detection.provider, AntiBotProvider::DataDome);
+        assert!(detection.confidence > 0.5);
+    }
+
+    #[test]
+    fn classifies_cloudflare_from_body_and_headers() {
+        let mut headers = BTreeMap::new();
+        let _ = headers.insert("server".to_string(), "cloudflare".to_string());
+        let _ = headers.insert("cf-ray".to_string(), "123-ORD".to_string());
+
+        let tx = TransactionView {
+            url: "https://www.capterra.com/".to_string(),
+            status: 403,
+            response_headers: headers,
+            response_body_snippet: Some("Attention Required! | Cloudflare".to_string()),
+        };
+
+        let detection = classify_transaction(&tx);
+
+        assert_eq!(detection.provider, AntiBotProvider::Cloudflare);
+        assert!(detection.confidence > 0.5);
+    }
+}

--- a/crates/stygian-charon/src/har.rs
+++ b/crates/stygian-charon/src/har.rs
@@ -1,0 +1,199 @@
+use std::collections::BTreeMap;
+
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::types::TransactionView;
+
+/// Errors returned while parsing HAR data.
+#[derive(Debug, Error)]
+pub enum HarError {
+    /// HAR payload is not valid JSON.
+    #[error("invalid HAR json: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+    /// Expected HAR structure is missing required fields.
+    #[error("invalid HAR structure: {0}")]
+    InvalidStructure(&'static str),
+}
+
+/// Internal parsed HAR representation.
+#[derive(Debug, Clone)]
+pub struct ParsedHar {
+    /// Page title from the HAR pages section when available.
+    pub page_title: Option<String>,
+    /// Parsed request transactions.
+    pub requests: Vec<TransactionViewWithType>,
+}
+
+/// Transaction plus optional resource type.
+#[derive(Debug, Clone)]
+pub struct TransactionViewWithType {
+    /// Transaction used by the classifier.
+    pub transaction: TransactionView,
+    /// Resource type (document/script/xhr/etc.) if present in HAR.
+    pub resource_type: Option<String>,
+}
+
+impl TransactionViewWithType {
+    /// Convenience accessor for URL.
+    #[allow(clippy::missing_const_for_fn)]
+    #[must_use]
+    pub fn url(&self) -> &str {
+        &self.transaction.url
+    }
+
+    /// Convenience accessor for status.
+    #[must_use]
+    pub const fn status(&self) -> u16 {
+        self.transaction.status
+    }
+}
+
+impl From<TransactionViewWithType> for TransactionView {
+    fn from(value: TransactionViewWithType) -> Self {
+        value.transaction
+    }
+}
+
+/// Parse a HAR JSON string into transactions usable by the classifier.
+///
+/// # Errors
+///
+/// Returns [`HarError::InvalidJson`] when `har_json` is not valid JSON,
+/// or [`HarError::InvalidStructure`] when required HAR fields are missing.
+pub fn parse_har_transactions(har_json: &str) -> Result<ParsedHar, HarError> {
+    let root: Value = serde_json::from_str(har_json)?;
+
+    let log = root
+        .get("log")
+        .ok_or(HarError::InvalidStructure("missing log object"))?;
+
+    let page_title = log
+        .get("pages")
+        .and_then(Value::as_array)
+        .and_then(|pages| pages.first())
+        .and_then(|page| page.get("title"))
+        .and_then(Value::as_str)
+        .map(str::to_owned);
+
+    let entries = log
+        .get("entries")
+        .and_then(Value::as_array)
+        .ok_or(HarError::InvalidStructure("missing entries array"))?;
+
+    let mut requests: Vec<TransactionViewWithType> = Vec::new();
+
+    for entry in entries {
+        let request = entry
+            .get("request")
+            .ok_or(HarError::InvalidStructure("entry missing request"))?;
+        let response = entry
+            .get("response")
+            .ok_or(HarError::InvalidStructure("entry missing response"))?;
+
+        let url = request
+            .get("url")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+            .unwrap_or_default();
+
+        let status = response
+            .get("status")
+            .and_then(Value::as_u64)
+            .and_then(|x| u16::try_from(x).ok())
+            .unwrap_or(0);
+
+        let headers = response
+            .get("headers")
+            .and_then(Value::as_array)
+            .map(|headers| extract_headers(headers))
+            .unwrap_or_default();
+
+        let body_snippet = response
+            .get("content")
+            .and_then(|content| content.get("text"))
+            .and_then(Value::as_str)
+            .map(|text| text.chars().take(2_048).collect::<String>());
+
+        let tx = TransactionView {
+            url,
+            status,
+            response_headers: headers,
+            response_body_snippet: body_snippet,
+        };
+
+        requests.push(TransactionViewWithType {
+            transaction: tx,
+            resource_type: entry
+                .get("_resourceType")
+                .and_then(Value::as_str)
+                .map(str::to_owned),
+        });
+    }
+
+    Ok(ParsedHar {
+        page_title,
+        requests,
+    })
+}
+
+fn extract_headers(headers: &[Value]) -> BTreeMap<String, String> {
+    let mut out = BTreeMap::new();
+    for header in headers {
+        let name = header
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let value = header
+            .get("value")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+
+        if let (Some(k), Some(v)) = (name, value) {
+            let _prev = out.insert(k, v);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_minimal_har() {
+        let json = r#"{
+            "log": {
+                "pages": [{"title": "https://example.com"}],
+                "entries": [
+                    {
+                        "_resourceType": "document",
+                        "request": {"url": "https://example.com"},
+                        "response": {
+                            "status": 403,
+                            "headers": [{"name": "server", "value": "cloudflare"}],
+                            "content": {"text": "Attention Required! | Cloudflare"}
+                        }
+                    }
+                ]
+            }
+        }"#;
+
+        let parsed_result = parse_har_transactions(json);
+        assert!(parsed_result.is_ok(), "parse should succeed");
+
+        let Ok(parsed) = parsed_result else {
+            return;
+        };
+
+        assert_eq!(parsed.page_title.as_deref(), Some("https://example.com"));
+        assert_eq!(parsed.requests.len(), 1);
+
+        let first = parsed.requests.first();
+        assert!(first.is_some(), "parsed requests unexpectedly empty");
+        if let Some(first) = first {
+            assert_eq!(first.status(), 403);
+            assert_eq!(first.url(), "https://example.com");
+        }
+    }
+}

--- a/crates/stygian-charon/src/har.rs
+++ b/crates/stygian-charon/src/har.rs
@@ -95,13 +95,13 @@ pub fn parse_har_transactions(har_json: &str) -> Result<ParsedHar, HarError> {
             .get("url")
             .and_then(Value::as_str)
             .map(str::to_owned)
-            .unwrap_or_default();
+            .ok_or(HarError::InvalidStructure("entry request missing url"))?;
 
         let status = response
             .get("status")
             .and_then(Value::as_u64)
             .and_then(|x| u16::try_from(x).ok())
-            .unwrap_or(0);
+            .ok_or(HarError::InvalidStructure("entry response missing status"))?;
 
         let headers = response
             .get("headers")

--- a/crates/stygian-charon/src/investigation.rs
+++ b/crates/stygian-charon/src/investigation.rs
@@ -1,0 +1,498 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::classifier::classify_transaction;
+use crate::har;
+use crate::types::{
+    AdapterStrategy, AntiBotProvider, AntiBotRequirement, Detection, HarRequestSummary,
+    HostSummary, IntegrationRecommendation, InvestigationDiff, InvestigationReport, MarkerCount,
+    RequirementLevel, RequirementsProfile,
+};
+
+/// Build an investigation report from a HAR payload.
+///
+/// # Errors
+///
+/// Returns [`har::HarError`] when the HAR payload is invalid or malformed.
+pub fn investigate_har(har_json: &str) -> Result<InvestigationReport, har::HarError> {
+    let parsed = har::parse_har_transactions(har_json)?;
+
+    let mut status_histogram: BTreeMap<u16, u64> = BTreeMap::new();
+    let mut resource_type_histogram: BTreeMap<String, u64> = BTreeMap::new();
+    let mut provider_histogram: BTreeMap<AntiBotProvider, u64> = BTreeMap::new();
+    let mut marker_histogram: BTreeMap<String, u64> = BTreeMap::new();
+    let mut host_accumulator: BTreeMap<String, HostSummary> = BTreeMap::new();
+
+    let mut blocked_requests = 0_u64;
+    let mut all_requests: Vec<HarRequestSummary> = Vec::new();
+    let mut suspicious_requests: Vec<HarRequestSummary> = Vec::new();
+
+    for req in parsed.requests {
+        let detection = classify_transaction(&req.transaction);
+
+        let summary = HarRequestSummary {
+            url: req.transaction.url.clone(),
+            status: req.transaction.status,
+            resource_type: req.resource_type.clone(),
+            detection,
+        };
+
+        let status_entry = status_histogram.entry(summary.status).or_insert(0);
+        *status_entry = status_entry.saturating_add(1);
+
+        let resource_label = summary
+            .resource_type
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string());
+        let resource_entry = resource_type_histogram.entry(resource_label).or_insert(0);
+        *resource_entry = resource_entry.saturating_add(1);
+
+        let provider_entry = provider_histogram
+            .entry(summary.detection.provider)
+            .or_insert(0);
+        *provider_entry = provider_entry.saturating_add(1);
+
+        for marker in &summary.detection.markers {
+            let marker_entry = marker_histogram.entry(marker.clone()).or_insert(0);
+            *marker_entry = marker_entry.saturating_add(1);
+        }
+
+        let is_blocked = summary.status == 403 || summary.status == 429;
+        if is_blocked {
+            blocked_requests = blocked_requests.saturating_add(1);
+        }
+
+        let host = extract_host(&summary.url);
+        let host_summary = host_accumulator.entry(host.clone()).or_insert(HostSummary {
+            host,
+            total_requests: 0,
+            blocked_requests: 0,
+        });
+        host_summary.total_requests = host_summary.total_requests.saturating_add(1);
+        if is_blocked {
+            host_summary.blocked_requests = host_summary.blocked_requests.saturating_add(1);
+        }
+
+        let is_suspicious = is_blocked || summary.detection.provider != AntiBotProvider::Unknown;
+        if is_suspicious {
+            suspicious_requests.push(summary.clone());
+        }
+
+        all_requests.push(summary);
+    }
+
+    let total_requests = u64::try_from(all_requests.len()).unwrap_or(u64::MAX);
+
+    let aggregate = aggregate_detection(&all_requests);
+
+    let mut top_markers = marker_histogram
+        .into_iter()
+        .map(|(marker, count)| MarkerCount { marker, count })
+        .collect::<Vec<_>>();
+    top_markers.sort_by_key(|marker| std::cmp::Reverse(marker.count));
+    if top_markers.len() > 25 {
+        top_markers.truncate(25);
+    }
+
+    let mut hosts = host_accumulator.into_values().collect::<Vec<_>>();
+    hosts.sort_by_key(|host| std::cmp::Reverse(host.total_requests));
+
+    suspicious_requests.sort_by_key(|req| std::cmp::Reverse(req.status));
+    if suspicious_requests.len() > 200 {
+        suspicious_requests.truncate(200);
+    }
+
+    Ok(InvestigationReport {
+        page_title: parsed.page_title,
+        total_requests,
+        blocked_requests,
+        status_histogram,
+        resource_type_histogram,
+        provider_histogram,
+        top_markers,
+        hosts,
+        suspicious_requests,
+        aggregate,
+    })
+}
+
+/// Compare a baseline and candidate investigation report.
+#[must_use]
+pub fn compare_reports(
+    baseline: &InvestigationReport,
+    candidate: &InvestigationReport,
+) -> InvestigationDiff {
+    let baseline_ratio = blocked_ratio(baseline.blocked_requests, baseline.total_requests);
+    let candidate_ratio = blocked_ratio(candidate.blocked_requests, candidate.total_requests);
+    let blocked_ratio_delta = candidate_ratio - baseline_ratio;
+
+    let mut provider_delta: BTreeMap<AntiBotProvider, i64> = BTreeMap::new();
+    let all_providers =
+        collect_provider_keys(&baseline.provider_histogram, &candidate.provider_histogram);
+    for provider in all_providers {
+        let base = baseline
+            .provider_histogram
+            .get(&provider)
+            .copied()
+            .unwrap_or(0);
+        let cand = candidate
+            .provider_histogram
+            .get(&provider)
+            .copied()
+            .unwrap_or(0);
+
+        let cand_i64 = i64::try_from(cand).unwrap_or(i64::MAX);
+        let base_i64 = i64::try_from(base).unwrap_or(i64::MAX);
+
+        let _ = provider_delta.insert(provider, cand_i64.saturating_sub(base_i64));
+    }
+
+    let baseline_markers = baseline
+        .top_markers
+        .iter()
+        .map(|marker| marker.marker.clone())
+        .collect::<BTreeSet<_>>();
+    let candidate_markers = candidate
+        .top_markers
+        .iter()
+        .map(|marker| marker.marker.clone())
+        .collect::<BTreeSet<_>>();
+    let new_markers = candidate_markers
+        .difference(&baseline_markers)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    InvestigationDiff {
+        baseline_total_requests: baseline.total_requests,
+        candidate_total_requests: candidate.total_requests,
+        baseline_blocked_requests: baseline.blocked_requests,
+        candidate_blocked_requests: candidate.blocked_requests,
+        blocked_ratio_delta,
+        likely_regression: blocked_ratio_delta >= 0.02,
+        provider_delta,
+        new_markers,
+    }
+}
+
+/// Infer operational requirements and adapter strategy from an investigation report.
+#[must_use]
+pub fn infer_requirements(report: &InvestigationReport) -> RequirementsProfile {
+    let mut requirements = Vec::new();
+
+    let blocked_ratio = blocked_ratio(report.blocked_requests, report.total_requests);
+    let marker_set = report
+        .top_markers
+        .iter()
+        .map(|marker| marker.marker.to_lowercase())
+        .collect::<BTreeSet<_>>();
+
+    let has_cloudflare = marker_set.iter().any(|m| {
+        m.contains("cf-ray") || m.contains("__cf_bm") || m.contains("cdn-cgi/challenge-platform")
+    });
+    let has_datadome = marker_set.iter().any(|m| {
+        m.contains("x-datadome")
+            || m.contains("x-dd-b")
+            || m.contains("datadome=")
+            || m.contains("captcha-delivery.com")
+    });
+
+    if has_cloudflare {
+        requirements.push(AntiBotRequirement {
+            id: "js_runtime_and_cookie_lifecycle".to_string(),
+            title: "Maintain JS-capable session flow".to_string(),
+            why: "Challenge markers indicate server-side scoring that expects browser-like session progression.".to_string(),
+            evidence: select_marker_evidence(&marker_set, &["cf-ray", "__cf_bm", "cdn-cgi/challenge-platform"]),
+            level: RequirementLevel::High,
+        });
+    }
+
+    if has_datadome {
+        requirements.push(AntiBotRequirement {
+            id: "fingerprint_and_identity_consistency".to_string(),
+            title: "Keep request identity consistent".to_string(),
+            why: "DataDome markers commonly correlate with strict consistency checks across headers, cookies, and connection profile.".to_string(),
+            evidence: select_marker_evidence(&marker_set, &["x-datadome", "x-dd-b", "datadome=", "captcha-delivery.com"]),
+            level: RequirementLevel::High,
+        });
+    }
+
+    if blocked_ratio >= 0.10 {
+        requirements.push(AntiBotRequirement {
+            id: "adaptive_rate_and_retry_budget".to_string(),
+            title: "Apply adaptive pacing and bounded retries".to_string(),
+            why: "Elevated block ratio suggests aggressive concurrency or retry behavior is increasing risk scoring.".to_string(),
+            evidence: vec![format!("blocked_ratio={blocked_ratio:.4}")],
+            level: RequirementLevel::High,
+        });
+    }
+
+    let status_429 = report.status_histogram.get(&429).copied().unwrap_or(0);
+    if status_429 > 0 {
+        requirements.push(AntiBotRequirement {
+            id: "rate_limit_backoff".to_string(),
+            title: "Honor explicit rate limits".to_string(),
+            why: "Observed HTTP 429 responses indicate throttling pressure.".to_string(),
+            evidence: vec![format!("status_429={status_429}")],
+            level: RequirementLevel::Medium,
+        });
+    }
+
+    let preflight_count = report
+        .resource_type_histogram
+        .get("preflight")
+        .copied()
+        .unwrap_or(0);
+    if preflight_count > 0 {
+        requirements.push(AntiBotRequirement {
+            id: "cors_and_header_fidelity".to_string(),
+            title: "Preserve browser-like CORS/header flow".to_string(),
+            why: "Preflight-heavy traffic can fail if adapter behavior diverges from browser request choreography.".to_string(),
+            evidence: vec![format!("preflight_requests={preflight_count}")],
+            level: RequirementLevel::Medium,
+        });
+    }
+
+    let recommendation = recommend_strategy(
+        report.aggregate.provider,
+        blocked_ratio,
+        has_cloudflare,
+        has_datadome,
+        &requirements,
+    );
+
+    RequirementsProfile {
+        provider: report.aggregate.provider,
+        confidence: report.aggregate.confidence,
+        requirements,
+        recommendation,
+    }
+}
+
+fn aggregate_detection(requests: &[HarRequestSummary]) -> Detection {
+    let mut provider_counts: BTreeMap<AntiBotProvider, u64> = BTreeMap::new();
+    let mut markers: Vec<String> = Vec::new();
+
+    for req in requests {
+        if req.detection.provider != AntiBotProvider::Unknown {
+            let entry = provider_counts.entry(req.detection.provider).or_insert(0);
+            *entry = entry.saturating_add(1);
+        }
+        markers.extend(req.detection.markers.iter().cloned());
+    }
+
+    if provider_counts.is_empty() {
+        return Detection {
+            provider: AntiBotProvider::Unknown,
+            confidence: 0.0,
+            markers: Vec::new(),
+        };
+    }
+
+    let mut ordered = provider_counts.into_iter().collect::<Vec<_>>();
+    ordered.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+
+    if let Some((provider, top_count)) = ordered.first().copied() {
+        let second_count = ordered.get(1).map_or(0, |pair| pair.1);
+        let confidence = if top_count + second_count == 0 {
+            0.0
+        } else {
+            to_f64(top_count) / to_f64(top_count + second_count)
+        };
+
+        Detection {
+            provider,
+            confidence,
+            markers,
+        }
+    } else {
+        Detection {
+            provider: AntiBotProvider::Unknown,
+            confidence: 0.0,
+            markers,
+        }
+    }
+}
+
+fn blocked_ratio(blocked: u64, total: u64) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        to_f64(blocked) / to_f64(total)
+    }
+}
+
+#[allow(clippy::cast_precision_loss)]
+const fn to_f64(value: u64) -> f64 {
+    value as f64
+}
+
+fn collect_provider_keys(
+    left: &BTreeMap<AntiBotProvider, u64>,
+    right: &BTreeMap<AntiBotProvider, u64>,
+) -> BTreeSet<AntiBotProvider> {
+    left.keys().chain(right.keys()).copied().collect()
+}
+
+fn extract_host(url: &str) -> String {
+    if let Some((_, rest)) = url.split_once("://") {
+        let before_path = rest.split('/').next().unwrap_or(rest);
+        let without_auth = before_path.split('@').next_back().unwrap_or(before_path);
+        without_auth.to_string()
+    } else {
+        url.split('/').next().unwrap_or(url).to_string()
+    }
+}
+
+fn select_marker_evidence(marker_set: &BTreeSet<String>, needles: &[&str]) -> Vec<String> {
+    let mut out = Vec::new();
+    for marker in marker_set {
+        if needles.iter().any(|needle| marker.contains(needle)) {
+            out.push(marker.clone());
+        }
+    }
+    out
+}
+
+fn recommend_strategy(
+    provider: AntiBotProvider,
+    blocked_ratio: f64,
+    has_cloudflare: bool,
+    has_datadome: bool,
+    requirements: &[AntiBotRequirement],
+) -> IntegrationRecommendation {
+    let mut required_stygian_features = Vec::new();
+    let mut config_hints = BTreeMap::new();
+
+    let strategy = if has_datadome {
+        required_stygian_features.push("stygian-browser".to_string());
+        required_stygian_features.push("stygian-proxy".to_string());
+        let _ = config_hints.insert("proxy.rotation".to_string(), "per-domain".to_string());
+        let _ = config_hints.insert("session.sticky_ttl_secs".to_string(), "600".to_string());
+        let _ = config_hints.insert(
+            "webrtc.policy".to_string(),
+            "disable_non_proxied_udp".to_string(),
+        );
+        AdapterStrategy::StickyProxy
+    } else if has_cloudflare || blocked_ratio >= 0.05 {
+        required_stygian_features.push("stygian-browser".to_string());
+        let _ = config_hints.insert("request.rate_limit.rps".to_string(), "1-3".to_string());
+        let _ = config_hints.insert(
+            "retry.backoff".to_string(),
+            "exponential+jitter".to_string(),
+        );
+        AdapterStrategy::BrowserStealth
+    } else if provider == AntiBotProvider::Unknown && requirements.is_empty() {
+        required_stygian_features.push("stygian-graph".to_string());
+        AdapterStrategy::DirectHttp
+    } else {
+        required_stygian_features.push("stygian-graph".to_string());
+        required_stygian_features.push("stygian-charon".to_string());
+        AdapterStrategy::InvestigateOnly
+    };
+
+    let rationale = match strategy {
+        AdapterStrategy::StickyProxy => {
+            "Provider markers suggest identity/session continuity and proxy stickiness are primary requirements."
+                .to_string()
+        }
+        AdapterStrategy::BrowserStealth => {
+            "Challenge density indicates browser-backed execution with conservative pacing is required."
+                .to_string()
+        }
+        AdapterStrategy::DirectHttp => {
+            "No strong anti-bot markers were detected; direct HTTP path appears sufficient."
+                .to_string()
+        }
+        AdapterStrategy::SessionWarmup => {
+            "Session priming is recommended before collection workloads."
+                .to_string()
+        }
+        AdapterStrategy::InvestigateOnly => {
+            "Signals are mixed; keep adaptive telemetry enabled and gather additional baseline runs."
+                .to_string()
+        }
+    };
+
+    IntegrationRecommendation {
+        strategy,
+        rationale,
+        required_stygian_features,
+        config_hints,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compare_reports_flags_block_ratio_regression() {
+        let baseline = InvestigationReport {
+            page_title: None,
+            total_requests: 100,
+            blocked_requests: 5,
+            status_histogram: BTreeMap::new(),
+            resource_type_histogram: BTreeMap::new(),
+            provider_histogram: BTreeMap::new(),
+            top_markers: Vec::new(),
+            hosts: Vec::new(),
+            suspicious_requests: Vec::new(),
+            aggregate: Detection {
+                provider: AntiBotProvider::Unknown,
+                confidence: 0.0,
+                markers: Vec::new(),
+            },
+        };
+
+        let candidate = InvestigationReport {
+            blocked_requests: 12,
+            ..baseline.clone()
+        };
+
+        let diff = compare_reports(&baseline, &candidate);
+        assert!(diff.blocked_ratio_delta > 0.02);
+        assert!(diff.likely_regression);
+    }
+
+    #[test]
+    fn infer_requirements_identifies_cloudflare_signals() {
+        let mut status_histogram = BTreeMap::new();
+        let _ = status_histogram.insert(403, 7);
+
+        let mut resource_histogram = BTreeMap::new();
+        let _ = resource_histogram.insert("document".to_string(), 10);
+
+        let report = InvestigationReport {
+            page_title: Some("https://example.com".to_string()),
+            total_requests: 10,
+            blocked_requests: 7,
+            status_histogram,
+            resource_type_histogram: resource_histogram,
+            provider_histogram: BTreeMap::new(),
+            top_markers: vec![
+                MarkerCount {
+                    marker: "cf-ray".to_string(),
+                    count: 5,
+                },
+                MarkerCount {
+                    marker: "__cf_bm".to_string(),
+                    count: 5,
+                },
+            ],
+            hosts: Vec::new(),
+            suspicious_requests: Vec::new(),
+            aggregate: Detection {
+                provider: AntiBotProvider::Cloudflare,
+                confidence: 0.9,
+                markers: vec!["cf-ray".to_string()],
+            },
+        };
+
+        let profile = infer_requirements(&report);
+        assert_eq!(profile.provider, AntiBotProvider::Cloudflare);
+        assert!(!profile.requirements.is_empty());
+        assert_eq!(
+            profile.recommendation.strategy,
+            AdapterStrategy::BrowserStealth
+        );
+    }
+}

--- a/crates/stygian-charon/src/investigation.rs
+++ b/crates/stygian-charon/src/investigation.rs
@@ -85,8 +85,11 @@ pub fn investigate_har(har_json: &str) -> Result<InvestigationReport, har::HarEr
     let aggregate = aggregate_detection(&all_requests);
 
     let mut top_markers = marker_histogram
-        .into_iter()
-        .map(|(marker, count)| MarkerCount { marker, count })
+        .iter()
+        .map(|(marker, count)| MarkerCount {
+            marker: marker.clone(),
+            count: *count,
+        })
         .collect::<Vec<_>>();
     top_markers.sort_by_key(|marker| std::cmp::Reverse(marker.count));
     if top_markers.len() > 25 {
@@ -108,6 +111,7 @@ pub fn investigate_har(har_json: &str) -> Result<InvestigationReport, har::HarEr
         status_histogram,
         resource_type_histogram,
         provider_histogram,
+        marker_histogram,
         top_markers,
         hosts,
         suspicious_requests,
@@ -147,14 +151,14 @@ pub fn compare_reports(
     }
 
     let baseline_markers = baseline
-        .top_markers
-        .iter()
-        .map(|marker| marker.marker.clone())
+        .marker_histogram
+        .keys()
+        .cloned()
         .collect::<BTreeSet<_>>();
     let candidate_markers = candidate
-        .top_markers
-        .iter()
-        .map(|marker| marker.marker.clone())
+        .marker_histogram
+        .keys()
+        .cloned()
         .collect::<BTreeSet<_>>();
     let new_markers = candidate_markers
         .difference(&baseline_markers)
@@ -433,6 +437,7 @@ mod tests {
             status_histogram: BTreeMap::new(),
             resource_type_histogram: BTreeMap::new(),
             provider_histogram: BTreeMap::new(),
+            marker_histogram: BTreeMap::new(),
             top_markers: Vec::new(),
             hosts: Vec::new(),
             suspicious_requests: Vec::new(),
@@ -468,6 +473,10 @@ mod tests {
             status_histogram,
             resource_type_histogram: resource_histogram,
             provider_histogram: BTreeMap::new(),
+            marker_histogram: BTreeMap::from([
+                ("cf-ray".to_string(), 5),
+                ("__cf_bm".to_string(), 5),
+            ]),
             top_markers: vec![
                 MarkerCount {
                     marker: "cf-ray".to_string(),

--- a/crates/stygian-charon/src/lib.rs
+++ b/crates/stygian-charon/src/lib.rs
@@ -1,0 +1,30 @@
+#![warn(missing_docs, rustdoc::broken_intra_doc_links)]
+#![deny(unsafe_code)]
+
+//! stygian-charon
+//!
+//! Defensive anti-bot diagnostics for Stygian.
+//! The crate classifies likely anti-bot providers from transaction evidence
+//! and from HTTP Archive (HAR) files.
+
+/// Provider signature classification logic.
+pub mod classifier;
+/// HAR parsing and extraction utilities.
+pub mod har;
+/// Investigation reports and baseline/candidate diffing.
+pub mod investigation;
+/// Runtime policy planning based on investigation output.
+pub mod policy;
+/// Public types for transaction and report models.
+pub mod types;
+
+pub use classifier::{classify_har, classify_transaction};
+pub use investigation::{compare_reports, infer_requirements, investigate_har};
+pub use policy::{analyze_and_plan, build_runtime_policy};
+pub use types::{
+    AdapterStrategy, AntiBotProvider, AntiBotRequirement, Detection, ExecutionMode,
+    HarClassificationReport, HarRequestSummary, HostSummary, IntegrationRecommendation,
+    InvestigationBundle, InvestigationDiff, InvestigationReport, MarkerCount, ProviderScore,
+    RequirementLevel, RequirementsProfile, RuntimePolicy, SessionMode, TelemetryLevel,
+    TransactionView,
+};

--- a/crates/stygian-charon/src/lib.rs
+++ b/crates/stygian-charon/src/lib.rs
@@ -20,7 +20,7 @@ pub mod types;
 
 pub use classifier::{classify_har, classify_transaction};
 pub use investigation::{compare_reports, infer_requirements, investigate_har};
-pub use policy::{analyze_and_plan, build_runtime_policy};
+pub use policy::{analyze_and_plan, build_runtime_policy, plan_from_report};
 pub use types::{
     AdapterStrategy, AntiBotProvider, AntiBotRequirement, Detection, ExecutionMode,
     HarClassificationReport, HarRequestSummary, HostSummary, IntegrationRecommendation,

--- a/crates/stygian-charon/src/policy.rs
+++ b/crates/stygian-charon/src/policy.rs
@@ -85,14 +85,20 @@ pub fn build_runtime_policy(
 /// Returns [`har::HarError`] when the HAR payload is invalid or malformed.
 pub fn analyze_and_plan(har_json: &str) -> Result<InvestigationBundle, har::HarError> {
     let report = investigate_har(har_json)?;
+    Ok(plan_from_report(report))
+}
+
+/// Infer requirements and build a runtime policy from an existing investigation report.
+#[must_use]
+pub fn plan_from_report(report: InvestigationReport) -> InvestigationBundle {
     let requirements = infer_requirements(&report);
     let policy = build_runtime_policy(&report, &requirements);
 
-    Ok(InvestigationBundle {
+    InvestigationBundle {
         report,
         requirements,
         policy,
-    })
+    }
 }
 
 fn apply_strategy_defaults(policy: &mut RuntimePolicy, recommendation: &IntegrationRecommendation) {
@@ -204,5 +210,43 @@ mod tests {
         assert_eq!(policy.session_mode, SessionMode::Sticky);
         assert!(policy.sticky_session_ttl_secs.is_some());
         assert!(policy.risk_score > 0.0);
+    }
+
+    #[test]
+    fn plan_from_report_preserves_report_and_builds_bundle() {
+        let report = InvestigationReport {
+            page_title: Some("https://example.com".to_string()),
+            total_requests: 10,
+            blocked_requests: 4,
+            status_histogram: BTreeMap::from([(200, 6), (403, 4)]),
+            resource_type_histogram: BTreeMap::from([("document".to_string(), 10)]),
+            provider_histogram: BTreeMap::from([(AntiBotProvider::Cloudflare, 4)]),
+            marker_histogram: BTreeMap::from([
+                ("cf-ray".to_string(), 4),
+                ("__cf_bm".to_string(), 4),
+            ]),
+            top_markers: vec![
+                MarkerCount {
+                    marker: "cf-ray".to_string(),
+                    count: 4,
+                },
+                MarkerCount {
+                    marker: "__cf_bm".to_string(),
+                    count: 4,
+                },
+            ],
+            hosts: Vec::new(),
+            suspicious_requests: Vec::new(),
+            aggregate: Detection {
+                provider: AntiBotProvider::Cloudflare,
+                confidence: 0.8,
+                markers: vec!["cf-ray".to_string(), "__cf_bm".to_string()],
+            },
+        };
+
+        let bundle = plan_from_report(report.clone());
+        assert_eq!(bundle.report, report);
+        assert_eq!(bundle.requirements.provider, AntiBotProvider::Cloudflare);
+        assert_eq!(bundle.policy.execution_mode, ExecutionMode::Browser);
     }
 }

--- a/crates/stygian-charon/src/policy.rs
+++ b/crates/stygian-charon/src/policy.rs
@@ -1,0 +1,207 @@
+use std::collections::BTreeMap;
+
+use crate::har;
+use crate::investigation::{infer_requirements, investigate_har};
+use crate::types::{
+    AdapterStrategy, AntiBotProvider, ExecutionMode, IntegrationRecommendation,
+    InvestigationBundle, InvestigationReport, RequirementsProfile, RuntimePolicy, SessionMode,
+    TelemetryLevel,
+};
+
+/// Build a concrete runtime policy from an investigation report and inferred requirements.
+#[must_use]
+pub fn build_runtime_policy(
+    report: &InvestigationReport,
+    requirements: &RequirementsProfile,
+) -> RuntimePolicy {
+    let blocked_ratio = if report.total_requests == 0 {
+        0.0
+    } else {
+        to_f64(report.blocked_requests) / to_f64(report.total_requests)
+    };
+
+    let mut policy = RuntimePolicy {
+        execution_mode: ExecutionMode::Http,
+        session_mode: SessionMode::Stateless,
+        telemetry_level: TelemetryLevel::Standard,
+        rate_limit_rps: 3.0,
+        max_retries: 2,
+        backoff_base_ms: 250,
+        enable_warmup: false,
+        enforce_webrtc_proxy_only: false,
+        sticky_session_ttl_secs: None,
+        required_stygian_features: requirements
+            .recommendation
+            .required_stygian_features
+            .clone(),
+        config_hints: requirements.recommendation.config_hints.clone(),
+        risk_score: blocked_ratio,
+    };
+
+    apply_strategy_defaults(&mut policy, &requirements.recommendation);
+
+    let has_429 = report.status_histogram.get(&429).copied().unwrap_or(0) > 0;
+    if has_429 {
+        policy.rate_limit_rps = policy.rate_limit_rps.min(2.0);
+        policy.max_retries = policy.max_retries.max(3);
+        policy.backoff_base_ms = policy.backoff_base_ms.max(500);
+        policy
+            .config_hints
+            .insert("retry.respect_429".to_string(), "true".to_string());
+    }
+
+    if report.blocked_requests > 0 {
+        policy.telemetry_level = TelemetryLevel::Deep;
+        policy.config_hints.insert(
+            "charon.capture_block_template".to_string(),
+            "true".to_string(),
+        );
+    }
+
+    // Clamp and enrich risk score with provider confidence and blocked ratio.
+    let provider_weight = match requirements.provider {
+        AntiBotProvider::Unknown => 0.1,
+        AntiBotProvider::Cloudflare => 0.25,
+        AntiBotProvider::DataDome => 0.35,
+        AntiBotProvider::Akamai
+        | AntiBotProvider::PerimeterX
+        | AntiBotProvider::Kasada
+        | AntiBotProvider::FingerprintCom => 0.3,
+    };
+
+    let mut risk = blocked_ratio * 0.7 + requirements.confidence * provider_weight;
+    if has_429 {
+        risk += 0.1;
+    }
+    policy.risk_score = risk.clamp(0.0, 1.0);
+
+    policy
+}
+
+/// Perform HAR investigation, infer requirements, and produce a runtime policy in one call.
+///
+/// # Errors
+///
+/// Returns [`har::HarError`] when the HAR payload is invalid or malformed.
+pub fn analyze_and_plan(har_json: &str) -> Result<InvestigationBundle, har::HarError> {
+    let report = investigate_har(har_json)?;
+    let requirements = infer_requirements(&report);
+    let policy = build_runtime_policy(&report, &requirements);
+
+    Ok(InvestigationBundle {
+        report,
+        requirements,
+        policy,
+    })
+}
+
+fn apply_strategy_defaults(policy: &mut RuntimePolicy, recommendation: &IntegrationRecommendation) {
+    match recommendation.strategy {
+        AdapterStrategy::DirectHttp => {
+            policy.execution_mode = ExecutionMode::Http;
+            policy.session_mode = SessionMode::Stateless;
+            policy.rate_limit_rps = 4.0;
+        }
+        AdapterStrategy::BrowserStealth => {
+            policy.execution_mode = ExecutionMode::Browser;
+            policy.session_mode = SessionMode::Stateless;
+            policy.rate_limit_rps = 2.0;
+            policy.max_retries = 3;
+            policy.enable_warmup = true;
+            policy.enforce_webrtc_proxy_only = true;
+        }
+        AdapterStrategy::StickyProxy => {
+            policy.execution_mode = ExecutionMode::Browser;
+            policy.session_mode = SessionMode::Sticky;
+            policy.rate_limit_rps = 1.5;
+            policy.max_retries = 3;
+            policy.backoff_base_ms = 600;
+            policy.enable_warmup = true;
+            policy.enforce_webrtc_proxy_only = true;
+            policy.sticky_session_ttl_secs = Some(600);
+            policy
+                .required_stygian_features
+                .push("stygian-proxy".to_string());
+            policy
+                .config_hints
+                .insert("proxy.rotation".to_string(), "per-domain".to_string());
+        }
+        AdapterStrategy::SessionWarmup => {
+            policy.execution_mode = ExecutionMode::Browser;
+            policy.enable_warmup = true;
+            policy.rate_limit_rps = 2.0;
+            policy.max_retries = 2;
+        }
+        AdapterStrategy::InvestigateOnly => {
+            policy.execution_mode = ExecutionMode::Http;
+            policy.telemetry_level = TelemetryLevel::Deep;
+            policy.rate_limit_rps = 2.0;
+            policy.max_retries = 1;
+            policy
+                .config_hints
+                .insert("charon.mode".to_string(), "investigation".to_string());
+        }
+    }
+
+    dedupe_required_features(&mut policy.required_stygian_features);
+}
+
+fn dedupe_required_features(features: &mut Vec<String>) {
+    let mut seen = BTreeMap::new();
+    features.retain(|feature| seen.insert(feature.clone(), true).is_none());
+}
+
+#[allow(clippy::cast_precision_loss)]
+const fn to_f64(value: u64) -> f64 {
+    value as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use crate::types::{Detection, InvestigationReport, MarkerCount, RequirementsProfile};
+
+    use super::*;
+
+    #[test]
+    fn sticky_proxy_strategy_enables_sticky_policy() {
+        let report = InvestigationReport {
+            page_title: Some("https://example.com".to_string()),
+            total_requests: 100,
+            blocked_requests: 30,
+            status_histogram: BTreeMap::from([(403, 30)]),
+            resource_type_histogram: BTreeMap::new(),
+            provider_histogram: BTreeMap::new(),
+            top_markers: vec![MarkerCount {
+                marker: "x-datadome".to_string(),
+                count: 30,
+            }],
+            hosts: Vec::new(),
+            suspicious_requests: Vec::new(),
+            aggregate: Detection {
+                provider: AntiBotProvider::DataDome,
+                confidence: 0.9,
+                markers: vec!["x-datadome".to_string()],
+            },
+        };
+
+        let requirements = RequirementsProfile {
+            provider: AntiBotProvider::DataDome,
+            confidence: 0.9,
+            requirements: Vec::new(),
+            recommendation: IntegrationRecommendation {
+                strategy: AdapterStrategy::StickyProxy,
+                rationale: "test".to_string(),
+                required_stygian_features: vec!["stygian-browser".to_string()],
+                config_hints: BTreeMap::new(),
+            },
+        };
+
+        let policy = build_runtime_policy(&report, &requirements);
+        assert_eq!(policy.execution_mode, ExecutionMode::Browser);
+        assert_eq!(policy.session_mode, SessionMode::Sticky);
+        assert!(policy.sticky_session_ttl_secs.is_some());
+        assert!(policy.risk_score > 0.0);
+    }
+}

--- a/crates/stygian-charon/src/policy.rs
+++ b/crates/stygian-charon/src/policy.rs
@@ -173,6 +173,7 @@ mod tests {
             status_histogram: BTreeMap::from([(403, 30)]),
             resource_type_histogram: BTreeMap::new(),
             provider_histogram: BTreeMap::new(),
+            marker_histogram: BTreeMap::from([("x-datadome".to_string(), 30)]),
             top_markers: vec![MarkerCount {
                 marker: "x-datadome".to_string(),
                 count: 30,

--- a/crates/stygian-charon/src/types.rs
+++ b/crates/stygian-charon/src/types.rs
@@ -1,0 +1,283 @@
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// A simplified view of one HTTP transaction used for provider classification.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TransactionView {
+    /// Request URL.
+    pub url: String,
+    /// HTTP status code.
+    pub status: u16,
+    /// Response headers (lower/upper case are normalized by the classifier).
+    pub response_headers: BTreeMap<String, String>,
+    /// Optional response body snippet.
+    pub response_body_snippet: Option<String>,
+}
+
+/// Known anti-bot providers recognized by the classifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum AntiBotProvider {
+    /// `DataDome`.
+    DataDome,
+    /// Cloudflare bot/challenge stack.
+    Cloudflare,
+    /// Akamai bot manager indicators.
+    Akamai,
+    /// Human Security / `PerimeterX` indicators.
+    PerimeterX,
+    /// Kasada indicators.
+    Kasada,
+    /// Fingerprint.com markers.
+    FingerprintCom,
+    /// Catch-all when no provider-specific signatures were found.
+    Unknown,
+}
+
+/// Classification result with evidence markers.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Detection {
+    /// Most likely provider.
+    pub provider: AntiBotProvider,
+    /// Simple confidence score in [0.0, 1.0].
+    pub confidence: f64,
+    /// Marker strings that matched.
+    pub markers: Vec<String>,
+}
+
+/// Scorecard for one provider.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ProviderScore {
+    /// Provider represented by this score.
+    pub provider: AntiBotProvider,
+    /// Weighted score from marker matches.
+    pub score: u32,
+    /// Evidence used to produce the score.
+    pub markers: Vec<String>,
+}
+
+/// Minimal per-request summary extracted from a HAR file.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HarRequestSummary {
+    /// URL requested.
+    pub url: String,
+    /// HTTP status code.
+    pub status: u16,
+    /// Best-effort resource type from HAR metadata.
+    pub resource_type: Option<String>,
+    /// Detection result for this request.
+    pub detection: Detection,
+}
+
+/// Full HAR classification report.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HarClassificationReport {
+    /// URL/title from HAR page metadata when available.
+    pub page_title: Option<String>,
+    /// Summary classification for all entries.
+    pub aggregate: Detection,
+    /// Request-level classification outputs.
+    pub requests: Vec<HarRequestSummary>,
+}
+
+/// Frequency count for a normalized marker string.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MarkerCount {
+    /// Marker text.
+    pub marker: String,
+    /// Number of requests where the marker appears.
+    pub count: u64,
+}
+
+/// Aggregated request metrics per host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HostSummary {
+    /// Hostname extracted from request URL.
+    pub host: String,
+    /// Total requests observed for this host.
+    pub total_requests: u64,
+    /// Requests that returned HTTP 403 or 429.
+    pub blocked_requests: u64,
+}
+
+/// Full-featured HAR investigation output suitable for diffs and alerting.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InvestigationReport {
+    /// URL/title from HAR page metadata when available.
+    pub page_title: Option<String>,
+    /// Total requests in the capture.
+    pub total_requests: u64,
+    /// Count of blocked/challenged requests (403/429).
+    pub blocked_requests: u64,
+    /// Status-code histogram.
+    pub status_histogram: BTreeMap<u16, u64>,
+    /// Resource-type histogram from HAR metadata.
+    pub resource_type_histogram: BTreeMap<String, u64>,
+    /// Provider histogram inferred from signatures.
+    pub provider_histogram: BTreeMap<AntiBotProvider, u64>,
+    /// Most frequent signature markers.
+    pub top_markers: Vec<MarkerCount>,
+    /// Top hosts by request volume.
+    pub hosts: Vec<HostSummary>,
+    /// Suspicious requests (blocked/challenged or with known provider markers).
+    pub suspicious_requests: Vec<HarRequestSummary>,
+    /// Aggregate provider classification.
+    pub aggregate: Detection,
+}
+
+/// Delta between a baseline report and a candidate report.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InvestigationDiff {
+    /// Baseline request count.
+    pub baseline_total_requests: u64,
+    /// Candidate request count.
+    pub candidate_total_requests: u64,
+    /// Baseline blocked requests.
+    pub baseline_blocked_requests: u64,
+    /// Candidate blocked requests.
+    pub candidate_blocked_requests: u64,
+    /// Candidate blocked ratio minus baseline blocked ratio.
+    pub blocked_ratio_delta: f64,
+    /// Whether blocked ratio increased by at least 2 percentage points.
+    pub likely_regression: bool,
+    /// Provider count delta: candidate minus baseline.
+    pub provider_delta: BTreeMap<AntiBotProvider, i64>,
+    /// New markers observed in candidate but not baseline.
+    pub new_markers: Vec<String>,
+}
+
+/// Severity/importance level for an inferred operational requirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum RequirementLevel {
+    /// Helpful, but usually not mandatory.
+    Low,
+    /// Strongly recommended for reliable automation.
+    Medium,
+    /// Typically required to avoid frequent blocks/challenges.
+    High,
+}
+
+/// One inferred operational requirement derived from telemetry.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AntiBotRequirement {
+    /// Stable identifier for the requirement.
+    pub id: String,
+    /// Human-friendly requirement title.
+    pub title: String,
+    /// Why this requirement appears to matter.
+    pub why: String,
+    /// Marker evidence or metrics supporting the inference.
+    pub evidence: Vec<String>,
+    /// Estimated requirement importance.
+    pub level: RequirementLevel,
+}
+
+/// High-level integration strategy for Stygian execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AdapterStrategy {
+    /// Standard HTTP adapter path appears sufficient.
+    DirectHttp,
+    /// Browser-backed execution is recommended.
+    BrowserStealth,
+    /// Sticky session + proxy continuity should be applied.
+    StickyProxy,
+    /// Warm-up/session priming before data collection is advised.
+    SessionWarmup,
+    /// Unknown/ambiguous conditions: keep in investigation mode.
+    InvestigateOnly,
+}
+
+/// Suggested Stygian integration plan derived from investigation signals.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IntegrationRecommendation {
+    /// Selected strategy.
+    pub strategy: AdapterStrategy,
+    /// Why this strategy was selected.
+    pub rationale: String,
+    /// Suggested feature flags/components for Stygian wiring.
+    pub required_stygian_features: Vec<String>,
+    /// Suggested runtime configuration hints.
+    pub config_hints: BTreeMap<String, String>,
+}
+
+/// Provider-aware operational profile and integration guidance.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RequirementsProfile {
+    /// Aggregate inferred provider.
+    pub provider: AntiBotProvider,
+    /// Confidence for the provider assignment.
+    pub confidence: f64,
+    /// Inferred operational requirements.
+    pub requirements: Vec<AntiBotRequirement>,
+    /// Suggested Stygian integration strategy.
+    pub recommendation: IntegrationRecommendation,
+}
+
+/// High-level execution mode for a target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExecutionMode {
+    /// Standard HTTP adapters.
+    Http,
+    /// Browser-backed execution.
+    Browser,
+}
+
+/// Session persistence mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SessionMode {
+    /// No explicit session persistence.
+    Stateless,
+    /// Reuse a sticky proxy/session identity.
+    Sticky,
+}
+
+/// Recommended anti-bot telemetry level.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TelemetryLevel {
+    /// Minimal telemetry.
+    Basic,
+    /// Normal diagnostics.
+    Standard,
+    /// Deep diagnostics and marker tracking.
+    Deep,
+}
+
+/// Concrete runtime policy that can be mapped to Stygian config.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimePolicy {
+    /// Recommended execution mode.
+    pub execution_mode: ExecutionMode,
+    /// Recommended session mode.
+    pub session_mode: SessionMode,
+    /// Recommended telemetry level.
+    pub telemetry_level: TelemetryLevel,
+    /// Requests per second budget.
+    pub rate_limit_rps: f64,
+    /// Max retries per request.
+    pub max_retries: u32,
+    /// Baseline backoff in milliseconds.
+    pub backoff_base_ms: u64,
+    /// Whether warm-up navigation/requests are recommended.
+    pub enable_warmup: bool,
+    /// Whether browser context should block WebRTC non-proxied paths.
+    pub enforce_webrtc_proxy_only: bool,
+    /// Suggested sticky-session TTL in seconds (if relevant).
+    pub sticky_session_ttl_secs: Option<u64>,
+    /// Required Stygian features/components.
+    pub required_stygian_features: Vec<String>,
+    /// Additional hints mapped by key.
+    pub config_hints: BTreeMap<String, String>,
+    /// Composite risk score in [0.0, 1.0].
+    pub risk_score: f64,
+}
+
+/// End-to-end result from HAR analysis, requirements inference, and policy planning.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct InvestigationBundle {
+    /// Parsed/aggregated investigation report.
+    pub report: InvestigationReport,
+    /// Inferred requirements profile.
+    pub requirements: RequirementsProfile,
+    /// Planned runtime policy.
+    pub policy: RuntimePolicy,
+}

--- a/crates/stygian-charon/src/types.rs
+++ b/crates/stygian-charon/src/types.rs
@@ -115,6 +115,8 @@ pub struct InvestigationReport {
     pub resource_type_histogram: BTreeMap<String, u64>,
     /// Provider histogram inferred from signatures.
     pub provider_histogram: BTreeMap<AntiBotProvider, u64>,
+    /// Full marker histogram inferred from signatures.
+    pub marker_histogram: BTreeMap<String, u64>,
     /// Most frequent signature markers.
     pub top_markers: Vec<MarkerCount>,
     /// Top hosts by request volume.


### PR DESCRIPTION
## Summary

Adds a JSON-driven polymorphic behavior adapter to `stygian-browser` and introduces the new `stygian-charon` crate for HAR-based investigation and policy classification.

### stygian-browser: Polymorphic Behavior Adapter

- **`PolymorphicBehaviorAdapter`** — dispatches across three adapter shapes from a single JSON input:
  - `RuntimePolicy` — execution mode, session mode, telemetry level
  - `InvestigationBundle` — policy + fingerprint + escalation hints derived from a Charon investigation
  - `DirectOverrides` — explicit per-field config overrides (stealth level, proxy, viewport, user agent, etc.)
- **`BrowserBehaviorAdapter` trait** — extensible port for downstream adapter implementors
- **`AppliedBehaviorPlan`** — typed result carrying the resolved `BrowserConfig` and metadata

### stygian-browser: MCP Tool

- **`browser_apply_behavior_json`** — new MCP tool; parses a behavior JSON object, applies it to `BrowserConfig`, and optionally binds the resolved plan to a live session
- **`browser_humanize`** — now falls back to the session's bound behavior plan `interaction_level` when no explicit `level` arg is provided
- README updated with MCP Behavior Policy Usage section and example payloads

### stygian-charon (new crate)

- `RuntimePolicy`, `InvestigationBundle`, `AdapterStrategy` domain types
- HAR parsing (`har.rs`) and request/response classifier (`classifier.rs`)
- Investigation orchestration module
- `investigation-bundle.schema.json` and output structure documentation

### Other

- `*.har` added to `.gitignore`
- Config validation tests isolated from environment variables