### PR TITLE
docs: update changelog for acquisition-runner branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,6 @@ Temporary Items
 tasks/
 plan*.toml
 IMPLEMENTATION_PLAN*.md
-PROGRESS*.md
 
 # =============================================================================
 # mdBook — generated book output (built from book/src/ via `mdbook build book`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `stygian-browser`: opinionated acquisition runner core with deterministic escalation
+  ladders and terminal failure bundles for timeout/setup-failure paths
+- `stygian-charon`: deterministic runtime-policy mapping layer for acquisition strategy
+  selection
+- `stygian-browser (mcp)`: new high-level tool `browser_acquire_and_extract` with
+  explicit mode validation and compact diagnostics payloads
+- `stygian-graph`: optional acquisition bridge for browser nodes, gated behind the
+  `acquisition-runner` feature and node-level `acquisition` opt-in block
+- `docs`: new developer handoff document
+  `docs/acquisition-runner-refactor-guide.md` covering T59-T63 architecture,
+  contracts, compatibility boundaries, and migration guidance
+
+### Changed
+
+- `book/mcp`: `pipeline_run` documentation now reflects post-refactor browser behavior:
+  browser nodes execute only when acquisition opt-in is configured and the feature is
+  enabled; otherwise they remain non-breaking and are skipped
+- `book/mcp`: added production MCP security baseline guidance (PII redaction,
+  input/output guardrails, exfiltration controls, RBAC/logging/runbook)
+- `docs/progress`: consolidated browser/integrations/stealth-v3 progress visibility
+  into workspace-level `PROGRESS.md` and reconciled stale open task statuses where
+  implementation evidence exists
+- `workspace`: `.gitignore` updated as part of branch housekeeping
+
+### Fixed
+
+- `stygian-browser` and `stygian-graph`: strict clippy compliance fixes across
+  acquisition-runner and graph bridge implementation paths
+- `stygian-graph`: callback future Send/Sync bound issues resolved in MCP pipeline
+  execution paths for acquisition bridge integration
+
+### Documentation
+
+- `README`/guides: runner-first acquisition mode guidance and compatibility notes
+  updated across workspace docs, including graph and MCP references
+- `examples`: added runner-focused usage references for mode selection and graph
+  opt-in integration (`examples/acquisition-runner-modes.md`,
+  `examples/acquisition-runner-graph-opt-in.toml`)
+
 ## [0.9.6] - 2026-04-23
 
 ### Added

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -122,7 +122,7 @@
 | Task | Status | Notes |
 |---|---|---|
 | T59 — Acquisition runner core in stygian-browser | `[x]` | Added `acquisition` runner facade, deterministic ladders, and stage failure bundles |
-| T60 — Map charon runtime policy to acquisition strategy | `[ ]` | Defined in `tasks/T60-charon-policy-mapping.md` |
+| T60 — Map charon runtime policy to acquisition strategy | `[x]` | Added deterministic policy-to-acquisition mapping layer in stygian-charon |
 | T61 — Add browser_acquire_and_extract MCP tool | `[ ]` | Defined in `tasks/T61-mcp-acquire-extract-tool.md` |
 | T62 — Optional stygian-graph acquisition bridge | `[ ]` | Additive and opt-in only; defined in `tasks/T62-graph-optional-bridge.md` |
 | T63 — Runner-first docs and compatibility checks | `[ ]` | Defined in `tasks/T63-runner-docs-compat.md` |
@@ -146,3 +146,4 @@
 - T54: `extract_all_with_fallback` and `extract_resilient` live inside the `#[cfg(feature = "extract")] impl PageHandle` block in `page.rs`. For resilient skipping, match on `ExtractionError::Missing { .. }` and `continue`; propagate all other variants as hard `BrowserError::ExtractionFailed`. Unit tests for the new methods can be `#[cfg(feature = "extract")]` inside the existing `mod tests` block — no live browser needed for error-variant classification tests.
 - T52: `ProxyCapabilities` cannot derive `Eq` when it includes `Option<f32>` (use `PartialEq` only). Capability filtering should reuse the same candidate construction path as normal proxy selection (`storage.list_with_metrics()` + health/circuit maps) to avoid stale or non-existent manager fields. Strict clippy (`-D warnings`) requires explicit `ProxyCapabilities::default()` in proxy literals and panic-safe assertions (`first()` over indexing) in tests.
 - T59: `AcquisitionRunner::run` should return a terminal result object instead of `Result` so timeout/setup-failure paths can be represented as deterministic failure bundles. For sticky browser retries, `BrowserPool::acquire_for(host)` gives opt-in context pinning without changing pool internals.
+- T60: keep runtime-policy mapping pure and deterministic (`map_policy_hints`), with explicit defaults for partial input and clamped risk score to prevent undefined strategy transitions.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -123,7 +123,7 @@
 |---|---|---|
 | T59 — Acquisition runner core in stygian-browser | `[x]` | Added `acquisition` runner facade, deterministic ladders, and stage failure bundles |
 | T60 — Map charon runtime policy to acquisition strategy | `[x]` | Added deterministic policy-to-acquisition mapping layer in stygian-charon |
-| T61 — Add browser_acquire_and_extract MCP tool | `[ ]` | Defined in `tasks/T61-mcp-acquire-extract-tool.md` |
+| T61 — Add browser_acquire_and_extract MCP tool | `[x]` | Added `browser_acquire_and_extract` MCP tool wired to `AcquisitionRunner` with schema + validation + output-shape tests |
 | T62 — Optional stygian-graph acquisition bridge | `[ ]` | Additive and opt-in only; defined in `tasks/T62-graph-optional-bridge.md` |
 | T63 — Runner-first docs and compatibility checks | `[ ]` | Defined in `tasks/T63-runner-docs-compat.md` |
 
@@ -147,3 +147,4 @@
 - T52: `ProxyCapabilities` cannot derive `Eq` when it includes `Option<f32>` (use `PartialEq` only). Capability filtering should reuse the same candidate construction path as normal proxy selection (`storage.list_with_metrics()` + health/circuit maps) to avoid stale or non-existent manager fields. Strict clippy (`-D warnings`) requires explicit `ProxyCapabilities::default()` in proxy literals and panic-safe assertions (`first()` over indexing) in tests.
 - T59: `AcquisitionRunner::run` should return a terminal result object instead of `Result` so timeout/setup-failure paths can be represented as deterministic failure bundles. For sticky browser retries, `BrowserPool::acquire_for(host)` gives opt-in context pinning without changing pool internals.
 - T60: keep runtime-policy mapping pure and deterministic (`map_policy_hints`), with explicit defaults for partial input and clamped risk score to prevent undefined strategy transitions.
+- T61: MCP tool wrappers around runner enums should parse string modes with explicit validation and emit a compact `diagnostics` bundle (`attempted`, `timed_out`, `failure_count`, `failures`) to keep failure paths stable for downstream automation.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -115,6 +115,20 @@
 
 ---
 
+## Phase 10 — Opinionated Acquisition Runner Refactor
+
+> Depends on: branch scaffolding complete (`feat/acquisition-runner-refactor` + phase branches)
+
+| Task | Status | Notes |
+|---|---|---|
+| T59 — Acquisition runner core in stygian-browser | `[x]` | Added `acquisition` runner facade, deterministic ladders, and stage failure bundles |
+| T60 — Map charon runtime policy to acquisition strategy | `[ ]` | Defined in `tasks/T60-charon-policy-mapping.md` |
+| T61 — Add browser_acquire_and_extract MCP tool | `[ ]` | Defined in `tasks/T61-mcp-acquire-extract-tool.md` |
+| T62 — Optional stygian-graph acquisition bridge | `[ ]` | Additive and opt-in only; defined in `tasks/T62-graph-optional-bridge.md` |
+| T63 — Runner-first docs and compatibility checks | `[ ]` | Defined in `tasks/T63-runner-docs-compat.md` |
+
+---
+
 ## Accumulated Learnings
 
 - T49: strict clippy settings (`-D warnings`, pedantic profile) require `writeln!` over `write!(...\n)`, const-friendly constructors, and panic/index-safe tests even under `#[ignore]`.
@@ -131,3 +145,4 @@
 - T53: `#[serde(untagged)]` on an enum is the cleanest way to handle multiple JSON envelope shapes. Use `Option<u16>` for port fields and `Option<String>` for address fields with `#[serde(default)]` to be tolerant of partial records. Builder methods on a fetcher (`.with_limit()`, `.with_protocol_filter()`, `.with_country_filter()`) should each carry `#[must_use]` and append query params lazily in a `request_url()` helper — keeps the `fetch()` impl clean.
 - T54: `extract_all_with_fallback` and `extract_resilient` live inside the `#[cfg(feature = "extract")] impl PageHandle` block in `page.rs`. For resilient skipping, match on `ExtractionError::Missing { .. }` and `continue`; propagate all other variants as hard `BrowserError::ExtractionFailed`. Unit tests for the new methods can be `#[cfg(feature = "extract")]` inside the existing `mod tests` block — no live browser needed for error-variant classification tests.
 - T52: `ProxyCapabilities` cannot derive `Eq` when it includes `Option<f32>` (use `PartialEq` only). Capability filtering should reuse the same candidate construction path as normal proxy selection (`storage.list_with_metrics()` + health/circuit maps) to avoid stale or non-existent manager fields. Strict clippy (`-D warnings`) requires explicit `ProxyCapabilities::default()` in proxy literals and panic-safe assertions (`first()` over indexing) in tests.
+- T59: `AcquisitionRunner::run` should return a terminal result object instead of `Result` so timeout/setup-failure paths can be represented as deterministic failure bundles. For sticky browser retries, `BrowserPool::acquire_for(host)` gives opt-in context pinning without changing pool internals.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -125,7 +125,7 @@
 | T60 — Map charon runtime policy to acquisition strategy | `[x]` | Added deterministic policy-to-acquisition mapping layer in stygian-charon |
 | T61 — Add browser_acquire_and_extract MCP tool | `[x]` | Added `browser_acquire_and_extract` MCP tool wired to `AcquisitionRunner` with schema + validation + output-shape tests |
 | T62 — Optional stygian-graph acquisition bridge | `[x]` | Additive and opt-in only; feature-gated `acquisition-runner` bridge for browser nodes via opt-in `acquisition` block |
-| T63 — Runner-first docs and compatibility checks | `[ ]` | Defined in `tasks/T63-runner-docs-compat.md` |
+| T63 — Runner-first docs and compatibility checks | `[x]` | Added runner-first mode docs/examples, migration notes, and downstream graph compatibility checklist/CI guidance |
 
 ---
 
@@ -149,3 +149,4 @@
 - T60: keep runtime-policy mapping pure and deterministic (`map_policy_hints`), with explicit defaults for partial input and clamped risk score to prevent undefined strategy transitions.
 - T61: MCP tool wrappers around runner enums should parse string modes with explicit validation and emit a compact `diagnostics` bundle (`attempted`, `timed_out`, `failure_count`, `failures`) to keep failure paths stable for downstream automation.
 - T62: Keep graph bridge behavior opt-in by requiring a node-level `acquisition` table for `browser` services; without that block, legacy `pipeline_run` skip semantics stay unchanged.
+- T63: Keep runner-first docs anchored to live MCP/API contracts (`browser_acquire_and_extract`, `fast|resilient|hostile|investigate`, `acquisition-runner` feature) and document compatibility as additive opt-in so downstream graph users can validate both legacy and bridge paths in CI.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -124,7 +124,7 @@
 | T59 — Acquisition runner core in stygian-browser | `[x]` | Added `acquisition` runner facade, deterministic ladders, and stage failure bundles |
 | T60 — Map charon runtime policy to acquisition strategy | `[x]` | Added deterministic policy-to-acquisition mapping layer in stygian-charon |
 | T61 — Add browser_acquire_and_extract MCP tool | `[x]` | Added `browser_acquire_and_extract` MCP tool wired to `AcquisitionRunner` with schema + validation + output-shape tests |
-| T62 — Optional stygian-graph acquisition bridge | `[ ]` | Additive and opt-in only; defined in `tasks/T62-graph-optional-bridge.md` |
+| T62 — Optional stygian-graph acquisition bridge | `[x]` | Additive and opt-in only; feature-gated `acquisition-runner` bridge for browser nodes via opt-in `acquisition` block |
 | T63 — Runner-first docs and compatibility checks | `[ ]` | Defined in `tasks/T63-runner-docs-compat.md` |
 
 ---
@@ -148,3 +148,4 @@
 - T59: `AcquisitionRunner::run` should return a terminal result object instead of `Result` so timeout/setup-failure paths can be represented as deterministic failure bundles. For sticky browser retries, `BrowserPool::acquire_for(host)` gives opt-in context pinning without changing pool internals.
 - T60: keep runtime-policy mapping pure and deterministic (`map_policy_hints`), with explicit defaults for partial input and clamped risk score to prevent undefined strategy transitions.
 - T61: MCP tool wrappers around runner enums should parse string modes with explicit validation and emit a compact `diagnostics` bundle (`attempted`, `timed_out`, `failure_count`, `failures`) to keep failure paths stable for downstream automation.
+- T62: Keep graph bridge behavior opt-in by requiring a node-level `acquisition` table for `browser` services; without that block, legacy `pipeline_run` skip semantics stay unchanged.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -129,6 +129,152 @@
 
 ---
 
+## Browser Track (Consolidated from PROGRESS-BROWSER.md)
+
+> This section consolidates browser-crate progress into the workspace-level tracker.
+
+### Browser Phase 1 — Foundation & Core Types
+
+| Task | Status | Notes |
+|---|---|---|
+| Browser T01 — Browser Crate Setup & Core Error Types | `[x]` | Rich error types with context, StealthLevel, PoolConfig, env var overrides |
+| Browser T02 — Browser Instance Lifecycle Management | `[x]` | BrowserInstance wrapper, launch, health check, graceful shutdown, timeout handling |
+| Browser T03 — Runtime.Enable CDP Leak Protection (Critical) | `[x]` | CdpProtection, AddBinding/IsolatedWorld/EnableDisable modes, source URL patching, env config |
+
+### Browser Phase 2 — Browser Pool & Resource Management
+
+| Task | Status | Notes |
+|---|---|---|
+| Browser T04 — Browser Instance Pool with Warmup | `[x]` | BrowserPool with warm queue, Semaphore, LRU eviction, acquire timeout, PoolStats |
+| Browser T05 — Page & Context Management | `[x]` | PageHandle with drop cleanup, ResourceFilter, WaitUntil, navigate, wait_for_selector, eval, save_cookies |
+
+### Browser Phase 3 — Anti-Detection & Fingerprint Protection
+
+| Task | Status | Notes |
+|---|---|---|
+| Browser T06 — Navigator Properties Spoofing | `[x]` | StealthProfile + NavigatorProfile injection script, Object.defineProperty, WebGL getParameter override |
+| Browser T07 — Fingerprint Injection (Canvas, WebGL, Fonts, Audio) | `[x]` | Fingerprint::random() with curated value pools, injection_script() coverage |
+| Browser T08 — Fingerprint Profile Generation with Statistical Distribution | `[x]` | Weighted profile selection, coherence validation, OS/browser alignment |
+| Browser T09 — WebRTC IP Spoofing & Proxy Integration | `[x]` | WebRtcPolicy modes, proxy/geolocation alignment, proxy bypass list support |
+
+### Browser Phase 4 — Human-Like Behavioral Mimicry
+
+| Task | Status | Notes |
+|---|---|---|
+| Browser T10 — Human-Like Mouse Movement (Distance-Aware Trajectories) | `[x]` | Bezier trajectories, jitter, deterministic seed support |
+| Browser T11 — Human-Like Typing Patterns | `[x]` | |
+| Browser T12 — Random Human-Like Page Interactions | `[x]` | |
+
+### Browser Phase 5 — Stealth Profiles & Configuration
+
+| Task | Status | Notes |
+|---|---|---|
+| Browser T13 — Configurable Stealth Levels (None, Basic, Advanced) | `[x]` | Stealth application wiring in browser new-page flow |
+| Browser T14 — Comprehensive Configuration Management | `[x]` | CDP mode/source controls, validation, JSON load/save, builder coverage |
+
+### Browser Phase 6 — Testing & Detection Validation
+
+| Task | Status | Notes |
+|---|---|---|
+| Browser T15 — Comprehensive Unit Test Suite | `[x]` | Property tests and broad module test coverage |
+| Browser T16 — Integration Tests with Real Browser | `[x]` | Real Chromium integration tests, user-data-dir wiring fixes |
+| Browser T17 — Anti-Detection Test Suite (Real-World Validation) | `[x]` | Property-level and live-network `#[ignore]` suites |
+
+### Browser Phase 7 — Documentation & Examples
+
+| Task | Status | Notes |
+|---|---|---|
+| Browser T18 — Comprehensive API Documentation | `[x]` | Public API docs clean with zero rustdoc warnings |
+| Browser T19 — Example Programs | `[x]` | Multiple browser examples compile and run paths documented |
+| Browser T20 — Architecture & Design Documentation | `[x]` | Architecture docs with diagrams, module map, and operational notes |
+
+### Browser Phase 8 — Advanced Features & Integrations
+
+| Task | Status | Notes |
+|---|---|---|
+| Browser T21 — Chrome DevTools MCP Integration | `[x]` | MCP JSON-RPC support, feature-gated server, tool/resource coverage |
+| Browser T22 — Performance Monitoring & Metrics | `[x]` | Prometheus-style metrics and pool instrumentation |
+| Browser T23 — Session Persistence & Cookie Management | `[x]` | Session snapshot save/restore with TTL and file I/O |
+| Browser T24 — Browser Session Recording & Debug Tools | `[x]` | CDP event logging, HAR export, NDJSON export |
+
+---
+
+## Integrations Track (Consolidated from PROGRESS-INTEGRATIONS.md)
+
+### Integrations Phase 1 — DataSink Port Trait
+
+| Task | Status | Notes |
+|---|---|---|
+| T25 — DataSinkPort Trait Definition | `[x]` | `DataSinkPort`, `SinkRecord`, `SinkReceipt`, `DataSinkError` in ports layer; unit tests added |
+
+### Integrations Phase 2 — Scrape Exchange Adapter
+
+| Task | Status | Notes |
+|---|---|---|
+| T26 — Scrape Exchange REST API Client | `[x]` | Implemented in `stygian-graph` (`adapters/scrape_exchange.rs`) with typed client/config/auth paths |
+| T27 — Scrape Exchange DataSinkPort Implementation | `[x]` | Depends on T26 |
+| T28 — Scrape Exchange WebSocket Real-Time Feed | `[x]` | Implemented in `stygian-graph` (`ScrapeExchangeFeed`) with adapter tests and live ignored test |
+
+### Integrations Phase 3 — Documentation & Examples
+
+| Task | Status | Notes |
+|---|---|---|
+| T29 — Integration Documentation & Examples | `[x]` | Added docs + examples (`book/src/graph/scrape-exchange.md`, `examples/scrape-exchange-*.toml`) |
+
+---
+
+## Stealth v3 Track (Consolidated from PROGRESS-STEALTH-V3.md)
+
+### Stealth v3 Phase 1 — Fingerprint Noise Pipeline
+
+| Task | Status | Notes |
+|---|---|---|
+| T37 — Deterministic noise seed engine | `[x]` | Foundation for downstream noise modules |
+| T38 — Canvas fingerprint noise injection | `[x]` | `canvas_noise` module wired in advanced stealth path |
+| T39 — WebGL parameter spoofing | `[x]` | `webgl_noise` module + profile-driven injection wired in stealth |
+| T40 — Audio fingerprint noise injection | `[x]` | `audio_noise` module + deterministic script injection |
+| T41 — ClientRects & TextMetrics noise | `[x]` | `rects_noise` module with layout/text metrics overrides |
+
+### Stealth v3 Phase 2 — Navigator & Device Coherence
+
+| Task | Status | Notes |
+|---|---|---|
+| T42 — Fingerprint profile config system | `[x]` | `FingerprintProfile` presets and coherence-first profile selection implemented |
+| T43 — Navigator property coherence | `[x]` | `navigator_coherence` module integrated into advanced stealth flow |
+| T44 — Performance timing protection | `[x]` | `timing_noise` module provides configurable timing jitter controls |
+
+### Stealth v3 Phase 3 — CDP Leak Hardening
+
+| Task | Status | Notes |
+|---|---|---|
+| T45 — CDP leak hardening (advanced detection) | `[x]` | CDP hardening paths (`AddBinding` modes, stack sanitization) implemented |
+
+### Stealth v3 Phase 4 — TLS & Network Validation
+
+| Task | Status | Notes |
+|---|---|---|
+| T46 — TLS fingerprint validation suite | `[x]` | TLS/JA3/JA4 validation support present (`tls_validation` + MCP diagnostic surfaces) |
+
+### Stealth v3 Phase 5 — Peripheral Detection Surfaces
+
+| Task | Status | Notes |
+|---|---|---|
+| T47 — Peripheral detection surface hardening | `[x]` | `peripheral_stealth` covers iframe/visibility/camera/port/rAF surfaces |
+
+### Stealth v3 Phase 6 — Anti-Bot Validation Suite
+
+| Task | Status | Notes |
+|---|---|---|
+| T48 — Anti-bot service validation suite | `[x]` | Validation framework + Tiered anti-bot targets in browser validation/tests |
+
+### Stealth v3 Phase 7 — VM-Driven Stealth Hardening
+
+| Task | Status | Notes |
+|---|---|---|
+| T58 — DataDome VM coherence hardening | `[x]` | Advanced coherent default path + diagnostics + known limitations + Tier1 baseline checks |
+
+---
+
 ## Accumulated Learnings
 
 - T49: strict clippy settings (`-D warnings`, pedantic profile) require `writeln!` over `write!(...\n)`, const-friendly constructors, and panic/index-safe tests even under `#[ignore]`.
@@ -150,3 +296,4 @@
 - T61: MCP tool wrappers around runner enums should parse string modes with explicit validation and emit a compact `diagnostics` bundle (`attempted`, `timed_out`, `failure_count`, `failures`) to keep failure paths stable for downstream automation.
 - T62: Keep graph bridge behavior opt-in by requiring a node-level `acquisition` table for `browser` services; without that block, legacy `pipeline_run` skip semantics stay unchanged.
 - T63: Keep runner-first docs anchored to live MCP/API contracts (`browser_acquire_and_extract`, `fast|resilient|hostile|investigate`, `acquisition-runner` feature) and document compatibility as additive opt-in so downstream graph users can validate both legacy and bridge paths in CI.
+- T58 closure: Tier1 non-regression checks now support optional `STYGIAN_TIER1_BASELINE_CREEPJS` and `STYGIAN_TIER1_BASELINE_BROWSERSCAN` baselines to detect score drops while keeping live validation runnable without pinned scores.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ MCP tool matrix (aggregator surface):
 | Namespace | Representative tools | Purpose |
 | --------- | -------------------- | ------- |
 | `graph_*` | `graph_scrape`, `graph_scrape_rest`, `graph_scrape_graphql`, `graph_pipeline_validate`, `graph_pipeline_run` | HTTP/API/feed scraping and DAG execution |
-| `browser_*` | `browser_acquire`, `browser_navigate`, `browser_query`, `browser_extract`, `browser_extract_with_fallback`, `browser_extract_resilient`, `browser_release` | Headless browser automation and structured extraction |
+| `browser_*` | `browser_acquire`, `browser_acquire_and_extract`, `browser_navigate`, `browser_query`, `browser_extract`, `browser_extract_with_fallback`, `browser_extract_resilient`, `browser_release` | Headless browser automation and structured extraction |
 | `proxy_*` | `proxy_add`, `proxy_remove`, `proxy_pool_stats`, `proxy_acquire`, `proxy_acquire_for_domain`, `proxy_acquire_with_capabilities`, `proxy_fetch_freelist`, `proxy_fetch_freeapiproxies`, `proxy_release` | Proxy pool management, capability-aware leasing, and feed bootstrap |
 | cross-crate | `scrape_proxied`, `browser_proxied` | End-to-end orchestration across graph/browser/proxy |
 
@@ -202,6 +202,44 @@ stygian-graph = { version = "*", features = ["full"] }
 stygian-browser = { version = "*", features = ["stealth", "tls-config"] }
 stygian-proxy = { version = "*", features = ["browser", "socks"] }
 ```
+
+### Runner-First Acquisition (Recommended)
+
+For hostile or variable targets, prefer a single `browser_acquire_and_extract` call over manually chaining low-level browser tools.
+
+Mode guide:
+
+| Mode | When to use |
+| ---- | ----------- |
+| `fast` | Low-friction pages where speed matters most |
+| `resilient` | Default for general production scraping with moderate anti-bot pressure |
+| `hostile` | High-friction targets needing heavier escalation and retries |
+| `investigate` | Diagnostics-first runs to understand which strategy tier succeeds |
+
+End-to-end example:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "browser_acquire_and_extract",
+    "arguments": {
+      "url": "https://example.com/products",
+      "mode": "resilient",
+      "wait_for_selector": "article.product",
+      "extraction_js": "Array.from(document.querySelectorAll('article.product h2')).map(n => n.textContent?.trim()).filter(Boolean)",
+      "total_timeout_secs": 45
+    }
+  }
+}
+```
+
+Migration note (old path vs runner path):
+
+- Old low-level path: `browser_acquire` -> `browser_navigate` -> `browser_eval`/`browser_extract` -> `browser_release`.
+- New runner path: one `browser_acquire_and_extract` call with `mode` and optional `wait_for_selector`/`extraction_js`.
+- Keep low-level tools when you need custom multi-step interaction. Use runner-first for deterministic escalation with fewer moving parts.
 
 ---
 

--- a/book/src/mcp/browser-tools.md
+++ b/book/src/mcp/browser-tools.md
@@ -1,6 +1,6 @@
 # Browser MCP Tools
 
-`stygian-browser` exposes thirteen tools for headless browser automation plus a pool stats tool.
+`stygian-browser` exposes browser automation tools including a runner-first acquisition path plus pool stats.
 
 ---
 
@@ -31,6 +31,15 @@ browser_acquire → browser_navigate → browser_eval / browser_screenshot / bro
 
 Always call `browser_release` when done; unreleased sessions hold a browser process open
 against the pool's `max` limit.
+
+Runner-first alternative:
+
+```
+browser_acquire_and_extract
+```
+
+Use this tool when you want acquisition strategy escalation and extraction in one call.
+The `mode` field accepts `fast`, `resilient`, `hostile`, and `investigate`.
 
 ---
 
@@ -517,6 +526,101 @@ Return current browser pool statistics. No parameters required.
   "available": 6
 }
 ```
+
+---
+
+### `browser_acquire_and_extract`
+
+Run the opinionated acquisition ladder and return extraction/content output from one call.
+
+| Parameter | Type | Required | Description |
+| --------- | ---- | -------- | ----------- |
+| `url` | string | ✓ | Target URL |
+| `mode` | string | ✓ | `fast` \| `resilient` \| `hostile` \| `investigate` |
+| `wait_for_selector` | string | | Optional selector gate for browser-stage success |
+| `selector_wait` | string | | Alias for `wait_for_selector` |
+| `extraction_js` | string | | Optional JavaScript extraction expression |
+| `total_timeout_secs` | number | | Optional wall-clock timeout for full run (must be > 0) |
+
+**Returns:**
+
+```json
+{
+  "success": true,
+  "strategy_used": "browser_light_stealth",
+  "final_url": "https://example.com",
+  "status_code": 200,
+  "extracted": {
+    "title": "Example Domain"
+  },
+  "html_excerpt": "<!doctype html><html>...",
+  "diagnostics": {
+    "attempted": ["direct_http", "browser_light_stealth"],
+    "timed_out": false,
+    "failure_count": 0,
+    "failures": []
+  }
+}
+```
+
+Mode examples:
+
+`fast`
+
+```json
+{
+  "name": "browser_acquire_and_extract",
+  "arguments": {
+    "url": "https://example.com",
+    "mode": "fast"
+  }
+}
+```
+
+`resilient`
+
+```json
+{
+  "name": "browser_acquire_and_extract",
+  "arguments": {
+    "url": "https://example.com/catalog",
+    "mode": "resilient",
+    "wait_for_selector": "article.item"
+  }
+}
+```
+
+`hostile`
+
+```json
+{
+  "name": "browser_acquire_and_extract",
+  "arguments": {
+    "url": "https://example.com/challenge",
+    "mode": "hostile",
+    "wait_for_selector": "main",
+    "total_timeout_secs": 60
+  }
+}
+```
+
+`investigate`
+
+```json
+{
+  "name": "browser_acquire_and_extract",
+  "arguments": {
+    "url": "https://example.com",
+    "mode": "investigate",
+    "extraction_js": "({ title: document.title, url: location.href })"
+  }
+}
+```
+
+Migration note:
+
+- Old low-level path: `browser_acquire` -> `browser_navigate` -> `browser_eval`/`browser_extract` -> `browser_release`.
+- New runner path: one `browser_acquire_and_extract` call with explicit `mode`.
 
 ---
 

--- a/book/src/mcp/graph-tools.md
+++ b/book/src/mcp/graph-tools.md
@@ -215,9 +215,9 @@ service lists, detected cycles, and computed topological execution order.
 Parse, validate, and execute a TOML pipeline DAG.
 
 - Nodes of kind `http`, `rest`, `graphql`, `sitemap`, and `rss` are executed directly.
-- Nodes of kind `ai` or `browser` are recorded in the `skipped` list (they require credentials
-  and a live browser that are not available inside the MCP server). Pass their output as
-  pre-computed `params` if needed, or use `browser_acquire` + `browser_navigate` directly.
+- Nodes of kind `ai` are recorded in the `skipped` list.
+- Nodes of kind `browser` are executed only when the node includes an opt-in `acquisition` block
+  and `stygian-graph` is built with the `acquisition-runner` feature; otherwise they are skipped.
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |
@@ -235,6 +235,28 @@ Parse, validate, and execute a TOML pipeline DAG.
   "errors": {}
 }
 ```
+
+Browser acquisition opt-in example:
+
+```toml
+[[services]]
+name = "browser_service"
+kind = "browser"
+
+[[nodes]]
+name = "render"
+service = "browser_service"
+url = "https://example.com"
+
+[nodes.params.acquisition]
+enabled = true
+mode = "resilient"
+wait_for_selector = "main"
+total_timeout_secs = 45
+```
+
+If the `acquisition` block is omitted, browser nodes remain non-breaking and are added to
+`skipped` as before.
 
 **Example pipeline TOML:**
 

--- a/book/src/mcp/graph-tools.md
+++ b/book/src/mcp/graph-tools.md
@@ -217,7 +217,8 @@ Parse, validate, and execute a TOML pipeline DAG.
 - Nodes of kind `http`, `rest`, `graphql`, `sitemap`, and `rss` are executed directly.
 - Nodes of kind `ai` are recorded in the `skipped` list.
 - Nodes of kind `browser` are executed only when the node includes an opt-in `acquisition` block
-  and `stygian-graph` is built with the `acquisition-runner` feature; otherwise they are skipped.
+  **and** `stygian-graph` is built with the `acquisition-runner` feature. If either condition is
+  missing — no `acquisition` block, or the feature is not enabled — the node is skipped.
 
 | Parameter | Type | Required | Description |
 | --------- | ---- | -------- | ----------- |

--- a/book/src/mcp/overview.md
+++ b/book/src/mcp/overview.md
@@ -139,3 +139,48 @@ channel. Control verbosity via the `RUST_LOG` environment variable:
 ```sh
 RUST_LOG=stygian_mcp=debug,stygian_graph=info ./stygian-mcp
 ```
+
+---
+
+## Production Security Baseline
+
+Production MCP deployments should enforce controls at the gateway/server boundary, not only
+inside individual agents.
+
+### 1) PII redaction before model context
+
+- Redact or pseudonymize sensitive fields on tool outputs before they enter model context.
+- Apply centrally so every agent/tool path gets the same treatment.
+- Keep an auditable trail of redaction events for compliance reviews.
+
+### 2) Input guardrails (prompt-injection resistance)
+
+- Scan untrusted content (user input, retrieved pages, tool outputs) for instruction-like payloads.
+- Flag jailbreak-style text and imperative operation prompts in data channels.
+- Use stricter checks for low-trust sources (scraped/public content).
+
+### 3) Output guardrails (egress control)
+
+- Validate tool call parameters before write/send/delete operations.
+- Enforce output schema and content policy checks.
+- Block PII leakage in agent-visible responses and outbound tool payloads.
+
+### 4) Data exfiltration prevention (session-level)
+
+- Monitor tool-call sequences, not only single calls.
+- Alert on unusual read volume and cross-tool data movement (read -> send/write).
+- Restrict communication destinations to approved allow-lists.
+
+### 5) Access and incident readiness
+
+- Apply least-privilege RBAC per tool.
+- Log each tool call with agent identity, request, response, and guardrail outcome.
+- Maintain a runbook to quickly suspend agent/tool access without full downtime.
+
+Operational checklist:
+
+- PII redaction active for sensitive tool outputs.
+- Input guardrails enabled and tuned for source trust levels.
+- Output guardrails enabled for all write-capable tools.
+- Destination allow-lists enforced for outbound channels.
+- Session traceability enabled for exfiltration/anomaly investigations.

--- a/crates/stygian-browser/src/acquisition.rs
+++ b/crates/stygian-browser/src/acquisition.rs
@@ -489,7 +489,12 @@ impl AcquisitionRunner {
             }
         };
 
-        let response = match client.get(&request.url).send().await {
+        let response = match client
+            .get(&request.url)
+            .timeout(request.request_timeout)
+            .send()
+            .await
+        {
             Ok(response) => response,
             Err(err) => {
                 return StageOutcome::Failure(StageFailure {

--- a/crates/stygian-browser/src/acquisition.rs
+++ b/crates/stygian-browser/src/acquisition.rs
@@ -1,0 +1,644 @@
+//! Opinionated acquisition runner with deterministic escalation.
+//!
+//! The runner executes a mode-specific strategy ladder and returns a terminal
+//! [`AcquisitionResult`] for every request, including setup-failure and timeout
+//! paths.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::BrowserError;
+use crate::page::WaitUntil;
+use crate::BrowserPool;
+
+/// Opinionated acquisition mode for the escalation ladder.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcquisitionMode {
+    /// Prioritize lowest-latency paths.
+    Fast,
+    /// Favor reliability with broader escalation.
+    Resilient,
+    /// Start from stronger anti-bot paths.
+    Hostile,
+    /// Enter from a policy-guided start point.
+    Investigate,
+}
+
+/// Strategy stage attempted by the acquisition runner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StrategyUsed {
+    /// Plain HTTP fetch.
+    DirectHttp,
+    /// HTTP fetch using a TLS-profiled client.
+    TlsProfiledHttp,
+    /// Browser session with opinionated light-stealth defaults.
+    BrowserLightStealth,
+    /// Browser session scoped to a sticky context id.
+    StickyProxyBrowserSession,
+    /// Policy-guided entry marker for investigation mode.
+    InvestigateEntry,
+}
+
+/// One acquisition request.
+#[derive(Debug, Clone)]
+pub struct AcquisitionRequest {
+    /// Target URL.
+    pub url: String,
+    /// Acquisition mode.
+    pub mode: AcquisitionMode,
+    /// Optional selector that must be present for browser-stage success.
+    pub wait_for_selector: Option<String>,
+    /// Optional JavaScript extraction expression evaluated in browser stages.
+    pub extraction_js: Option<String>,
+    /// Hard wall-clock timeout for the whole acquisition attempt.
+    pub total_timeout: Duration,
+    /// Per-navigation timeout for browser stages.
+    pub navigation_timeout: Duration,
+    /// Per-request timeout for HTTP stages.
+    pub request_timeout: Duration,
+    /// Maximum HTML bytes captured into `html_excerpt`.
+    pub html_excerpt_bytes: usize,
+    /// Optional policy-guided stage that `Investigate` mode starts from.
+    pub investigate_start: Option<StrategyUsed>,
+}
+
+impl Default for AcquisitionRequest {
+    fn default() -> Self {
+        Self {
+            url: String::new(),
+            mode: AcquisitionMode::Resilient,
+            wait_for_selector: None,
+            extraction_js: None,
+            total_timeout: Duration::from_secs(45),
+            navigation_timeout: Duration::from_secs(30),
+            request_timeout: Duration::from_secs(15),
+            html_excerpt_bytes: 4_096,
+            investigate_start: None,
+        }
+    }
+}
+
+/// Failure class recorded per strategy stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StageFailureKind {
+    /// Stage initialization/setup failed.
+    Setup,
+    /// Stage hit a timeout.
+    Timeout,
+    /// Stage reached a known anti-bot block class.
+    Blocked,
+    /// Transport/runtime failure.
+    Transport,
+    /// Extraction/validation failure.
+    Extraction,
+}
+
+/// Captured failure record for one stage.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StageFailure {
+    /// Stage where the failure happened.
+    pub strategy: StrategyUsed,
+    /// Coarse failure kind.
+    pub kind: StageFailureKind,
+    /// Compact diagnostic message.
+    pub message: String,
+}
+
+/// Terminal acquisition result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcquisitionResult {
+    /// `true` when any stage satisfied success criteria.
+    pub success: bool,
+    /// Stage that produced the terminal success, if any.
+    pub strategy_used: Option<StrategyUsed>,
+    /// Ordered stage attempts.
+    pub attempted: Vec<StrategyUsed>,
+    /// Final URL observed from the successful stage.
+    pub final_url: Option<String>,
+    /// HTTP status code observed from the successful stage.
+    pub status_code: Option<u16>,
+    /// Best-effort HTML excerpt from the successful stage.
+    pub html_excerpt: Option<String>,
+    /// Optional extraction payload.
+    pub extracted: Option<Value>,
+    /// Failure bundle collected across stages.
+    pub failures: Vec<StageFailure>,
+    /// `true` when the wall-clock timeout fired before completion.
+    pub timed_out: bool,
+}
+
+impl AcquisitionResult {
+    const fn empty() -> Self {
+        Self {
+            success: false,
+            strategy_used: None,
+            attempted: Vec::new(),
+            final_url: None,
+            status_code: None,
+            html_excerpt: None,
+            extracted: None,
+            failures: Vec::new(),
+            timed_out: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct StageSuccess {
+    final_url: Option<String>,
+    status_code: Option<u16>,
+    html_excerpt: Option<String>,
+    extracted: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+enum StageOutcome {
+    Success(StageSuccess),
+    Failure(StageFailure),
+}
+
+/// Runner facade for opinionated acquisition.
+#[derive(Clone)]
+pub struct AcquisitionRunner {
+    pool: Arc<BrowserPool>,
+}
+
+impl AcquisitionRunner {
+    /// Create a new acquisition runner.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use stygian_browser::{AcquisitionRunner, BrowserConfig, BrowserPool};
+    ///
+    /// # async fn run() -> stygian_browser::Result<()> {
+    /// let pool = BrowserPool::new(BrowserConfig::default()).await?;
+    /// let _runner = AcquisitionRunner::new(pool);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn new(pool: Arc<BrowserPool>) -> Self {
+        Self { pool }
+    }
+
+    /// Return the deterministic stage ladder for a mode.
+    ///
+    /// Investigation mode starts at `investigate_start` when provided.
+    #[must_use]
+    pub fn strategy_ladder(
+        mode: AcquisitionMode,
+        investigate_start: Option<StrategyUsed>,
+    ) -> Vec<StrategyUsed> {
+        let mut stages = match mode {
+            AcquisitionMode::Fast => vec![
+                StrategyUsed::DirectHttp,
+                StrategyUsed::TlsProfiledHttp,
+                StrategyUsed::BrowserLightStealth,
+            ],
+            AcquisitionMode::Resilient => vec![
+                StrategyUsed::DirectHttp,
+                StrategyUsed::TlsProfiledHttp,
+                StrategyUsed::BrowserLightStealth,
+                StrategyUsed::StickyProxyBrowserSession,
+            ],
+            AcquisitionMode::Hostile => vec![
+                StrategyUsed::BrowserLightStealth,
+                StrategyUsed::StickyProxyBrowserSession,
+                StrategyUsed::TlsProfiledHttp,
+                StrategyUsed::DirectHttp,
+            ],
+            AcquisitionMode::Investigate => {
+                let start = investigate_start.unwrap_or(StrategyUsed::BrowserLightStealth);
+                vec![
+                    StrategyUsed::InvestigateEntry,
+                    start,
+                    StrategyUsed::StickyProxyBrowserSession,
+                    StrategyUsed::TlsProfiledHttp,
+                ]
+            }
+        };
+
+        dedupe_preserve_order(&mut stages);
+        stages
+    }
+
+    /// Execute the acquisition ladder and return a terminal result.
+    ///
+    /// This method never panics and always returns an [`AcquisitionResult`],
+    /// including timeout and setup-failure paths.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use stygian_browser::{AcquisitionMode, AcquisitionRequest, AcquisitionRunner, BrowserConfig, BrowserPool};
+    ///
+    /// # async fn run() -> stygian_browser::Result<()> {
+    /// let pool = BrowserPool::new(BrowserConfig::default()).await?;
+    /// let runner = AcquisitionRunner::new(pool);
+    /// let request = AcquisitionRequest {
+    ///     url: "https://example.com".to_string(),
+    ///     mode: AcquisitionMode::Resilient,
+    ///     ..AcquisitionRequest::default()
+    /// };
+    /// let _result = runner.run(request).await;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn run(&self, request: AcquisitionRequest) -> AcquisitionResult {
+        let timeout = request.total_timeout;
+        let mut result = match tokio::time::timeout(timeout, self.run_inner(&request)).await {
+            Ok(inner) => inner,
+            Err(_) => {
+                let mut timed_out = AcquisitionResult::empty();
+                timed_out.timed_out = true;
+                timed_out.failures.push(StageFailure {
+                    strategy: StrategyUsed::InvestigateEntry,
+                    kind: StageFailureKind::Timeout,
+                    message: format!("acquisition timed out after {}ms", timeout.as_millis()),
+                });
+                timed_out
+            }
+        };
+
+        if result.success {
+            result
+        } else {
+            // Guarantee deterministic terminal output for all unsuccessful runs.
+            if result.failures.is_empty() {
+                result.failures.push(StageFailure {
+                    strategy: StrategyUsed::InvestigateEntry,
+                    kind: StageFailureKind::Transport,
+                    message: "acquisition ended without stage output".to_string(),
+                });
+            }
+            result
+        }
+    }
+
+    async fn run_inner(&self, request: &AcquisitionRequest) -> AcquisitionResult {
+        let mut result = AcquisitionResult::empty();
+        let ladder = Self::strategy_ladder(request.mode, request.investigate_start);
+        let started = Instant::now();
+
+        for strategy in ladder {
+            if started.elapsed() >= request.total_timeout {
+                result.timed_out = true;
+                result.failures.push(StageFailure {
+                    strategy,
+                    kind: StageFailureKind::Timeout,
+                    message: "wall-clock timeout reached before stage execution".to_string(),
+                });
+                break;
+            }
+
+            result.attempted.push(strategy);
+            match self.execute_stage(strategy, request).await {
+                StageOutcome::Success(success) => {
+                    result.success = true;
+                    result.strategy_used = Some(strategy);
+                    result.final_url = success.final_url;
+                    result.status_code = success.status_code;
+                    result.html_excerpt = success.html_excerpt;
+                    result.extracted = success.extracted;
+                    break;
+                }
+                StageOutcome::Failure(failure) => result.failures.push(failure),
+            }
+        }
+
+        result
+    }
+
+    async fn execute_stage(&self, strategy: StrategyUsed, request: &AcquisitionRequest) -> StageOutcome {
+        match strategy {
+            StrategyUsed::DirectHttp => self.run_http_stage(request, false).await,
+            StrategyUsed::TlsProfiledHttp => self.run_http_stage(request, true).await,
+            StrategyUsed::BrowserLightStealth => self.run_browser_stage(request, false).await,
+            StrategyUsed::StickyProxyBrowserSession => self.run_browser_stage(request, true).await,
+            StrategyUsed::InvestigateEntry => StageOutcome::Failure(StageFailure {
+                strategy,
+                kind: StageFailureKind::Setup,
+                message: "investigate entry marker: awaiting policy-guided start".to_string(),
+            }),
+        }
+    }
+
+    async fn run_browser_stage(&self, request: &AcquisitionRequest, sticky: bool) -> StageOutcome {
+        let strategy = if sticky {
+            StrategyUsed::StickyProxyBrowserSession
+        } else {
+            StrategyUsed::BrowserLightStealth
+        };
+
+        let handle_result = if sticky {
+            let context = host_hint(&request.url).unwrap_or_else(|| "default".to_string());
+            self.pool.acquire_for(&context).await
+        } else {
+            self.pool.acquire().await
+        };
+
+        let handle = match handle_result {
+            Ok(handle) => handle,
+            Err(err) => {
+                return StageOutcome::Failure(StageFailure {
+                    strategy,
+                    kind: StageFailureKind::Setup,
+                    message: format!("browser acquire failed: {err}"),
+                });
+            }
+        };
+
+        let page_result = async {
+            let browser = handle.browser().ok_or_else(|| BrowserError::ConfigError("browser handle already released".to_string()))?;
+            let mut page = browser.new_page().await?;
+            page.navigate(
+                &request.url,
+                WaitUntil::DomContentLoaded,
+                request.navigation_timeout,
+            )
+            .await?;
+
+            if let Some(selector) = &request.wait_for_selector {
+                page.wait_for_selector(selector, request.navigation_timeout)
+                    .await?;
+            }
+
+            let extracted = match request.extraction_js.as_deref() {
+                Some(script) => Some(page.eval::<Value>(script).await.map_err(|err| BrowserError::ScriptExecutionFailed {
+                    script: script.to_string(),
+                    reason: err.to_string(),
+                })?),
+                None => None,
+            };
+
+            let html = page.content().await?;
+            let final_url = page.url().await.ok();
+            let status_code = page.status_code().ok().flatten();
+            let html_excerpt = truncate_html(&html, request.html_excerpt_bytes);
+
+            drop(page);
+
+            Ok::<StageSuccess, BrowserError>(StageSuccess {
+                final_url,
+                status_code,
+                html_excerpt: Some(html_excerpt),
+                extracted,
+            })
+        }
+        .await;
+
+        handle.release().await;
+
+        match page_result {
+            Ok(success) => {
+                if is_block_status(success.status_code) {
+                    StageOutcome::Failure(StageFailure {
+                        strategy,
+                        kind: StageFailureKind::Blocked,
+                        message: format!("blocked status during browser stage: {:?}", success.status_code),
+                    })
+                } else {
+                    StageOutcome::Success(success)
+                }
+            }
+            Err(err) => StageOutcome::Failure(StageFailure {
+                strategy,
+                kind: classify_browser_error(&err),
+                message: err.to_string(),
+            }),
+        }
+    }
+
+    async fn run_http_stage(&self, request: &AcquisitionRequest, tls_profiled: bool) -> StageOutcome {
+        if request.wait_for_selector.is_some() || request.extraction_js.is_some() {
+            return StageOutcome::Failure(StageFailure {
+                strategy: if tls_profiled {
+                    StrategyUsed::TlsProfiledHttp
+                } else {
+                    StrategyUsed::DirectHttp
+                },
+                kind: StageFailureKind::Extraction,
+                message: "HTTP stages cannot satisfy selector/extraction requirements".to_string(),
+            });
+        }
+
+        self.run_http_stage_impl(request, tls_profiled).await
+    }
+
+    #[cfg(feature = "tls-config")]
+    async fn run_http_stage_impl(&self, request: &AcquisitionRequest, tls_profiled: bool) -> StageOutcome {
+        use crate::tls::{build_profiled_client_preset, CHROME_131};
+
+        let strategy = if tls_profiled {
+            StrategyUsed::TlsProfiledHttp
+        } else {
+            StrategyUsed::DirectHttp
+        };
+
+        let client = if tls_profiled {
+            match build_profiled_client_preset(&CHROME_131, None) {
+                Ok(client) => client,
+                Err(err) => {
+                    return StageOutcome::Failure(StageFailure {
+                        strategy,
+                        kind: StageFailureKind::Setup,
+                        message: format!("tls-profiled client setup failed: {err}"),
+                    });
+                }
+            }
+        } else {
+            match reqwest::Client::builder()
+                .timeout(request.request_timeout)
+                .cookie_store(true)
+                .build()
+            {
+                Ok(client) => client,
+                Err(err) => {
+                    return StageOutcome::Failure(StageFailure {
+                        strategy,
+                        kind: StageFailureKind::Setup,
+                        message: format!("http client setup failed: {err}"),
+                    });
+                }
+            }
+        };
+
+        let response = match client.get(&request.url).send().await {
+            Ok(response) => response,
+            Err(err) => {
+                return StageOutcome::Failure(StageFailure {
+                    strategy,
+                    kind: if err.is_timeout() {
+                        StageFailureKind::Timeout
+                    } else {
+                        StageFailureKind::Transport
+                    },
+                    message: err.to_string(),
+                });
+            }
+        };
+
+        let status_code = Some(response.status().as_u16());
+        let final_url = Some(response.url().to_string());
+        let html = match response.text().await {
+            Ok(text) => text,
+            Err(err) => {
+                return StageOutcome::Failure(StageFailure {
+                    strategy,
+                    kind: StageFailureKind::Transport,
+                    message: format!("response body read failed: {err}"),
+                });
+            }
+        };
+
+        if is_block_status(status_code) {
+            return StageOutcome::Failure(StageFailure {
+                strategy,
+                kind: StageFailureKind::Blocked,
+                message: format!("blocked status from HTTP stage: {status_code:?}"),
+            });
+        }
+
+        StageOutcome::Success(StageSuccess {
+            final_url,
+            status_code,
+            html_excerpt: Some(truncate_html(&html, request.html_excerpt_bytes)),
+            extracted: None,
+        })
+    }
+
+    #[cfg(not(feature = "tls-config"))]
+    async fn run_http_stage_impl(&self, _request: &AcquisitionRequest, tls_profiled: bool) -> StageOutcome {
+        let strategy = if tls_profiled {
+            StrategyUsed::TlsProfiledHttp
+        } else {
+            StrategyUsed::DirectHttp
+        };
+        StageOutcome::Failure(StageFailure {
+            strategy,
+            kind: StageFailureKind::Setup,
+            message: "HTTP acquisition requires the `tls-config` feature".to_string(),
+        })
+    }
+}
+
+fn dedupe_preserve_order(stages: &mut Vec<StrategyUsed>) {
+    let mut seen = Vec::new();
+    stages.retain(|stage| {
+        if seen.contains(stage) {
+            false
+        } else {
+            seen.push(*stage);
+            true
+        }
+    });
+}
+
+fn classify_browser_error(error: &BrowserError) -> StageFailureKind {
+    match error {
+        BrowserError::Timeout { .. } => StageFailureKind::Timeout,
+        BrowserError::NavigationFailed { reason, .. } if reason.contains("selector") => {
+            StageFailureKind::Blocked
+        }
+        BrowserError::ScriptExecutionFailed { .. } => StageFailureKind::Extraction,
+        BrowserError::ConfigError(_) | BrowserError::PoolExhausted { .. } => StageFailureKind::Setup,
+        BrowserError::ProxyUnavailable { .. }
+        | BrowserError::ConnectionError { .. }
+        | BrowserError::CdpError { .. }
+        | BrowserError::LaunchFailed { .. }
+        | BrowserError::NavigationFailed { .. }
+        | BrowserError::Io(_) 
+        | BrowserError::StaleNode { .. } => StageFailureKind::Transport,
+        #[cfg(feature = "extract")]
+        BrowserError::ExtractionFailed(_) => StageFailureKind::Extraction,
+    }
+}
+
+fn is_block_status(status: Option<u16>) -> bool {
+    matches!(status, Some(401 | 403 | 407 | 429 | 503))
+}
+
+fn truncate_html(html: &str, max_bytes: usize) -> String {
+    if html.len() <= max_bytes {
+        return html.to_string();
+    }
+
+    let mut out = String::new();
+    for ch in html.chars() {
+        if out.len() + ch.len_utf8() > max_bytes {
+            break;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn host_hint(url: &str) -> Option<String> {
+    let without_scheme = url.split_once("://")?.1;
+    let authority = without_scheme.split('/').next()?;
+    let host = authority.rsplit('@').next()?.split(':').next()?;
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_ascii_lowercase())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ladder_is_deterministic_for_modes() {
+        assert_eq!(
+            AcquisitionRunner::strategy_ladder(AcquisitionMode::Fast, None),
+            vec![
+                StrategyUsed::DirectHttp,
+                StrategyUsed::TlsProfiledHttp,
+                StrategyUsed::BrowserLightStealth,
+            ]
+        );
+
+        assert_eq!(
+            AcquisitionRunner::strategy_ladder(
+                AcquisitionMode::Investigate,
+                Some(StrategyUsed::StickyProxyBrowserSession)
+            ),
+            vec![
+                StrategyUsed::InvestigateEntry,
+                StrategyUsed::StickyProxyBrowserSession,
+                StrategyUsed::TlsProfiledHttp,
+            ]
+        );
+    }
+
+    #[test]
+    fn block_statuses_are_classified() {
+        assert!(is_block_status(Some(403)));
+        assert!(is_block_status(Some(429)));
+        assert!(!is_block_status(Some(200)));
+        assert!(!is_block_status(None));
+    }
+
+    #[test]
+    fn host_hint_extracts_authority() {
+        assert_eq!(
+            host_hint("https://user:pass@example.com:8443/path"),
+            Some("example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn truncate_html_respects_utf8_boundaries() {
+        let src = "abc😀def";
+        let out = truncate_html(src, 5);
+        assert_eq!(out, "abc");
+    }
+}

--- a/crates/stygian-browser/src/acquisition.rs
+++ b/crates/stygian-browser/src/acquisition.rs
@@ -10,9 +10,9 @@ use std::time::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use crate::BrowserPool;
 use crate::error::BrowserError;
 use crate::page::WaitUntil;
-use crate::BrowserPool;
 
 /// Opinionated acquisition mode for the escalation ladder.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -184,7 +184,7 @@ impl AcquisitionRunner {
     /// # }
     /// ```
     #[must_use]
-    pub fn new(pool: Arc<BrowserPool>) -> Self {
+    pub const fn new(pool: Arc<BrowserPool>) -> Self {
         Self { pool }
     }
 
@@ -253,9 +253,9 @@ impl AcquisitionRunner {
     /// ```
     pub async fn run(&self, request: AcquisitionRequest) -> AcquisitionResult {
         let timeout = request.total_timeout;
-        let mut result = match tokio::time::timeout(timeout, self.run_inner(&request)).await {
-            Ok(inner) => inner,
-            Err(_) => {
+        let mut result = tokio::time::timeout(timeout, self.run_inner(&request))
+            .await
+            .unwrap_or_else(|_| {
                 let mut timed_out = AcquisitionResult::empty();
                 timed_out.timed_out = true;
                 timed_out.failures.push(StageFailure {
@@ -264,12 +264,9 @@ impl AcquisitionRunner {
                     message: format!("acquisition timed out after {}ms", timeout.as_millis()),
                 });
                 timed_out
-            }
-        };
+            });
 
-        if result.success {
-            result
-        } else {
+        if !result.success {
             // Guarantee deterministic terminal output for all unsuccessful runs.
             if result.failures.is_empty() {
                 result.failures.push(StageFailure {
@@ -278,8 +275,9 @@ impl AcquisitionRunner {
                     message: "acquisition ended without stage output".to_string(),
                 });
             }
-            result
         }
+
+        result
     }
 
     async fn run_inner(&self, request: &AcquisitionRequest) -> AcquisitionResult {
@@ -316,7 +314,11 @@ impl AcquisitionRunner {
         result
     }
 
-    async fn execute_stage(&self, strategy: StrategyUsed, request: &AcquisitionRequest) -> StageOutcome {
+    async fn execute_stage(
+        &self,
+        strategy: StrategyUsed,
+        request: &AcquisitionRequest,
+    ) -> StageOutcome {
         match strategy {
             StrategyUsed::DirectHttp => self.run_http_stage(request, false).await,
             StrategyUsed::TlsProfiledHttp => self.run_http_stage(request, true).await,
@@ -356,7 +358,9 @@ impl AcquisitionRunner {
         };
 
         let page_result = async {
-            let browser = handle.browser().ok_or_else(|| BrowserError::ConfigError("browser handle already released".to_string()))?;
+            let browser = handle.browser().ok_or_else(|| {
+                BrowserError::ConfigError("browser handle already released".to_string())
+            })?;
             let mut page = browser.new_page().await?;
             page.navigate(
                 &request.url,
@@ -371,9 +375,11 @@ impl AcquisitionRunner {
             }
 
             let extracted = match request.extraction_js.as_deref() {
-                Some(script) => Some(page.eval::<Value>(script).await.map_err(|err| BrowserError::ScriptExecutionFailed {
-                    script: script.to_string(),
-                    reason: err.to_string(),
+                Some(script) => Some(page.eval::<Value>(script).await.map_err(|err| {
+                    BrowserError::ScriptExecutionFailed {
+                        script: script.to_string(),
+                        reason: err.to_string(),
+                    }
                 })?),
                 None => None,
             };
@@ -402,7 +408,10 @@ impl AcquisitionRunner {
                     StageOutcome::Failure(StageFailure {
                         strategy,
                         kind: StageFailureKind::Blocked,
-                        message: format!("blocked status during browser stage: {:?}", success.status_code),
+                        message: format!(
+                            "blocked status during browser stage: {:?}",
+                            success.status_code
+                        ),
                     })
                 } else {
                     StageOutcome::Success(success)
@@ -416,7 +425,11 @@ impl AcquisitionRunner {
         }
     }
 
-    async fn run_http_stage(&self, request: &AcquisitionRequest, tls_profiled: bool) -> StageOutcome {
+    async fn run_http_stage(
+        &self,
+        request: &AcquisitionRequest,
+        tls_profiled: bool,
+    ) -> StageOutcome {
         if request.wait_for_selector.is_some() || request.extraction_js.is_some() {
             return StageOutcome::Failure(StageFailure {
                 strategy: if tls_profiled {
@@ -433,8 +446,12 @@ impl AcquisitionRunner {
     }
 
     #[cfg(feature = "tls-config")]
-    async fn run_http_stage_impl(&self, request: &AcquisitionRequest, tls_profiled: bool) -> StageOutcome {
-        use crate::tls::{build_profiled_client_preset, CHROME_131};
+    async fn run_http_stage_impl(
+        &self,
+        request: &AcquisitionRequest,
+        tls_profiled: bool,
+    ) -> StageOutcome {
+        use crate::tls::{CHROME_131, build_profiled_client_preset};
 
         let strategy = if tls_profiled {
             StrategyUsed::TlsProfiledHttp
@@ -515,7 +532,11 @@ impl AcquisitionRunner {
     }
 
     #[cfg(not(feature = "tls-config"))]
-    async fn run_http_stage_impl(&self, _request: &AcquisitionRequest, tls_profiled: bool) -> StageOutcome {
+    async fn run_http_stage_impl(
+        &self,
+        _request: &AcquisitionRequest,
+        tls_profiled: bool,
+    ) -> StageOutcome {
         let strategy = if tls_profiled {
             StrategyUsed::TlsProfiledHttp
         } else {
@@ -548,20 +569,22 @@ fn classify_browser_error(error: &BrowserError) -> StageFailureKind {
             StageFailureKind::Blocked
         }
         BrowserError::ScriptExecutionFailed { .. } => StageFailureKind::Extraction,
-        BrowserError::ConfigError(_) | BrowserError::PoolExhausted { .. } => StageFailureKind::Setup,
+        BrowserError::ConfigError(_) | BrowserError::PoolExhausted { .. } => {
+            StageFailureKind::Setup
+        }
         BrowserError::ProxyUnavailable { .. }
         | BrowserError::ConnectionError { .. }
         | BrowserError::CdpError { .. }
         | BrowserError::LaunchFailed { .. }
         | BrowserError::NavigationFailed { .. }
-        | BrowserError::Io(_) 
+        | BrowserError::Io(_)
         | BrowserError::StaleNode { .. } => StageFailureKind::Transport,
         #[cfg(feature = "extract")]
         BrowserError::ExtractionFailed(_) => StageFailureKind::Extraction,
     }
 }
 
-fn is_block_status(status: Option<u16>) -> bool {
+const fn is_block_status(status: Option<u16>) -> bool {
     matches!(status, Some(401 | 403 | 407 | 429 | 503))
 }
 

--- a/crates/stygian-browser/src/acquisition.rs
+++ b/crates/stygian-browser/src/acquisition.rs
@@ -159,6 +159,7 @@ struct StageSuccess {
 
 #[derive(Debug, Clone)]
 enum StageOutcome {
+    Marker,
     Success(StageSuccess),
     Failure(StageFailure),
 }
@@ -253,13 +254,17 @@ impl AcquisitionRunner {
     /// ```
     pub async fn run(&self, request: AcquisitionRequest) -> AcquisitionResult {
         let timeout = request.total_timeout;
+        let timeout_strategy = Self::strategy_ladder(request.mode, request.investigate_start)
+            .into_iter()
+            .find(|strategy| *strategy != StrategyUsed::InvestigateEntry)
+            .unwrap_or(StrategyUsed::DirectHttp);
         let mut result = tokio::time::timeout(timeout, self.run_inner(&request))
             .await
             .unwrap_or_else(|_| {
                 let mut timed_out = AcquisitionResult::empty();
                 timed_out.timed_out = true;
                 timed_out.failures.push(StageFailure {
-                    strategy: StrategyUsed::InvestigateEntry,
+                    strategy: timeout_strategy,
                     kind: StageFailureKind::Timeout,
                     message: format!("acquisition timed out after {}ms", timeout.as_millis()),
                 });
@@ -270,7 +275,7 @@ impl AcquisitionRunner {
             // Guarantee deterministic terminal output for all unsuccessful runs.
             if result.failures.is_empty() {
                 result.failures.push(StageFailure {
-                    strategy: StrategyUsed::InvestigateEntry,
+                    strategy: timeout_strategy,
                     kind: StageFailureKind::Transport,
                     message: "acquisition ended without stage output".to_string(),
                 });
@@ -298,6 +303,7 @@ impl AcquisitionRunner {
 
             result.attempted.push(strategy);
             match self.execute_stage(strategy, request).await {
+                StageOutcome::Marker => {}
                 StageOutcome::Success(success) => {
                     result.success = true;
                     result.strategy_used = Some(strategy);
@@ -324,11 +330,7 @@ impl AcquisitionRunner {
             StrategyUsed::TlsProfiledHttp => self.run_http_stage(request, true).await,
             StrategyUsed::BrowserLightStealth => self.run_browser_stage(request, false).await,
             StrategyUsed::StickyProxyBrowserSession => self.run_browser_stage(request, true).await,
-            StrategyUsed::InvestigateEntry => StageOutcome::Failure(StageFailure {
-                strategy,
-                kind: StageFailureKind::Setup,
-                message: "investigate entry marker: awaiting policy-guided start".to_string(),
-            }),
+            StrategyUsed::InvestigateEntry => StageOutcome::Marker,
         }
     }
 

--- a/crates/stygian-browser/src/lib.rs
+++ b/crates/stygian-browser/src/lib.rs
@@ -67,11 +67,11 @@
 //! | [`webrtc`] | [`WebRtcConfig`], [`WebRtcPolicy`], [`ProxyLocation`] |
 //! | [`cdp_protection`] | CDP leak protection modes |
 
+pub mod acquisition;
 pub mod behavior_adapter;
 pub mod browser;
 pub mod cdp_protection;
 pub mod config;
-pub mod acquisition;
 pub mod error;
 pub mod page;
 pub mod pool;
@@ -152,13 +152,13 @@ pub mod session;
 
 pub mod recorder;
 
-pub use behavior_adapter::{
-    AdapterKind, AppliedBehaviorPlan, BehaviorInteractionLevel, BrowserBehaviorAdapter,
-    ExecutionMode, PolymorphicBehaviorAdapter, SessionMode, TelemetryLevel,
-};
 pub use acquisition::{
     AcquisitionMode, AcquisitionRequest, AcquisitionResult, AcquisitionRunner, StageFailure,
     StageFailureKind, StrategyUsed,
+};
+pub use behavior_adapter::{
+    AdapterKind, AppliedBehaviorPlan, BehaviorInteractionLevel, BrowserBehaviorAdapter,
+    ExecutionMode, PolymorphicBehaviorAdapter, SessionMode, TelemetryLevel,
 };
 pub use browser::BrowserInstance;
 pub use config::{BrowserConfig, HeadlessMode, StealthLevel};

--- a/crates/stygian-browser/src/lib.rs
+++ b/crates/stygian-browser/src/lib.rs
@@ -71,6 +71,7 @@ pub mod behavior_adapter;
 pub mod browser;
 pub mod cdp_protection;
 pub mod config;
+pub mod acquisition;
 pub mod error;
 pub mod page;
 pub mod pool;
@@ -154,6 +155,10 @@ pub mod recorder;
 pub use behavior_adapter::{
     AdapterKind, AppliedBehaviorPlan, BehaviorInteractionLevel, BrowserBehaviorAdapter,
     ExecutionMode, PolymorphicBehaviorAdapter, SessionMode, TelemetryLevel,
+};
+pub use acquisition::{
+    AcquisitionMode, AcquisitionRequest, AcquisitionResult, AcquisitionRunner, StageFailure,
+    StageFailureKind, StrategyUsed,
 };
 pub use browser::BrowserInstance;
 pub use config::{BrowserConfig, HeadlessMode, StealthLevel};

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -2733,6 +2733,8 @@ impl McpBrowserServer {
     }
 
     fn parse_acquisition_request(args: &Value) -> Result<AcquisitionRequest> {
+        const MAX_ACQUISITION_TIMEOUT_SECS: f64 = 86_400.0;
+
         let url = Self::require_str(args, "url")?;
         let mode_raw = Self::require_str(args, "mode")?;
         let mode = Self::parse_acquisition_mode(&mode_raw)?;
@@ -2749,10 +2751,16 @@ impl McpBrowserServer {
             .map(ToString::to_string);
 
         let total_timeout = match args.get("total_timeout_secs").and_then(Value::as_f64) {
-            Some(value) if value.is_finite() && value > 0.0 => Duration::from_secs_f64(value),
+            Some(value)
+                if value.is_finite() && value > 0.0 && value <= MAX_ACQUISITION_TIMEOUT_SECS =>
+            {
+                Duration::from_secs_f64(value)
+            }
             Some(_) => {
                 return Err(BrowserError::ConfigError(
-                    "total_timeout_secs must be a positive finite number".to_string(),
+                    format!(
+                        "total_timeout_secs must be a positive finite number <= {MAX_ACQUISITION_TIMEOUT_SECS}"
+                    ),
                 ));
             }
             None => AcquisitionRequest::default().total_timeout,

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -43,6 +43,7 @@
 //! | Tool | Parameters | Returns |
 //! | ------ | ----------- | --------- |
 //! | `browser_acquire` | `stealth_level?`, `tls_profile?`, `webrtc_policy?`, `cdp_fix_mode?`, `proxy?` | `session_id`, `requested_metadata` |
+//! | `browser_acquire_and_extract` | `url, mode, wait_for_selector?, extraction_js?, total_timeout_secs?` | `strategy_used, final_url, status_code, extracted?, html_excerpt?, diagnostics` |
 //! | `browser_navigate` | `session_id, url, timeout_secs?` | `title, url` |
 //! | `browser_eval` | `session_id, script` | `result: Value` |
 //! | `browser_screenshot` | `session_id` | `data: base64 PNG` |
@@ -86,7 +87,8 @@ use ulid::Ulid;
 use futures::StreamExt;
 
 use crate::{
-    BrowserConfig, BrowserHandle, BrowserPool,
+    AcquisitionMode, AcquisitionRequest, AcquisitionResult, AcquisitionRunner, BrowserConfig,
+    BrowserHandle, BrowserPool,
     behavior::{InteractionLevel, InteractionSimulator},
     behavior_adapter::{BehaviorInteractionLevel, PolymorphicBehaviorAdapter},
     config::StealthLevel,
@@ -266,6 +268,39 @@ static TOOL_DEFINITIONS: LazyLock<Vec<Value>> = LazyLock::new(|| {
                     "timeout_secs": { "type": "integer", "default": 30 }
                 },
                 "required": ["session_id", "url"]
+            }
+        }),
+        json!({
+            "name": "browser_acquire_and_extract",
+            "description": "Run the opinionated acquisition ladder and return structured extraction/content output in one call. Uses AcquisitionRunner facade with deterministic strategy escalation.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "url": { "type": "string", "description": "Target URL to acquire." },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["fast", "resilient", "hostile", "investigate"],
+                        "description": "Acquisition ladder mode."
+                    },
+                    "wait_for_selector": {
+                        "type": "string",
+                        "description": "Optional selector wait gate for browser-stage success."
+                    },
+                    "selector_wait": {
+                        "type": "string",
+                        "description": "Alias for wait_for_selector."
+                    },
+                    "extraction_js": {
+                        "type": "string",
+                        "description": "Optional JavaScript extraction expression evaluated in browser stages."
+                    },
+                    "total_timeout_secs": {
+                        "type": "number",
+                        "default": 45,
+                        "description": "Optional wall-clock timeout for the full acquisition run."
+                    }
+                },
+                "required": ["url", "mode"]
             }
         }),
         json!({
@@ -816,6 +851,7 @@ impl McpBrowserServer {
 
         let result = match name.as_str() {
             "browser_acquire" => self.tool_browser_acquire(&args).await,
+            "browser_acquire_and_extract" => self.tool_browser_acquire_and_extract(&args).await,
             "browser_navigate" => self.tool_browser_navigate(&args).await,
             "browser_eval" => self.tool_browser_eval(&args).await,
             "browser_screenshot" => self.tool_browser_screenshot(&args).await,
@@ -945,6 +981,13 @@ impl McpBrowserServer {
                 "target_profile": target_profile
             }
         }))
+    }
+
+    async fn tool_browser_acquire_and_extract(&self, args: &Value) -> Result<Value> {
+        let request = Self::parse_acquisition_request(args)?;
+        let runner = AcquisitionRunner::new(self.pool.clone());
+        let result = runner.run(request).await;
+        Ok(Self::acquisition_result_to_tool_output(&result))
     }
 
     #[cfg(feature = "stealth")]
@@ -2677,6 +2720,75 @@ impl McpBrowserServer {
             .ok_or_else(|| BrowserError::ConfigError(format!("Missing required argument: {key}")))
     }
 
+    fn parse_acquisition_mode(mode: &str) -> Result<AcquisitionMode> {
+        match mode {
+            "fast" => Ok(AcquisitionMode::Fast),
+            "resilient" => Ok(AcquisitionMode::Resilient),
+            "hostile" => Ok(AcquisitionMode::Hostile),
+            "investigate" => Ok(AcquisitionMode::Investigate),
+            other => Err(BrowserError::ConfigError(format!(
+                "Invalid mode '{other}'. Use one of: fast, resilient, hostile, investigate"
+            ))),
+        }
+    }
+
+    fn parse_acquisition_request(args: &Value) -> Result<AcquisitionRequest> {
+        let url = Self::require_str(args, "url")?;
+        let mode_raw = Self::require_str(args, "mode")?;
+        let mode = Self::parse_acquisition_mode(&mode_raw)?;
+
+        let wait_for_selector = args
+            .get("wait_for_selector")
+            .or_else(|| args.get("selector_wait"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+
+        let extraction_js = args
+            .get("extraction_js")
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+
+        let total_timeout = match args.get("total_timeout_secs").and_then(Value::as_f64) {
+            Some(value) if value.is_finite() && value > 0.0 => Duration::from_secs_f64(value),
+            Some(_) => {
+                return Err(BrowserError::ConfigError(
+                    "total_timeout_secs must be a positive finite number".to_string(),
+                ));
+            }
+            None => AcquisitionRequest::default().total_timeout,
+        };
+
+        Ok(AcquisitionRequest {
+            url,
+            mode,
+            wait_for_selector,
+            extraction_js,
+            total_timeout,
+            ..AcquisitionRequest::default()
+        })
+    }
+
+    fn acquisition_result_to_tool_output(result: &AcquisitionResult) -> Value {
+        let strategy_used = serde_json::to_value(result.strategy_used).unwrap_or(Value::Null);
+        let attempted = serde_json::to_value(&result.attempted).unwrap_or(Value::Array(Vec::new()));
+        let failures = serde_json::to_value(&result.failures).unwrap_or(Value::Array(Vec::new()));
+
+        json!({
+            "success": result.success,
+            "strategy_used": strategy_used,
+            "final_url": result.final_url,
+            "status_code": result.status_code,
+            "extracted": result.extracted,
+            "html_excerpt": result.html_excerpt,
+            "diagnostics": {
+                "attempted": attempted,
+                "timed_out": result.timed_out,
+                "failure_count": result.failures.len(),
+                "failures": failures
+            }
+        })
+    }
+
     fn parse_root_selectors(args: &Value) -> Result<Vec<String>> {
         let selectors: Vec<String> = args
             .get("root_selectors")
@@ -2769,6 +2881,17 @@ mod tests {
             defs.iter()
                 .any(|t| t.get("name").and_then(|n| n.as_str()) == Some("browser_extract")),
             "TOOL_DEFINITIONS must contain browser_extract"
+        );
+    }
+
+    #[test]
+    fn tool_defs_include_browser_acquire_and_extract() {
+        let defs = &*TOOL_DEFINITIONS;
+        assert!(
+            defs.iter()
+                .any(|t| t.get("name").and_then(|n| n.as_str())
+                    == Some("browser_acquire_and_extract")),
+            "TOOL_DEFINITIONS must contain browser_acquire_and_extract"
         );
     }
 
@@ -2868,6 +2991,125 @@ mod tests {
                 .is_some_and(|a| a.iter().any(|v| v == "schema"))
         );
         Ok(())
+    }
+
+    #[test]
+    fn browser_acquire_and_extract_required_args()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let defs = &*TOOL_DEFINITIONS;
+        let def = defs
+            .iter()
+            .find(|t| t.get("name").and_then(|n| n.as_str()) == Some("browser_acquire_and_extract"))
+            .ok_or("browser_acquire_and_extract must be in TOOL_DEFINITIONS")?;
+
+        let required = def
+            .get("inputSchema")
+            .and_then(|s| s.get("required"))
+            .and_then(Value::as_array)
+            .ok_or("browser_acquire_and_extract inputSchema missing 'required' array")?;
+        assert!(required.iter().any(|v| v == "url"));
+        assert!(required.iter().any(|v| v == "mode"));
+
+        let mode_values = def
+            .get("inputSchema")
+            .and_then(|s| s.get("properties"))
+            .and_then(|p| p.get("mode"))
+            .and_then(|m| m.get("enum"))
+            .and_then(Value::as_array)
+            .ok_or("browser_acquire_and_extract mode enum missing")?;
+        assert!(mode_values.iter().any(|v| v == "fast"));
+        assert!(mode_values.iter().any(|v| v == "resilient"));
+        assert!(mode_values.iter().any(|v| v == "hostile"));
+        assert!(mode_values.iter().any(|v| v == "investigate"));
+        Ok(())
+    }
+
+    #[test]
+    fn acquisition_mode_parsing_accepts_all_supported_values()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        assert_eq!(
+            McpBrowserServer::parse_acquisition_mode("fast")?,
+            AcquisitionMode::Fast
+        );
+        assert_eq!(
+            McpBrowserServer::parse_acquisition_mode("resilient")?,
+            AcquisitionMode::Resilient
+        );
+        assert_eq!(
+            McpBrowserServer::parse_acquisition_mode("hostile")?,
+            AcquisitionMode::Hostile
+        );
+        assert_eq!(
+            McpBrowserServer::parse_acquisition_mode("investigate")?,
+            AcquisitionMode::Investigate
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn acquisition_mode_parsing_rejects_unknown() {
+        let err = McpBrowserServer::parse_acquisition_mode("invalid").err();
+        assert!(err.is_some(), "invalid mode should return an error");
+    }
+
+    #[test]
+    fn acquisition_request_validation_missing_url_fails() {
+        let err = McpBrowserServer::parse_acquisition_request(&json!({"mode": "fast"})).err();
+        assert!(err.is_some(), "missing url should fail validation");
+    }
+
+    #[test]
+    fn acquisition_request_validation_invalid_timeout_fails() {
+        let err = McpBrowserServer::parse_acquisition_request(&json!({
+            "url": "https://example.com",
+            "mode": "resilient",
+            "total_timeout_secs": 0
+        }))
+        .err();
+        assert!(err.is_some(), "zero timeout should fail validation");
+    }
+
+    #[test]
+    fn acquisition_result_output_has_stable_top_level_shape() {
+        let result = AcquisitionResult {
+            success: false,
+            strategy_used: None,
+            attempted: vec![crate::StrategyUsed::DirectHttp],
+            final_url: Some("https://example.com".to_string()),
+            status_code: Some(429),
+            html_excerpt: Some("<html>blocked</html>".to_string()),
+            extracted: None,
+            failures: vec![crate::StageFailure {
+                strategy: crate::StrategyUsed::DirectHttp,
+                kind: crate::StageFailureKind::Blocked,
+                message: "blocked status".to_string(),
+            }],
+            timed_out: false,
+        };
+
+        let payload = McpBrowserServer::acquisition_result_to_tool_output(&result);
+        assert!(payload.get("success").is_some());
+        assert!(payload.get("strategy_used").is_some());
+        assert!(payload.get("final_url").is_some());
+        assert!(payload.get("status_code").is_some());
+        assert!(payload.get("html_excerpt").is_some());
+        assert!(payload.get("diagnostics").is_some());
+
+        let diagnostics = payload.get("diagnostics");
+        assert!(
+            diagnostics
+                .and_then(|d| d.get("attempted"))
+                .and_then(Value::as_array)
+                .is_some(),
+            "diagnostics.attempted should be an array"
+        );
+        assert!(
+            diagnostics
+                .and_then(|d| d.get("failures"))
+                .and_then(Value::as_array)
+                .is_some(),
+            "diagnostics.failures should be an array"
+        );
     }
 
     #[test]

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -2757,11 +2757,9 @@ impl McpBrowserServer {
                 Duration::from_secs_f64(value)
             }
             Some(_) => {
-                return Err(BrowserError::ConfigError(
-                    format!(
-                        "total_timeout_secs must be a positive finite number <= {MAX_ACQUISITION_TIMEOUT_SECS}"
-                    ),
-                ));
+                return Err(BrowserError::ConfigError(format!(
+                    "total_timeout_secs must be a positive finite number <= {MAX_ACQUISITION_TIMEOUT_SECS}"
+                )));
             }
             None => AcquisitionRequest::default().total_timeout,
         };

--- a/crates/stygian-browser/tests/mcp_integration.rs
+++ b/crates/stygian-browser/tests/mcp_integration.rs
@@ -367,6 +367,51 @@ async fn mcp_acquire_navigate_release_round_trip() -> Result<(), Box<dyn std::er
 
 #[tokio::test]
 #[ignore = "requires Chrome and external network"]
+async fn mcp_browser_acquire_and_extract_returns_structured_payload() -> Result<(), DynError> {
+    let pool = BrowserPool::new(test_config()).await?;
+    let server = McpBrowserServer::new(pool);
+
+    let payload = call_tool(
+        &server,
+        200,
+        "browser_acquire_and_extract",
+        json!({
+            "url": "https://example.com",
+            "mode": "resilient",
+            "total_timeout_secs": 20
+        }),
+    )
+    .await?;
+
+    assert!(payload.get("success").is_some());
+    assert!(payload.get("strategy_used").is_some());
+    assert!(payload.get("final_url").is_some());
+    assert!(payload.get("status_code").is_some());
+    assert!(payload.get("diagnostics").is_some());
+
+    let diagnostics = payload
+        .get("diagnostics")
+        .ok_or_else(|| std::io::Error::other("missing diagnostics bundle"))?;
+    assert!(
+        diagnostics
+            .get("attempted")
+            .and_then(Value::as_array)
+            .is_some(),
+        "diagnostics.attempted should be an array"
+    );
+    assert!(
+        diagnostics
+            .get("failures")
+            .and_then(Value::as_array)
+            .is_some(),
+        "diagnostics.failures should be an array"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires Chrome and external network"]
 async fn mcp_session_save_restore_and_humanize_round_trip() -> Result<(), Box<dyn std::error::Error>>
 {
     let pool = BrowserPool::new(test_config()).await?;

--- a/crates/stygian-charon/src/acquisition.rs
+++ b/crates/stygian-charon/src/acquisition.rs
@@ -1,0 +1,228 @@
+//! Pure mapping from Charon policy outputs to acquisition-runner input hints.
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::{AdapterStrategy, ExecutionMode, RuntimePolicy, SessionMode, TelemetryLevel};
+
+/// Strategy mode hint for downstream acquisition runners.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcquisitionModeHint {
+    /// Lowest-latency path, minimal escalation.
+    Fast,
+    /// Balanced reliability path.
+    Resilient,
+    /// Strong anti-bot posture first.
+    Hostile,
+    /// Investigation-first entry.
+    Investigate,
+}
+
+/// Optional starting stage hint for investigation mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AcquisitionStartHint {
+    /// Start from direct HTTP.
+    DirectHttp,
+    /// Start from TLS-profiled HTTP.
+    TlsProfiledHttp,
+    /// Start from browser-backed stage.
+    BrowserLightStealth,
+    /// Start from sticky-session browser stage.
+    StickyProxyBrowser,
+}
+
+/// Deterministic runner input derived from runtime policy.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AcquisitionPolicy {
+    /// Recommended acquisition mode.
+    pub mode: AcquisitionModeHint,
+    /// Optional investigation entry point.
+    pub investigate_start: Option<AcquisitionStartHint>,
+    /// Retry budget hint for transient failures.
+    pub retry_budget: u32,
+    /// Base retry backoff in milliseconds.
+    pub backoff_base_ms: u64,
+    /// Warmup recommendation.
+    pub enable_warmup: bool,
+    /// Sticky-session recommendation.
+    pub sticky_session: bool,
+    /// Telemetry intensity carried through for logging/diagnostics.
+    pub telemetry_level: TelemetryLevel,
+    /// Risk score clamped to [0.0, 1.0].
+    pub risk_score: f64,
+}
+
+/// Optional runtime-policy hints for partial policy inputs.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct RuntimePolicyHints {
+    /// Optional execution mode.
+    pub execution_mode: Option<ExecutionMode>,
+    /// Optional session mode.
+    pub session_mode: Option<SessionMode>,
+    /// Optional telemetry level.
+    pub telemetry_level: Option<TelemetryLevel>,
+    /// Optional risk score.
+    pub risk_score: Option<f64>,
+    /// Optional retry count.
+    pub max_retries: Option<u32>,
+    /// Optional backoff base.
+    pub backoff_base_ms: Option<u64>,
+    /// Optional warmup flag.
+    pub enable_warmup: Option<bool>,
+}
+
+/// Map a Charon strategy recommendation into an acquisition mode.
+#[must_use]
+pub const fn map_adapter_strategy(strategy: AdapterStrategy) -> AcquisitionModeHint {
+    match strategy {
+        AdapterStrategy::DirectHttp => AcquisitionModeHint::Fast,
+        AdapterStrategy::BrowserStealth | AdapterStrategy::SessionWarmup => {
+            AcquisitionModeHint::Resilient
+        }
+        AdapterStrategy::StickyProxy => AcquisitionModeHint::Hostile,
+        AdapterStrategy::InvestigateOnly => AcquisitionModeHint::Investigate,
+    }
+}
+
+/// Map a full runtime policy into deterministic acquisition hints.
+#[must_use]
+pub fn map_runtime_policy(policy: &RuntimePolicy) -> AcquisitionPolicy {
+    map_policy_hints(&RuntimePolicyHints {
+        execution_mode: Some(policy.execution_mode),
+        session_mode: Some(policy.session_mode),
+        telemetry_level: Some(policy.telemetry_level),
+        risk_score: Some(policy.risk_score),
+        max_retries: Some(policy.max_retries),
+        backoff_base_ms: Some(policy.backoff_base_ms),
+        enable_warmup: Some(policy.enable_warmup),
+    })
+}
+
+/// Map partial runtime-policy hints with documented defaults.
+#[must_use]
+pub fn map_policy_hints(hints: &RuntimePolicyHints) -> AcquisitionPolicy {
+    let execution_mode = hints.execution_mode.unwrap_or(ExecutionMode::Http);
+    let session_mode = hints.session_mode.unwrap_or(SessionMode::Stateless);
+    let telemetry_level = hints.telemetry_level.unwrap_or(TelemetryLevel::Standard);
+    let risk_score = clamp_unit(hints.risk_score.unwrap_or(0.5));
+    let retry_budget = hints.max_retries.unwrap_or(2);
+    let backoff_base_ms = hints.backoff_base_ms.unwrap_or(250);
+    let enable_warmup = hints.enable_warmup.unwrap_or(false);
+
+    let mode = if telemetry_level == TelemetryLevel::Deep && execution_mode == ExecutionMode::Http {
+        AcquisitionModeHint::Investigate
+    } else if session_mode == SessionMode::Sticky || risk_score >= 0.8 {
+        AcquisitionModeHint::Hostile
+    } else if execution_mode == ExecutionMode::Http && risk_score <= 0.35 && retry_budget <= 2 {
+        AcquisitionModeHint::Fast
+    } else {
+        AcquisitionModeHint::Resilient
+    };
+
+    let investigate_start = if mode == AcquisitionModeHint::Investigate {
+        Some(match (execution_mode, session_mode, risk_score) {
+            (_, SessionMode::Sticky, _) => AcquisitionStartHint::StickyProxyBrowser,
+            (ExecutionMode::Browser, _, _) => AcquisitionStartHint::BrowserLightStealth,
+            (_, _, r) if r >= 0.7 => AcquisitionStartHint::TlsProfiledHttp,
+            _ => AcquisitionStartHint::DirectHttp,
+        })
+    } else {
+        None
+    };
+
+    AcquisitionPolicy {
+        mode,
+        investigate_start,
+        retry_budget,
+        backoff_base_ms,
+        enable_warmup,
+        sticky_session: session_mode == SessionMode::Sticky,
+        telemetry_level,
+        risk_score,
+    }
+}
+
+fn clamp_unit(value: f64) -> f64 {
+    value.clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::RuntimePolicy;
+
+    #[test]
+    fn adapter_strategy_maps_to_expected_mode() {
+        assert_eq!(
+            map_adapter_strategy(AdapterStrategy::DirectHttp),
+            AcquisitionModeHint::Fast
+        );
+        assert_eq!(
+            map_adapter_strategy(AdapterStrategy::BrowserStealth),
+            AcquisitionModeHint::Resilient
+        );
+        assert_eq!(
+            map_adapter_strategy(AdapterStrategy::StickyProxy),
+            AcquisitionModeHint::Hostile
+        );
+        assert_eq!(
+            map_adapter_strategy(AdapterStrategy::InvestigateOnly),
+            AcquisitionModeHint::Investigate
+        );
+    }
+
+    #[test]
+    fn high_risk_biases_to_stronger_mode() {
+        let mapped = map_policy_hints(&RuntimePolicyHints {
+            execution_mode: Some(ExecutionMode::Http),
+            session_mode: Some(SessionMode::Stateless),
+            telemetry_level: Some(TelemetryLevel::Standard),
+            risk_score: Some(0.92),
+            max_retries: Some(2),
+            backoff_base_ms: Some(250),
+            enable_warmup: Some(false),
+        });
+
+        assert_eq!(mapped.mode, AcquisitionModeHint::Hostile);
+        assert!(mapped.risk_score >= 0.9);
+    }
+
+    #[test]
+    fn missing_fields_fall_back_to_defaults() {
+        let mapped = map_policy_hints(&RuntimePolicyHints::default());
+
+        assert_eq!(mapped.mode, AcquisitionModeHint::Resilient);
+        assert_eq!(mapped.retry_budget, 2);
+        assert_eq!(mapped.backoff_base_ms, 250);
+        assert!(!mapped.enable_warmup);
+        assert!(!mapped.sticky_session);
+        assert_eq!(mapped.telemetry_level, TelemetryLevel::Standard);
+        assert_eq!(mapped.risk_score, 0.5);
+    }
+
+    #[test]
+    fn runtime_policy_mapping_is_stable() {
+        let policy = RuntimePolicy {
+            execution_mode: ExecutionMode::Browser,
+            session_mode: SessionMode::Sticky,
+            telemetry_level: TelemetryLevel::Deep,
+            rate_limit_rps: 1.0,
+            max_retries: 5,
+            backoff_base_ms: 700,
+            enable_warmup: true,
+            enforce_webrtc_proxy_only: true,
+            sticky_session_ttl_secs: Some(300),
+            required_stygian_features: vec![],
+            config_hints: Default::default(),
+            risk_score: 0.81,
+        };
+
+        let mapped = map_runtime_policy(&policy);
+        assert_eq!(mapped.mode, AcquisitionModeHint::Hostile);
+        assert!(mapped.sticky_session);
+        assert_eq!(mapped.retry_budget, 5);
+        assert_eq!(mapped.backoff_base_ms, 700);
+        assert!(mapped.enable_warmup);
+    }
+}

--- a/crates/stygian-charon/src/acquisition.rs
+++ b/crates/stygian-charon/src/acquisition.rs
@@ -143,8 +143,14 @@ pub fn map_policy_hints(hints: &RuntimePolicyHints) -> AcquisitionPolicy {
     }
 }
 
-fn clamp_unit(value: f64) -> f64 {
-    value.clamp(0.0, 1.0)
+const fn clamp_unit(value: f64) -> f64 {
+    if value < 0.0 {
+        0.0
+    } else if value > 1.0 {
+        1.0
+    } else {
+        value
+    }
 }
 
 #[cfg(test)]
@@ -198,7 +204,7 @@ mod tests {
         assert!(!mapped.enable_warmup);
         assert!(!mapped.sticky_session);
         assert_eq!(mapped.telemetry_level, TelemetryLevel::Standard);
-        assert_eq!(mapped.risk_score, 0.5);
+        assert!((mapped.risk_score - 0.5).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -214,7 +220,7 @@ mod tests {
             enforce_webrtc_proxy_only: true,
             sticky_session_ttl_secs: Some(300),
             required_stygian_features: vec![],
-            config_hints: Default::default(),
+            config_hints: std::collections::BTreeMap::default(),
             risk_score: 0.81,
         };
 

--- a/crates/stygian-charon/src/lib.rs
+++ b/crates/stygian-charon/src/lib.rs
@@ -7,6 +7,8 @@
 //! The crate classifies likely anti-bot providers from transaction evidence
 //! and from HTTP Archive (HAR) files.
 
+/// Mapping layer from runtime policy to acquisition strategy hints.
+pub mod acquisition;
 /// Provider signature classification logic.
 pub mod classifier;
 /// HAR parsing and extraction utilities.
@@ -18,6 +20,10 @@ pub mod policy;
 /// Public types for transaction and report models.
 pub mod types;
 
+pub use acquisition::{
+    AcquisitionModeHint, AcquisitionPolicy, AcquisitionStartHint, RuntimePolicyHints,
+    map_adapter_strategy, map_policy_hints, map_runtime_policy,
+};
 pub use classifier::{classify_har, classify_transaction};
 pub use investigation::{compare_reports, infer_requirements, investigate_har};
 pub use policy::{analyze_and_plan, build_runtime_policy, plan_from_report};

--- a/crates/stygian-charon/src/types.rs
+++ b/crates/stygian-charon/src/types.rs
@@ -175,7 +175,7 @@ pub struct AntiBotRequirement {
 }
 
 /// High-level integration strategy for Stygian execution.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AdapterStrategy {
     /// Standard HTTP adapter path appears sufficient.
     DirectHttp,

--- a/crates/stygian-graph/Cargo.toml
+++ b/crates/stygian-graph/Cargo.toml
@@ -120,7 +120,7 @@ default = ["browser"]
 # Include browser automation support
 browser = ["dep:stygian-browser"]
 # Full feature set
-full = ["browser", "extract", "api", "wasm-plugins", "postgres", "cloudflare-crawl", "redis", "object-storage", "scrape-exchange", "escalation"]
+full = ["browser", "extract", "api", "wasm-plugins", "postgres", "cloudflare-crawl", "redis", "object-storage", "scrape-exchange", "escalation", "acquisition-runner"]
 # Scrape Exchange REST API client and adapters
 scrape-exchange = []
 # Redis / Valkey cache adapter
@@ -139,6 +139,8 @@ cloudflare-crawl = []
 escalation = []
 # MCP (Model Context Protocol) server — exposes scraping & pipeline tools over stdin/stdout JSON-RPC 2.0
 mcp = []
+# Optional bridge for running stygian-browser AcquisitionRunner from graph pipeline nodes
+acquisition-runner = ["browser"]
 # Structured data extraction via derive macros (requires browser)
 extract = ["browser", "stygian-browser/extract"]
 

--- a/crates/stygian-graph/README.md
+++ b/crates/stygian-graph/README.md
@@ -56,6 +56,7 @@ stygian-graph = { version = "*", features = ["browser", "redis", "extract"] }
 | `wasm-plugins` | wasmtime | WASM plugin system |
 | `escalation` | — | Tiered escalation policy adapter |
 | `mcp` | — | MCP (Model Context Protocol) tools |
+| `acquisition-runner` | `browser` | Optional bridge that lets browser pipeline nodes opt into `stygian-browser` acquisition runner |
 | `full` | *all of above* | All features enabled |
 
 ---
@@ -358,6 +359,62 @@ Adapters requiring live external services (HTTP, browser) are tested with mock p
 Benchmarks (Apple M4 Pro):
 
 - DAG executor: ~50µs overhead per wave
+
+---
+
+## Optional Acquisition Runner Bridge (Opt-In)
+
+The `stygian-graph` bridge to the browser acquisition runner is optional and disabled unless you explicitly opt in.
+
+Opt-in requirements:
+
+- Build with feature `acquisition-runner`.
+- Add a node-level `acquisition` table on `browser` nodes.
+
+Without that node-level `acquisition` table, browser nodes keep legacy behavior in `graph_pipeline_run` and are reported as skipped.
+
+Example (`pipeline_run` TOML):
+
+```toml
+[[services]]
+name = "browser"
+kind = "browser"
+
+[[nodes]]
+name = "target"
+service = "browser"
+url = "https://example.com"
+
+[nodes.params.acquisition]
+mode = "resilient"
+wait_for_selector = "main"
+total_timeout_secs = 45
+```
+
+Supported `acquisition.mode` values are `fast`, `resilient`, `hostile`, and `investigate`.
+
+Migration note (old low-level path vs runner path):
+
+- Old path: browser node behavior relied on existing low-level execution/skip flow only.
+- New path: add `[nodes.params.acquisition]` to opt into runner execution for that node.
+- No migration is required for existing pipelines unless you want runner behavior.
+
+### Downstream Compatibility Checklist
+
+- Confirm pipelines without `[nodes.params.acquisition]` still produce expected skipped browser nodes.
+- Confirm pipelines with `[nodes.params.acquisition]` return acquisition metadata (`acquisition_runner`, diagnostics) as expected.
+- Validate both feature sets in CI to prevent accidental behavior changes.
+
+Suggested CI matrix guidance:
+
+```bash
+# Legacy behavior surface
+cargo test -p stygian-graph --no-default-features --features mcp
+
+# Opt-in bridge surface
+cargo test -p stygian-graph --no-default-features --features "mcp,browser,acquisition-runner"
+```
+
 - HTTP adapter: ~2ms per request (cached DNS)
 - Browser adapter: <100ms acquisition (warm pool)
 

--- a/crates/stygian-graph/src/mcp.rs
+++ b/crates/stygian-graph/src/mcp.rs
@@ -1405,6 +1405,7 @@ where
     }
 }
 
+#[cfg(feature = "acquisition-runner")]
 async fn execute_browser_pipeline_node<F, Fut>(
     node: &NodeDecl,
     node_name: &str,
@@ -1426,6 +1427,20 @@ where
     };
 
     Some(run_acquisition(url.to_string(), cfg).await)
+}
+
+#[cfg(not(feature = "acquisition-runner"))]
+async fn execute_browser_pipeline_node<F, Fut>(
+    _node: &NodeDecl,
+    _node_name: &str,
+    _url: &str,
+    _run_acquisition: &F,
+) -> Option<Result<Value, String>>
+where
+    F: Fn(String, AcquisitionNodeConfig) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<Value, String>> + Send,
+{
+    None
 }
 
 /// Convert a [`toml::Value`] to a [`serde_json::Value`] for adapter params.

--- a/crates/stygian-graph/src/mcp.rs
+++ b/crates/stygian-graph/src/mcp.rs
@@ -1217,7 +1217,7 @@ async fn run_acquisition_bridge(url: &str, cfg: &AcquisitionNodeConfig) -> Resul
         extraction_js: cfg.extraction_js.clone(),
         total_timeout: cfg
             .total_timeout
-            .unwrap_or(AcquisitionRequest::default().total_timeout),
+            .unwrap_or_else(|| AcquisitionRequest::default().total_timeout),
         ..AcquisitionRequest::default()
     };
 
@@ -1368,19 +1368,7 @@ where
                     .map_err(|e| e.to_string()),
             )
         }
-        "browser" => {
-            let cfg = match acquisition_config_from_node(node) {
-                Ok(Some(cfg)) => cfg,
-                Ok(None) => return None,
-                Err(err) => {
-                    return Some(Err(format!(
-                        "Invalid acquisition config for node '{node_name}': {err}"
-                    )));
-                }
-            };
-
-            Some(run_acquisition(url.to_string(), cfg).await)
-        }
+        "browser" => execute_browser_pipeline_node(node, node_name, url, &run_acquisition).await,
         other => {
             warn!(
                 kind = other,
@@ -1390,6 +1378,29 @@ where
             None
         }
     }
+}
+
+async fn execute_browser_pipeline_node<F, Fut>(
+    node: &NodeDecl,
+    node_name: &str,
+    url: &str,
+    run_acquisition: &F,
+) -> Option<Result<Value, String>>
+where
+    F: Fn(String, AcquisitionNodeConfig) -> Fut,
+    Fut: Future<Output = Result<Value, String>>,
+{
+    let cfg = match acquisition_config_from_node(node) {
+        Ok(Some(cfg)) => cfg,
+        Ok(None) => return None,
+        Err(err) => {
+            return Some(Err(format!(
+                "Invalid acquisition config for node '{node_name}': {err}"
+            )));
+        }
+    };
+
+    Some(run_acquisition(url.to_string(), cfg).await)
 }
 
 /// Convert a [`toml::Value`] to a [`serde_json::Value`] for adapter params.
@@ -1601,29 +1612,30 @@ depends_on = ["fetch"]
         )
         .await;
 
-        let output = result.expect("browser acquisition should be attempted");
-        let payload = output.expect("mock bridge should succeed");
+        let payload = match result {
+            Some(Ok(payload)) => payload,
+            other => {
+                assert!(
+                    matches!(other, Some(Ok(_))),
+                    "browser acquisition should return Some(Ok(_))"
+                );
+                return;
+            }
+        };
 
         assert_eq!(
-            payload
-                .pointer("/data/url")
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-            "https://example.com"
+            payload.pointer("/data/url").and_then(Value::as_str),
+            Some("https://example.com")
         );
         assert_eq!(
-            payload
-                .pointer("/data/mode")
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-            "fast"
+            payload.pointer("/data/mode").and_then(Value::as_str),
+            Some("fast")
         );
         assert_eq!(
             payload
                 .pointer("/data/wait_for_selector")
-                .and_then(Value::as_str)
-                .unwrap_or_default(),
-            "main"
+                .and_then(Value::as_str),
+            Some("main")
         );
     }
 
@@ -1654,9 +1666,16 @@ depends_on = ["fetch"]
         )
         .await;
 
-        let err = result
-            .expect("invalid config should return Some(Err)")
-            .expect_err("invalid timeout must fail validation");
+        let err = match result {
+            Some(Err(err)) => err,
+            other => {
+                assert!(
+                    matches!(other, Some(Err(_))),
+                    "invalid config should return Some(Err(_))"
+                );
+                return;
+            }
+        };
 
         assert!(
             err.contains("total_timeout_secs") || err.contains("Invalid acquisition config"),

--- a/crates/stygian-graph/src/mcp.rs
+++ b/crates/stygian-graph/src/mcp.rs
@@ -1125,6 +1125,7 @@ struct AcquisitionNodeConfig {
     total_timeout: Option<Duration>,
 }
 
+#[cfg(feature = "acquisition-runner")]
 fn parse_optional_positive_secs(value: &toml::Value) -> Result<Duration, String> {
     const MAX_ACQUISITION_TIMEOUT_SECS: u64 = 86_400;
     const MAX_ACQUISITION_TIMEOUT_SECS_F64: f64 = 86_400.0;
@@ -1153,6 +1154,7 @@ fn parse_optional_positive_secs(value: &toml::Value) -> Result<Duration, String>
     Err("acquisition.total_timeout_secs must be a number".to_string())
 }
 
+#[cfg(feature = "acquisition-runner")]
 fn acquisition_config_from_node(node: &NodeDecl) -> Result<Option<AcquisitionNodeConfig>, String> {
     let Some(raw) = node.params.get("acquisition") else {
         return Ok(None);
@@ -1613,6 +1615,7 @@ depends_on = ["fetch"]
         assert!(result.is_none());
     }
 
+    #[cfg(feature = "acquisition-runner")]
     #[tokio::test]
     async fn pipeline_browser_node_with_acquisition_uses_bridge_path() {
         let mut acquisition = toml::map::Map::new();
@@ -1679,6 +1682,37 @@ depends_on = ["fetch"]
         );
     }
 
+    #[cfg(not(feature = "acquisition-runner"))]
+    #[tokio::test]
+    async fn pipeline_browser_node_with_acquisition_is_skipped_without_feature() {
+        let mut acquisition = toml::map::Map::new();
+        acquisition.insert("mode".to_string(), toml::Value::String("fast".to_string()));
+
+        let mut params = HashMap::new();
+        params.insert("acquisition".to_string(), toml::Value::Table(acquisition));
+
+        let node = NodeDecl {
+            name: "render".to_string(),
+            service: "browser".to_string(),
+            depends_on: Vec::new(),
+            url: Some("https://example.com".to_string()),
+            params,
+        };
+
+        let result = execute_pipeline_node_with(
+            "browser",
+            "https://example.com",
+            "render",
+            &node,
+            30,
+            |_url, _cfg| async { Ok(json!({"data": "should-not-run"})) },
+        )
+        .await;
+
+        assert!(result.is_none());
+    }
+
+    #[cfg(feature = "acquisition-runner")]
     #[tokio::test]
     async fn pipeline_browser_node_invalid_acquisition_timeout_returns_error() {
         let mut acquisition = toml::map::Map::new();

--- a/crates/stygian-graph/src/mcp.rs
+++ b/crates/stygian-graph/src/mcp.rs
@@ -50,6 +50,7 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+#[cfg(feature = "acquisition-runner")]
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -1126,10 +1127,10 @@ struct AcquisitionNodeConfig {
 
 fn parse_optional_positive_secs(value: &toml::Value) -> Result<Duration, String> {
     const MAX_ACQUISITION_TIMEOUT_SECS: u64 = 86_400;
+    const MAX_ACQUISITION_TIMEOUT_SECS_F64: f64 = 86_400.0;
 
     if let Some(seconds) = value.as_float() {
-        if seconds.is_finite() && seconds > 0.0 && seconds <= MAX_ACQUISITION_TIMEOUT_SECS as f64
-        {
+        if seconds.is_finite() && seconds > 0.0 && seconds <= MAX_ACQUISITION_TIMEOUT_SECS_F64 {
             return Ok(Duration::from_secs_f64(seconds));
         }
         return Err(format!(
@@ -1140,11 +1141,9 @@ fn parse_optional_positive_secs(value: &toml::Value) -> Result<Duration, String>
     if let Some(seconds) = value.as_integer() {
         if seconds > 0 && seconds <= i64::try_from(MAX_ACQUISITION_TIMEOUT_SECS).unwrap_or(i64::MAX)
         {
-            return Ok(Duration::from_secs(
-                u64::try_from(seconds).map_err(|_| {
-                    "acquisition.total_timeout_secs must fit into an unsigned integer".to_string()
-                })?,
-            ));
+            return Ok(Duration::from_secs(u64::try_from(seconds).map_err(
+                |_| "acquisition.total_timeout_secs must fit into an unsigned integer".to_string(),
+            )?));
         }
         return Err(format!(
             "acquisition.total_timeout_secs must be an integer in 1..={MAX_ACQUISITION_TIMEOUT_SECS}"

--- a/crates/stygian-graph/src/mcp.rs
+++ b/crates/stygian-graph/src/mcp.rs
@@ -50,10 +50,13 @@
 
 use std::collections::HashMap;
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+#[cfg(feature = "acquisition-runner")]
+use tokio::sync::OnceCell;
 use tracing::{debug, info, warn};
 
 #[cfg(feature = "acquisition-runner")]
@@ -1122,20 +1125,30 @@ struct AcquisitionNodeConfig {
 }
 
 fn parse_optional_positive_secs(value: &toml::Value) -> Result<Duration, String> {
+    const MAX_ACQUISITION_TIMEOUT_SECS: u64 = 86_400;
+
     if let Some(seconds) = value.as_float() {
-        if seconds.is_finite() && seconds > 0.0 {
+        if seconds.is_finite() && seconds > 0.0 && seconds <= MAX_ACQUISITION_TIMEOUT_SECS as f64
+        {
             return Ok(Duration::from_secs_f64(seconds));
         }
-        return Err("acquisition.total_timeout_secs must be a positive finite number".to_string());
+        return Err(format!(
+            "acquisition.total_timeout_secs must be a positive finite number <= {MAX_ACQUISITION_TIMEOUT_SECS}"
+        ));
     }
 
     if let Some(seconds) = value.as_integer() {
-        if seconds > 0 {
+        if seconds > 0 && seconds <= i64::try_from(MAX_ACQUISITION_TIMEOUT_SECS).unwrap_or(i64::MAX)
+        {
             return Ok(Duration::from_secs(
-                u64::try_from(seconds).unwrap_or(u64::MAX),
+                u64::try_from(seconds).map_err(|_| {
+                    "acquisition.total_timeout_secs must fit into an unsigned integer".to_string()
+                })?,
             ));
         }
-        return Err("acquisition.total_timeout_secs must be greater than 0".to_string());
+        return Err(format!(
+            "acquisition.total_timeout_secs must be an integer in 1..={MAX_ACQUISITION_TIMEOUT_SECS}"
+        ));
     }
 
     Err("acquisition.total_timeout_secs must be a number".to_string())
@@ -1203,11 +1216,24 @@ fn parse_acquisition_mode(raw: &str) -> Result<AcquisitionMode, String> {
 }
 
 #[cfg(feature = "acquisition-runner")]
+static ACQUISITION_BRIDGE_POOL: OnceCell<Arc<BrowserPool>> = OnceCell::const_new();
+
+#[cfg(feature = "acquisition-runner")]
+async fn acquisition_bridge_pool() -> Result<Arc<BrowserPool>, String> {
+    let pool = ACQUISITION_BRIDGE_POOL
+        .get_or_try_init(|| async {
+            BrowserPool::new(BrowserConfig::default())
+                .await
+                .map_err(|e| format!("acquisition bridge browser pool init failed: {e}"))
+        })
+        .await?;
+    Ok(Arc::clone(pool))
+}
+
+#[cfg(feature = "acquisition-runner")]
 async fn run_acquisition_bridge(url: &str, cfg: &AcquisitionNodeConfig) -> Result<Value, String> {
     let mode = parse_acquisition_mode(&cfg.mode)?;
-    let pool = BrowserPool::new(BrowserConfig::default())
-        .await
-        .map_err(|e| format!("acquisition bridge browser pool init failed: {e}"))?;
+    let pool = acquisition_bridge_pool().await?;
 
     let runner = AcquisitionRunner::new(pool);
     let request = AcquisitionRequest {

--- a/crates/stygian-graph/src/mcp.rs
+++ b/crates/stygian-graph/src/mcp.rs
@@ -49,10 +49,17 @@
 //! | `pipeline_run` | `toml`, `timeout_secs?` | per-node `outputs`, `skipped`, `errors` |
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::time::Duration;
 
 use serde_json::{Value, json};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tracing::{debug, info, warn};
+
+#[cfg(feature = "acquisition-runner")]
+use stygian_browser::{
+    AcquisitionMode, AcquisitionRequest, AcquisitionRunner, BrowserConfig, BrowserPool,
+};
 
 use crate::{
     adapters::{
@@ -338,7 +345,7 @@ impl McpGraphServer {
             }),
             json!({
                 "name": "pipeline_run",
-                "description": "Parse, validate, and execute a TOML pipeline DAG. HTTP, REST, GraphQL, sitemap, and RSS nodes are executed. AI/browser nodes are recorded in the skipped list.",
+                "description": "Parse, validate, and execute a TOML pipeline DAG. HTTP, REST, GraphQL, sitemap, and RSS nodes are executed. AI nodes and browser nodes without opt-in acquisition config are recorded in the skipped list.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
@@ -1106,6 +1113,148 @@ fn build_graphql_node_request(
     )
 }
 
+#[derive(Debug, Clone, PartialEq)]
+struct AcquisitionNodeConfig {
+    mode: String,
+    wait_for_selector: Option<String>,
+    extraction_js: Option<String>,
+    total_timeout: Option<Duration>,
+}
+
+fn parse_optional_positive_secs(value: &toml::Value) -> Result<Duration, String> {
+    if let Some(seconds) = value.as_float() {
+        if seconds.is_finite() && seconds > 0.0 {
+            return Ok(Duration::from_secs_f64(seconds));
+        }
+        return Err("acquisition.total_timeout_secs must be a positive finite number".to_string());
+    }
+
+    if let Some(seconds) = value.as_integer() {
+        if seconds > 0 {
+            return Ok(Duration::from_secs(
+                u64::try_from(seconds).unwrap_or(u64::MAX),
+            ));
+        }
+        return Err("acquisition.total_timeout_secs must be greater than 0".to_string());
+    }
+
+    Err("acquisition.total_timeout_secs must be a number".to_string())
+}
+
+fn acquisition_config_from_node(node: &NodeDecl) -> Result<Option<AcquisitionNodeConfig>, String> {
+    let Some(raw) = node.params.get("acquisition") else {
+        return Ok(None);
+    };
+
+    let table = raw
+        .as_table()
+        .ok_or_else(|| "acquisition must be a TOML table".to_string())?;
+
+    let enabled = table
+        .get("enabled")
+        .and_then(toml::Value::as_bool)
+        .unwrap_or(true);
+
+    if !enabled {
+        return Ok(None);
+    }
+
+    let mode = table
+        .get("mode")
+        .and_then(toml::Value::as_str)
+        .unwrap_or("resilient")
+        .to_string();
+
+    let wait_for_selector = table
+        .get("wait_for_selector")
+        .or_else(|| table.get("selector_wait"))
+        .and_then(toml::Value::as_str)
+        .map(ToString::to_string);
+
+    let extraction_js = table
+        .get("extraction_js")
+        .and_then(toml::Value::as_str)
+        .map(ToString::to_string);
+
+    let total_timeout = table
+        .get("total_timeout_secs")
+        .map(parse_optional_positive_secs)
+        .transpose()?;
+
+    Ok(Some(AcquisitionNodeConfig {
+        mode,
+        wait_for_selector,
+        extraction_js,
+        total_timeout,
+    }))
+}
+
+#[cfg(feature = "acquisition-runner")]
+fn parse_acquisition_mode(raw: &str) -> Result<AcquisitionMode, String> {
+    match raw {
+        "fast" => Ok(AcquisitionMode::Fast),
+        "resilient" => Ok(AcquisitionMode::Resilient),
+        "hostile" => Ok(AcquisitionMode::Hostile),
+        "investigate" => Ok(AcquisitionMode::Investigate),
+        other => Err(format!(
+            "Invalid acquisition mode '{other}'. Use one of: fast, resilient, hostile, investigate"
+        )),
+    }
+}
+
+#[cfg(feature = "acquisition-runner")]
+async fn run_acquisition_bridge(url: &str, cfg: &AcquisitionNodeConfig) -> Result<Value, String> {
+    let mode = parse_acquisition_mode(&cfg.mode)?;
+    let pool = BrowserPool::new(BrowserConfig::default())
+        .await
+        .map_err(|e| format!("acquisition bridge browser pool init failed: {e}"))?;
+
+    let runner = AcquisitionRunner::new(pool);
+    let request = AcquisitionRequest {
+        url: url.to_string(),
+        mode,
+        wait_for_selector: cfg.wait_for_selector.clone(),
+        extraction_js: cfg.extraction_js.clone(),
+        total_timeout: cfg
+            .total_timeout
+            .unwrap_or(AcquisitionRequest::default().total_timeout),
+        ..AcquisitionRequest::default()
+    };
+
+    let result = runner.run(request).await;
+    let strategy_used = serde_json::to_value(result.strategy_used).unwrap_or(Value::Null);
+    let attempted = serde_json::to_value(&result.attempted).unwrap_or(Value::Array(Vec::new()));
+    let failures = serde_json::to_value(&result.failures).unwrap_or(Value::Array(Vec::new()));
+
+    Ok(json!({
+        "data": {
+            "success": result.success,
+            "strategy_used": strategy_used,
+            "final_url": result.final_url,
+            "status_code": result.status_code,
+            "extracted": result.extracted,
+            "html_excerpt": result.html_excerpt,
+        },
+        "metadata": {
+            "acquisition_runner": true,
+            "diagnostics": {
+                "attempted": attempted,
+                "timed_out": result.timed_out,
+                "failure_count": result.failures.len(),
+                "failures": failures,
+            }
+        }
+    }))
+}
+
+#[cfg(not(feature = "acquisition-runner"))]
+async fn run_acquisition_bridge(_url: &str, _cfg: &AcquisitionNodeConfig) -> Result<Value, String> {
+    Err(
+        "acquisition bridge requested but stygian-graph was built without feature 'acquisition-runner'"
+            .to_string(),
+    )
+}
+
 /// Execute a single pipeline node of a given service kind.
 ///
 /// Returns `None` if the kind is not supported (node is skipped);
@@ -1117,10 +1266,33 @@ async fn execute_pipeline_node(
     node: &NodeDecl,
     timeout_secs: u64,
 ) -> Option<Result<Value, String>> {
+    execute_pipeline_node_with(
+        kind,
+        url,
+        node_name,
+        node,
+        timeout_secs,
+        |bridge_url, cfg| async move { run_acquisition_bridge(&bridge_url, &cfg).await },
+    )
+    .await
+}
+
+async fn execute_pipeline_node_with<F, Fut>(
+    kind: &str,
+    url: &str,
+    node_name: &str,
+    node: &NodeDecl,
+    timeout_secs: u64,
+    run_acquisition: F,
+) -> Option<Result<Value, String>>
+where
+    F: Fn(String, AcquisitionNodeConfig) -> Fut,
+    Fut: Future<Output = Result<Value, String>>,
+{
     match kind {
         "http" => {
             let config = HttpConfig {
-                timeout: std::time::Duration::from_secs(timeout_secs),
+                timeout: Duration::from_secs(timeout_secs),
                 ..HttpConfig::default()
             };
             let adapter = HttpAdapter::with_config(config);
@@ -1195,6 +1367,19 @@ async fn execute_pipeline_node(
                     .map(|out| json!({ "data": out.data, "metadata": out.metadata }))
                     .map_err(|e| e.to_string()),
             )
+        }
+        "browser" => {
+            let cfg = match acquisition_config_from_node(node) {
+                Ok(Some(cfg)) => cfg,
+                Ok(None) => return None,
+                Err(err) => {
+                    return Some(Err(format!(
+                        "Invalid acquisition config for node '{node_name}': {err}"
+                    )));
+                }
+            };
+
+            Some(run_acquisition(url.to_string(), cfg).await)
         }
         other => {
             warn!(
@@ -1352,5 +1537,130 @@ depends_on = ["fetch"]
         // so just verify the tool_pipeline_validate path for missing param.
         let resp = McpGraphServer::tool_pipeline_validate(&id, &args);
         assert!(resp.get("error").is_some_and(Value::is_object));
+    }
+
+    #[tokio::test]
+    async fn pipeline_browser_node_without_acquisition_is_skipped() {
+        let node = NodeDecl {
+            name: "render".to_string(),
+            service: "browser".to_string(),
+            depends_on: Vec::new(),
+            url: Some("https://example.com".to_string()),
+            params: HashMap::new(),
+        };
+
+        let result = execute_pipeline_node_with(
+            "browser",
+            "https://example.com",
+            "render",
+            &node,
+            30,
+            |_url, _cfg| async { Ok(json!({"data": "should-not-run"})) },
+        )
+        .await;
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn pipeline_browser_node_with_acquisition_uses_bridge_path() {
+        let mut acquisition = toml::map::Map::new();
+        acquisition.insert("mode".to_string(), toml::Value::String("fast".to_string()));
+        acquisition.insert(
+            "wait_for_selector".to_string(),
+            toml::Value::String("main".to_string()),
+        );
+
+        let mut params = HashMap::new();
+        params.insert("acquisition".to_string(), toml::Value::Table(acquisition));
+
+        let node = NodeDecl {
+            name: "render".to_string(),
+            service: "browser".to_string(),
+            depends_on: Vec::new(),
+            url: Some("https://example.com".to_string()),
+            params,
+        };
+
+        let result = execute_pipeline_node_with(
+            "browser",
+            "https://example.com",
+            "render",
+            &node,
+            30,
+            |url, cfg| async move {
+                Ok(json!({
+                    "data": {
+                        "url": url,
+                        "mode": cfg.mode,
+                        "wait_for_selector": cfg.wait_for_selector,
+                    },
+                    "metadata": {"bridge": "mock"}
+                }))
+            },
+        )
+        .await;
+
+        let output = result.expect("browser acquisition should be attempted");
+        let payload = output.expect("mock bridge should succeed");
+
+        assert_eq!(
+            payload
+                .pointer("/data/url")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            "https://example.com"
+        );
+        assert_eq!(
+            payload
+                .pointer("/data/mode")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            "fast"
+        );
+        assert_eq!(
+            payload
+                .pointer("/data/wait_for_selector")
+                .and_then(Value::as_str)
+                .unwrap_or_default(),
+            "main"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_browser_node_invalid_acquisition_timeout_returns_error() {
+        let mut acquisition = toml::map::Map::new();
+        acquisition.insert("mode".to_string(), toml::Value::String("fast".to_string()));
+        acquisition.insert("total_timeout_secs".to_string(), toml::Value::Integer(0));
+
+        let mut params = HashMap::new();
+        params.insert("acquisition".to_string(), toml::Value::Table(acquisition));
+
+        let node = NodeDecl {
+            name: "render".to_string(),
+            service: "browser".to_string(),
+            depends_on: Vec::new(),
+            url: Some("https://example.com".to_string()),
+            params,
+        };
+
+        let result = execute_pipeline_node_with(
+            "browser",
+            "https://example.com",
+            "render",
+            &node,
+            30,
+            |_url, _cfg| async { Ok(json!({"data": "unexpected"})) },
+        )
+        .await;
+
+        let err = result
+            .expect("invalid config should return Some(Err)")
+            .expect_err("invalid timeout must fail validation");
+
+        assert!(
+            err.contains("total_timeout_secs") || err.contains("Invalid acquisition config"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/stygian-graph/src/mcp.rs
+++ b/crates/stygian-graph/src/mcp.rs
@@ -1286,8 +1286,8 @@ async fn execute_pipeline_node_with<F, Fut>(
     run_acquisition: F,
 ) -> Option<Result<Value, String>>
 where
-    F: Fn(String, AcquisitionNodeConfig) -> Fut,
-    Fut: Future<Output = Result<Value, String>>,
+    F: Fn(String, AcquisitionNodeConfig) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<Value, String>> + Send,
 {
     match kind {
         "http" => {
@@ -1387,8 +1387,8 @@ async fn execute_browser_pipeline_node<F, Fut>(
     run_acquisition: &F,
 ) -> Option<Result<Value, String>>
 where
-    F: Fn(String, AcquisitionNodeConfig) -> Fut,
-    Fut: Future<Output = Result<Value, String>>,
+    F: Fn(String, AcquisitionNodeConfig) -> Fut + Send + Sync,
+    Fut: Future<Output = Result<Value, String>> + Send,
 {
     let cfg = match acquisition_config_from_node(node) {
         Ok(Some(cfg)) => cfg,

--- a/crates/stygian-mcp/README.md
+++ b/crates/stygian-mcp/README.md
@@ -61,6 +61,11 @@ All tools from the three underlying crates are available under their respective 
 
 \* `browser_attach` requires the `mcp-attach` feature.
 
+Runner-first tool:
+
+- `browser_acquire_and_extract` is the recommended high-level browser path for acquisition + extraction in one call.
+- Supported `mode` values are `fast`, `resilient`, `hostile`, and `investigate`.
+
 The aggregator also adds two cross-crate tools:
 
 | Tool | Description |
@@ -187,6 +192,84 @@ With `extract` feature enabled, use `browser_extract`:
   }
 }
 ```
+
+### Runner-First Acquisition by Mode
+
+Use `browser_acquire_and_extract` when you want deterministic strategy escalation with minimal orchestration code.
+
+`fast` mode:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "browser_acquire_and_extract",
+    "arguments": {
+      "url": "https://example.com",
+      "mode": "fast"
+    }
+  }
+}
+```
+
+`resilient` mode:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "browser_acquire_and_extract",
+    "arguments": {
+      "url": "https://example.com/catalog",
+      "mode": "resilient",
+      "wait_for_selector": "article.item"
+    }
+  }
+}
+```
+
+`hostile` mode:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "browser_acquire_and_extract",
+    "arguments": {
+      "url": "https://example.com/challenged",
+      "mode": "hostile",
+      "wait_for_selector": "main",
+      "total_timeout_secs": 60
+    }
+  }
+}
+```
+
+`investigate` mode:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "browser_acquire_and_extract",
+    "arguments": {
+      "url": "https://example.com",
+      "mode": "investigate",
+      "extraction_js": "({ title: document.title, href: location.href })"
+    }
+  }
+}
+```
+
+Migration note (old low-level path vs new runner path):
+
+- Old low-level MCP path: `browser_acquire` -> `browser_navigate` -> `browser_eval` or `browser_extract` -> `browser_release`.
+- New runner path: `browser_acquire_and_extract` with one call and explicit `mode`.
+- The low-level path remains supported for custom multi-step interactions.
 
 ## License
 

--- a/docs/acquisition-runner-refactor-guide.md
+++ b/docs/acquisition-runner-refactor-guide.md
@@ -162,7 +162,9 @@ Bridge activation requires both:
 - acquisition-runner feature in stygian-graph build
 - node-level acquisition opt-in block in pipeline TOML
 
-Without both conditions, behavior remains legacy and non-breaking.
+Without both conditions, the browser node is skipped — behavior remains legacy and non-breaking.
+If the feature is not compiled in but a node carries an `acquisition` block, the block is ignored
+and the node is still recorded in the `skipped` list, not `errors`.
 
 ## Migration Guidance for Developers
 

--- a/docs/acquisition-runner-refactor-guide.md
+++ b/docs/acquisition-runner-refactor-guide.md
@@ -1,0 +1,263 @@
+# Acquisition Runner Refactor Guide (T59-T63)
+
+## Audience and Purpose
+
+This document explains the recently completed acquisition-runner refactor for contributors who were not involved in implementation.
+
+It focuses on:
+
+- what changed and why
+- where changes landed by crate
+- compatibility guarantees
+- how to use the new behavior
+- how to validate and extend it safely
+
+## Executive Summary
+
+The refactor introduced an opinionated acquisition runner that improves hard-target scraping ergonomics without changing workspace layout or breaking existing graph behavior.
+
+The completed tasks were:
+
+- T59: acquisition runner core in stygian-browser
+- T60: deterministic charon runtime-policy mapping
+- T61: high-level MCP tool browser_acquire_and_extract
+- T62: optional, additive stygian-graph bridge
+- T63: runner-first docs and compatibility checks
+
+The key outcome is a clear default execution path for difficult targets while preserving opt-in boundaries for downstream users.
+
+## Why This Refactor Was Done
+
+Before this refactor, users often had to understand and manually combine lower-level controls early, even for common acquisition workflows. The new runner-first path compresses intent-to-outcome and standardizes failure reporting.
+
+Design goals that drove implementation:
+
+- keep crate layout unchanged
+- keep stygian-graph behavior stable by default
+- make new graph behavior additive and opt-in
+- provide deterministic failure shapes for automation
+- preserve advanced knobs as secondary paths
+
+## Architecture Decision Record (Short Form)
+
+### Decision 1: Put orchestration in stygian-browser
+
+The acquisition ladder belongs close to browser session lifecycle and extraction primitives. This keeps orchestration thin and avoids duplicating runtime behavior across crates.
+
+### Decision 2: Keep charon mapping pure and deterministic
+
+Runtime policy mapping was isolated as pure conversion logic. This prevents hidden coupling and makes behavior predictable for tests and downstream tools.
+
+### Decision 3: Expose one high-level MCP entry point
+
+browser_acquire_and_extract is the operator-friendly wrapper around the runner. It enables one-call acquisition plus extraction with stable diagnostics.
+
+### Decision 4: Keep graph bridge opt-in
+
+No existing graph pipeline changes behavior unless a browser node explicitly opts in with an acquisition block and the acquisition-runner feature is enabled.
+
+## What Changed by Crate
+
+## stygian-browser
+
+Primary additions and behavior:
+
+- acquisition runner core added
+- deterministic strategy ladder execution
+- terminal result object for success and failure paths
+- stable failure bundle and diagnostics fields
+
+Notable implementation details:
+
+- timeout and setup-failure paths are represented as terminal structured results
+- sticky browser retries can pin by host via browser-pool context acquisition
+
+Main touched areas:
+
+- crates/stygian-browser/src/acquisition.rs
+- crates/stygian-browser/src/mcp.rs
+- crates/stygian-browser/tests/mcp_integration.rs
+
+## stygian-charon
+
+Primary additions and behavior:
+
+- runtime-policy to acquisition mapping layer
+- deterministic mapping helpers and explicit defaulting
+- risk/clamp handling to avoid undefined transitions
+
+Main touched areas:
+
+- crates/stygian-charon/src/acquisition.rs
+- crates/stygian-charon/src/lib.rs
+- crates/stygian-charon/src/types.rs
+
+## stygian-graph
+
+Primary additions and behavior:
+
+- optional bridge to run browser nodes through acquisition runner
+- guarded by acquisition-runner feature
+- browser nodes only route to the bridge when the node has an acquisition block
+
+Compatibility behavior:
+
+- if acquisition block is absent, prior browser-node skip semantics remain
+- existing pipelines remain non-breaking by default
+
+Main touched areas:
+
+- crates/stygian-graph/Cargo.toml
+- crates/stygian-graph/src/mcp.rs
+
+## Documentation and examples
+
+Primary additions and behavior:
+
+- MCP docs updated to reflect pipeline_run browser opt-in behavior
+- browser acquisition example added
+- production security baseline added for MCP operations
+
+Main touched areas:
+
+- book/src/mcp/graph-tools.md
+- book/src/mcp/overview.md
+
+## New or Updated Runtime Contracts
+
+## Runner modes
+
+Supported high-level modes:
+
+- fast
+- resilient
+- hostile
+- investigate
+
+These are now the documented and tested operator-facing strategy selectors.
+
+## MCP tool contract
+
+High-level tool:
+
+- browser_acquire_and_extract
+
+Contract characteristics:
+
+- validates mode strings explicitly
+- emits compact diagnostics for failure analysis
+- preserves deterministic output shape for downstream automation
+
+Diagnostics fields include:
+
+- attempted
+- timed_out
+- failure_count
+- failures
+
+## Graph bridge contract
+
+Bridge activation requires both:
+
+- acquisition-runner feature in stygian-graph build
+- node-level acquisition opt-in block in pipeline TOML
+
+Without both conditions, behavior remains legacy and non-breaking.
+
+## Migration Guidance for Developers
+
+Most users do not need migration changes unless they want runner behavior in graph pipelines.
+
+## If you use MCP directly
+
+Recommended path:
+
+- adopt browser_acquire_and_extract for runner-first workflows
+- keep lower-level browser tools for advanced or debugging flows
+
+## If you use stygian-graph pipelines
+
+To opt into acquisition runner on browser nodes:
+
+1. enable acquisition-runner feature
+2. add node-level acquisition block
+3. validate pipeline behavior in CI for both legacy and opt-in paths
+
+Example opt-in block:
+
+```toml
+[nodes.params.acquisition]
+enabled = true
+mode = "resilient"
+wait_for_selector = "main"
+total_timeout_secs = 45
+```
+
+## Compatibility Guarantees and Boundaries
+
+Guaranteed by this refactor:
+
+- additive graph integration only
+- legacy graph behavior preserved by default
+- no crate-layout changes
+- deterministic runner/MCP failure structures
+
+Not guaranteed:
+
+- automatic behavioral changes to existing graph browser nodes
+- blanket migration of all low-level browser workflows to runner-first APIs
+
+## Verification and CI Expectations
+
+Recommended validation sequence:
+
+1. cargo build --workspace --all-features
+2. cargo test --workspace --all-features
+3. cargo clippy --workspace --all-features -- -D warnings
+
+For graph users, add matrix checks where practical:
+
+- legacy path (without acquisition-runner feature)
+- opt-in bridge path (with acquisition-runner and acquisition block)
+
+## Extending This Refactor Safely
+
+Follow these guardrails for future changes:
+
+- keep runner outputs deterministic and machine-consumable
+- preserve additive-only behavior in stygian-graph
+- keep policy mapping pure in stygian-charon
+- avoid coupling MCP protocol concerns into runtime internals
+- preserve no-unwrap/no-expect policy in library code
+
+When adding new runner modes or diagnostics:
+
+- update MCP schema/docs and integration tests together
+- add at least one failure-path test and one success-path test
+- document compatibility impact explicitly
+
+## Quick File Map
+
+- Refactor plan: plan-refactor.toml
+- Progress status: PROGRESS.md
+- Browser runner core: crates/stygian-browser/src/acquisition.rs
+- MCP high-level tool: crates/stygian-browser/src/mcp.rs
+- Charon mapping: crates/stygian-charon/src/acquisition.rs
+- Optional graph bridge: crates/stygian-graph/src/mcp.rs
+- Graph MCP docs: book/src/mcp/graph-tools.md
+- MCP security baseline docs: book/src/mcp/overview.md
+
+## Known Operational Benefits After Refactor
+
+- clearer default path for hard-target acquisition
+- fewer manual low-level tool combinations for common cases
+- more stable diagnostics for automation and incident triage
+- safer downstream adoption due to explicit opt-in boundaries
+
+## Open Follow-Ups (Optional)
+
+Potential future improvements that are compatible with this design:
+
+- expand runner mode guidance with target-type playbooks
+- add more pipeline examples that compare legacy vs opt-in bridge behavior
+- add docs page dedicated to diagnostics interpretation and failure triage

--- a/examples/acquisition-runner-graph-opt-in.toml
+++ b/examples/acquisition-runner-graph-opt-in.toml
@@ -1,0 +1,25 @@
+# acquisition-runner-graph-opt-in.toml
+#
+# Demonstrates optional stygian-graph bridge usage for browser nodes.
+#
+# Important:
+# - Build stygian-graph with feature `acquisition-runner`.
+# - The bridge runs only when [nodes.params.acquisition] is present.
+# - Without this block, browser nodes keep legacy skip behavior in graph_pipeline_run.
+
+[[services]]
+name = "browser"
+kind = "browser"
+
+[[nodes]]
+name = "acquire-example"
+service = "browser"
+url = "https://example.com"
+
+[nodes.params.acquisition]
+mode = "resilient"
+wait_for_selector = "body"
+total_timeout_secs = 45
+
+# Optional extraction expression evaluated in browser stages.
+# extraction_js = "({ title: document.title, href: location.href })"

--- a/examples/acquisition-runner-modes.md
+++ b/examples/acquisition-runner-modes.md
@@ -1,0 +1,89 @@
+# acquisition-runner-modes.md
+
+Runner-first MCP examples for the browser acquisition ladder.
+
+Tool name: `browser_acquire_and_extract`
+
+Supported modes:
+
+- `fast`
+- `resilient`
+- `hostile`
+- `investigate`
+
+## End-to-end call (`resilient`)
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "browser_acquire_and_extract",
+    "arguments": {
+      "url": "https://example.com/products",
+      "mode": "resilient",
+      "wait_for_selector": "article.product",
+      "extraction_js": "Array.from(document.querySelectorAll('article.product h2')).map(n => n.textContent?.trim()).filter(Boolean)",
+      "total_timeout_secs": 45
+    }
+  }
+}
+```
+
+## `fast`
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "browser_acquire_and_extract",
+    "arguments": {
+      "url": "https://example.com",
+      "mode": "fast"
+    }
+  }
+}
+```
+
+## `hostile`
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "browser_acquire_and_extract",
+    "arguments": {
+      "url": "https://example.com/challenge",
+      "mode": "hostile",
+      "wait_for_selector": "main",
+      "total_timeout_secs": 60
+    }
+  }
+}
+```
+
+## `investigate`
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "browser_acquire_and_extract",
+    "arguments": {
+      "url": "https://example.com",
+      "mode": "investigate",
+      "extraction_js": "({ title: document.title, href: location.href })"
+    }
+  }
+}
+```
+
+## Migration quick reference
+
+- Old low-level MCP flow: `browser_acquire` -> `browser_navigate` -> `browser_eval`/`browser_extract` -> `browser_release`
+- New runner-first flow: one `browser_acquire_and_extract` call with `mode`
+
+Use the old low-level path only when you need custom multi-step interaction control.


### PR DESCRIPTION
## Added
- Added stygian-browser acquisition runner core with deterministic escalation ladders and timeout/setup-failure bundles.
- Added stygian-charon runtime-policy mapping and MCP tool browser_acquire_and_extract with mode validation and compact diagnostics.
- Added stygian-graph optional acquisition bridge behind acquisition-runner feature and node opt-in.
- Added docs/acquisition-runner-refactor-guide.md for architecture, contracts, compatibility, and migration.

## Changed
- Updated pipeline_run docs for post-refactor browser node opt-in/feature-gated execution behavior.
- Added MCP security baseline guidance (PII redaction, guardrails, exfiltration controls, RBAC/logging/runbook).
- Consolidated progress reporting into workspace PROGRESS.md and updated .gitignore housekeeping.

## Fixed
- Applied strict clippy compliance fixes across acquisition-runner and graph bridge paths.
- Resolved stygian-graph callback future Send/Sync bound issues in MCP pipeline bridge execution.

## Documentation
- Updated README/guides with runner-first mode guidance and compatibility notes.
- Added runner-focused examples for mode selection and graph opt-in integration.