### PR TITLE
feat(proxy): CDN edge type, persistent TCP, TLS capability, DNS discovery, health jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **stygian-proxy (health jitter)**: `ProxyConfig::health_check_jitter_pct` spreads
+  health-check wake intervals by ±N% using a CSPRNG, preventing thundering-herd
+  probes against shared targets
+- **stygian-proxy (CDN egress)**: `ProxyType::CdnEdge` variant for CDN-fronted egress
+  nodes; paired with `ProxyCapabilities::is_cdn_edge` and `cdn_provider` fields and
+  the `CapabilityRequirement::require_cdn_edge` filter
+- **stygian-proxy (persistent connections)**: `TransportPreference::PersistentTcp`
+  routing path with `ProxyConfig::max_requests_per_connection` and
+  `connection_max_age_secs` lifetime bounds
+- **stygian-proxy (DNS discovery)**: `DnsTxtFetcher` behind the `dns-fetcher` feature
+  gate resolves proxy lists from DNS TXT records via `hickory-resolver`
+- **stygian-proxy (TLS capability)**: `ProxyCapabilities::tls_profile` and
+  `CapabilityRequirement::require_tls_profile` for profile-aware proxy selection;
+  `ProxyManagerBridge::bind_proxy_with_tls_profile()` in the `browser` feature
 - **Extension (recorder UI)**: Reworked in-page recording experience with hover tooltip,
   selector confidence badges, in-page region naming card, undo support, and compact
   recording overlay with live region count

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,6 +1332,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,6 +1786,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.6",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.6",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2151,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry",
+ "windows-result 0.4.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2255,6 +2325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2370,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -3394,6 +3479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4321,6 +4412,7 @@ version = "0.13.4"
 dependencies = [
  "async-trait",
  "futures",
+ "hickory-resolver",
  "rand 0.10.1",
  "reqwest 0.13.2",
  "serde",
@@ -5578,6 +5670,12 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/book/src/proxy/health-circuit-breaker.md
+++ b/book/src/proxy/health-circuit-breaker.md
@@ -36,6 +36,28 @@ let (cancel, _task) = manager.start();
 cancel.cancel();
 ```
 
+### Interval jitter
+
+To prevent all health-check probes from firing at the same instant (a
+"thundering herd" against shared infrastructure), set `health_check_jitter_pct`
+in `ProxyConfig`. Each sleep between cycles is perturbed by a random factor in
+`[1 − pct, 1 + pct)` using a thread-local CSPRNG.
+
+```rust,no_run
+use std::time::Duration;
+use stygian_proxy::ProxyConfig;
+
+let config = ProxyConfig {
+    health_check_interval: Duration::from_secs(60),
+    // Each cycle sleeps between 48 s and 72 s (±20%)
+    health_check_jitter_pct: 0.20,
+    ..ProxyConfig::default()
+};
+```
+
+`health_check_jitter_pct` is clamped to `[0.0, 0.99]`. Set it to `0.0`
+(the default) for a fixed interval.
+
 ### On-demand check
 
 Call `health_checker.check_once().await` to run a single probe cycle without
@@ -132,4 +154,32 @@ println!("total={} healthy={} open_circuits={}",
 | High-churn scraping (many short requests) | Lower `circuit_open_threshold` to 2–3; shorter `circuit_half_open_after` (10–15 s) |
 | Long-lived connections | Raise `circuit_open_threshold` to 10+; extend `circuit_half_open_after` (60–120 s) |
 | Residential proxies (naturally flaky) | Use `WeightedStrategy` with lower weights for known flaky proxies; keep threshold at default (5) |
+| Shared datacenter egress | Set `health_check_jitter_pct = 0.20–0.30` to spread probes across the interval window |
 | Dev / testing | `health_check_interval = 5 s`; `health_check_url` pointing to a local echo server |
+
+---
+
+## Persistent-connection config
+
+For workloads that benefit from reusing TCP connections across multiple requests
+(e.g. CONNECT-tunnelled HTTP/1.1 or HTTP/2), set `TransportPreference::PersistentTcp`
+at the routing layer and configure the lifetime bounds:
+
+```rust,no_run
+use stygian_proxy::ProxyConfig;
+
+let config = ProxyConfig {
+    // Retire a connection after 200 requests or 5 minutes, whichever comes first.
+    max_requests_per_connection: Some(200),
+    connection_max_age_secs: Some(300),
+    ..ProxyConfig::default()
+};
+```
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `max_requests_per_connection` | `None` | Maximum requests before connection retirement |
+| `connection_max_age_secs` | `None` | Wall-clock lifetime cap in seconds |
+
+When both fields are `None` the connection lifetime is governed entirely by the proxy
+server and TCP keepalive. Set either limit to prevent silent connection staleness.

--- a/book/src/proxy/integrations.md
+++ b/book/src/proxy/integrations.md
@@ -127,6 +127,86 @@ impl BrowserProxySource for MyProxySource {
 
 ---
 
+## DNS TXT proxy discovery (`dns-fetcher` feature)
+
+Enable the `dns-fetcher` feature to resolve proxy lists from DNS TXT records.
+This is useful for infrastructure-managed proxy registries that publish endpoints
+via DNS rather than an HTTP API.
+
+```toml
+[dependencies]
+stygian-proxy = { version = "*", features = ["dns-fetcher"] }
+```
+
+`DnsTxtFetcher` implements `ProxyFetcher` and queries a DNS TXT record where each
+string is a proxy URL (`http://host:port` or `socks5://host:port`):
+
+```rust,no_run
+use stygian_proxy::DnsTxtFetcher;
+use stygian_proxy::fetcher::{ProxyFetcher, load_from_fetcher};
+use std::sync::Arc;
+use stygian_proxy::{MemoryProxyStore, ProxyConfig, ProxyManager};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let storage = Arc::new(MemoryProxyStore::default());
+    let manager = Arc::new(
+        ProxyManager::with_round_robin(Arc::clone(&storage), ProxyConfig::default())?
+    );
+
+    // Load proxies from DNS TXT at "proxies.internal.example.com"
+    let fetcher = DnsTxtFetcher::new("proxies.internal.example.com");
+    let loaded = load_from_fetcher(&fetcher, &manager).await?;
+    println!("loaded {loaded} proxies from DNS");
+
+    Ok(())
+}
+```
+
+The TXT record format is one proxy URL per string value:
+
+```
+proxies.internal.example.com. 60 IN TXT "http://10.0.1.5:8080"
+proxies.internal.example.com. 60 IN TXT "socks5://10.0.1.6:1080"
+```
+
+`DnsTxtFetcher` uses `hickory-resolver` under the hood. The system resolver is
+used by default; call `DnsTxtFetcher::with_resolver_config()` to supply a custom
+one.
+
+---
+
+## TLS-profile-aware browser binding
+
+`ProxyManagerBridge` also exposes `bind_proxy_with_tls_profile()`, which
+combines proxy acquisition with a `CapabilityRequirement` that matches a
+specific TLS fingerprint profile. This ensures the acquired proxy is
+capable of presenting the correct TLS fingerprint for the browser session.
+
+```rust,no_run
+use std::sync::Arc;
+use stygian_proxy::{MemoryProxyStore, ProxyConfig, ProxyManager};
+use stygian_proxy::browser::ProxyManagerBridge;
+
+let bridge = ProxyManagerBridge::new(Arc::new(
+    ProxyManager::with_round_robin(
+        Arc::new(MemoryProxyStore::default()),
+        ProxyConfig::default(),
+    ).unwrap()
+));
+
+// Acquire a proxy that carries the "chrome_131" TLS profile
+let (proxy_url, handle) = bridge.bind_proxy_with_tls_profile("chrome_131").await?;
+// Pass proxy_url to your browser context; handle tracks the session outcome.
+handle.mark_success();
+```
+
+If no proxy in the pool satisfies the requested profile,
+`ProxyError::AllProxiesUnhealthy` is returned — the same error returned
+when no healthy proxy of any kind is available.
+
+---
+
 ## Failure tracking across integrations
 
 `ProxyHandle` uses RAII to track request outcomes. The same contract applies

--- a/book/src/proxy/overview.md
+++ b/book/src/proxy/overview.md
@@ -14,11 +14,16 @@ latency metrics, and integrates directly with both `stygian-graph` HTTP adapters
 | **Rotation strategies** | Round-robin, random, weighted (by proxy weight), least-used (by request count) |
 | **Per-proxy metrics** | Atomic latency and success-rate tracking — zero lock contention |
 | **Async health checker** | Configurable-interval background task; each proxy probed concurrently via `JoinSet` |
+| **Health-check jitter** | Per-cycle random ±N% interval spread via `health_check_jitter_pct` — prevents thundering-herd against shared targets |
 | **Circuit breaker** | Per-proxy lock-free FSM: `Closed → Open → HalfOpen`; auto-recovery after cooldown |
+| **Capability filtering** | Tag proxies with `tls_profile`, `is_cdn_edge`, and arbitrary tags; filter at acquire time via `CapabilityRequirement` |
+| **CDN-edge proxy type** | `ProxyType::CdnEdge` for CDN-fronted egress nodes alongside `Http`, `Https`, `Socks4`, `Socks5` |
+| **Persistent connections** | `TransportPreference::PersistentTcp` with configurable max-requests and connection max-age |
 | **In-memory pool** | No external database required; satisfies the `ProxyStoragePort` trait |
 | **graph integration** | `ProxyManagerPort` trait for `stygian-graph` HTTP adapters (feature `graph`) |
-| **browser integration** | Per-context proxy binding for `stygian-browser` (feature `browser`) |
+| **browser integration** | Per-context proxy binding for `stygian-browser` (feature `browser`); TLS-profile-aware via `bind_proxy_with_tls_profile` |
 | **SOCKS support** | `Socks4` and `Socks5` proxy types (feature `socks`) |
+| **DNS TXT discovery** | `DnsTxtFetcher` resolves proxy lists from DNS TXT records (feature `dns-fetcher`) |
 
 ---
 
@@ -80,13 +85,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 │                                         │
 │  ┌──────────────┐  ┌─────────────────┐  │
 │  │ HealthChecker│  │ CircuitBreakers │  │
-│  │  (background)│  │  (per proxy)    │  │
-│  └──────────────┘  └─────────────────┘  │
+  │ + jitter     │  │  (per proxy)    │  │
+  └──────────────┘  └─────────────────┘  │
 │                                         │
 │  ┌──────────────────────────────────┐   │
 │  │       RotationStrategy           │   │
 │  │  RoundRobin / Random / Weighted  │   │
 │  │  / LeastUsed                     │   │
+│  └──────────────────────────────────┘   │
+│                                         │
+│  ┌──────────────────────────────────┐   │
+│  │  CapabilityRequirement filter    │   │
+│  │  tls_profile / cdn_edge / tags   │   │
 │  └──────────────────────────────────┘   │
 │                                         │
 │  ┌──────────────────────────────────┐   │

--- a/book/src/proxy/strategies.md
+++ b/book/src/proxy/strategies.md
@@ -78,6 +78,56 @@ Use this strategy when proxies have different capacities, quotas, or observed sp
 
 ---
 
+## Capability filtering
+
+All four strategies operate on a pre-filtered `ProxyCandidate` slice. Before
+a strategy runs, `ProxyManager` filters the pool by `CapabilityRequirement`.
+Use `acquire_with_capabilities()` to express requirements at call time:
+
+```rust,no_run
+use stygian_proxy::types::CapabilityRequirement;
+
+let req = CapabilityRequirement {
+    require_tls_profile: Some("chrome_131".into()),
+    require_cdn_edge: false,
+    require_tags: vec!["us-east".into()],
+    ..CapabilityRequirement::default()
+};
+let handle = manager.acquire_with_capabilities(req).await?;
+```
+
+### ProxyCapabilities fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `tls_profile` | `Option<String>` | Named TLS fingerprint profile (`"chrome_131"`, `"firefox_133"`, …) |
+| `is_cdn_edge` | `bool` | `true` for CDN-fronted egress nodes (`ProxyType::CdnEdge`) |
+| `cdn_provider` | `Option<String>` | Optional CDN provider name (e.g. `"cloudflare"`) |
+| `tags` | `Vec<String>` | Arbitrary operator-defined labels |
+
+Annotate proxies at registration time:
+
+```rust,no_run
+use stygian_proxy::types::{Proxy, ProxyType, ProxyCapabilities};
+
+manager.add_proxy(Proxy {
+    url: "http://edge1.cdn.example.com:8080".into(),
+    proxy_type: ProxyType::CdnEdge,
+    capabilities: ProxyCapabilities {
+        tls_profile: Some("chrome_131".into()),
+        is_cdn_edge: true,
+        cdn_provider: Some("cloudflare".into()),
+        tags: vec!["eu-west".into()],
+    },
+    ..Default::default()
+}).await?;
+```
+
+Proxies whose capabilities do not satisfy a `CapabilityRequirement` are
+removed from the candidate slice before the rotation strategy runs.
+
+---
+
 ## LeastUsedStrategy
 
 Selects the healthy proxy with the **lowest total request count** at the time of the call.

--- a/crates/stygian-browser/src/proxy.rs
+++ b/crates/stygian-browser/src/proxy.rs
@@ -136,4 +136,20 @@ pub trait ProxySource: Send + Sync + fmt::Debug + 'static {
     /// Returns [`crate::error::BrowserError::ProxyUnavailable`] if no proxy
     /// is currently available (e.g. circuit breaker open, pool empty).
     async fn bind_proxy(&self) -> Result<(String, Box<dyn ProxyLease>)>;
+
+    /// Acquire a proxy that presents the specified TLS fingerprint profile.
+    ///
+    /// `profile` is an advisory hint such as `"chrome-131"` or `"firefox-120"`.
+    /// `None` means no preference — equivalent to calling
+    /// [`bind_proxy`](ProxySource::bind_proxy).
+    ///
+    /// The default implementation ignores `profile` and delegates to
+    /// [`bind_proxy`](ProxySource::bind_proxy).  Override this method when
+    /// the backing pool supports TLS-profile-aware selection.
+    async fn bind_proxy_with_tls_profile(
+        &self,
+        _profile: Option<&str>,
+    ) -> Result<(String, Box<dyn ProxyLease>)> {
+        self.bind_proxy().await
+    }
 }

--- a/crates/stygian-proxy/Cargo.toml
+++ b/crates/stygian-proxy/Cargo.toml
@@ -19,6 +19,7 @@ browser      = ["dep:stygian-browser"]
 tls-profiled = ["dep:stygian-browser", "stygian-browser/tls-config"]
 # MCP (Model Context Protocol) server — exposes proxy pool tools over stdin/stdout JSON-RPC 2.0
 mcp = []
+dns-fetcher  = ["dep:hickory-resolver"]
 
 [dependencies]
 # Workspace deps
@@ -43,6 +44,9 @@ rand = { workspace = true }
 
 # Browser integration (optional)
 stygian-browser = { path = "../stygian-browser", version = "0.13.4", optional = true }
+
+# DNS TXT proxy discovery (optional)
+hickory-resolver = { version = "0.24", features = ["tokio-runtime"], optional = true }
 
 [dev-dependencies]
 tokio       = { workspace = true }

--- a/crates/stygian-proxy/src/browser.rs
+++ b/crates/stygian-proxy/src/browser.rs
@@ -138,6 +138,28 @@ impl stygian_browser::proxy::ProxySource for ProxyManagerBridge {
         let url = handle.proxy_url.clone();
         Ok((url, Box::new(ProxyLeaseAdapter(handle))))
     }
+
+    async fn bind_proxy_with_tls_profile(
+        &self,
+        profile: Option<&str>,
+    ) -> stygian_browser::error::Result<(String, Box<dyn stygian_browser::proxy::ProxyLease>)> {
+        let Some(profile) = profile else {
+            return stygian_browser::proxy::ProxySource::bind_proxy(self).await;
+        };
+        let req = crate::types::CapabilityRequirement {
+            require_tls_profile: Some(profile.to_string()),
+            ..Default::default()
+        };
+        let handle = self
+            .manager
+            .acquire_with_capabilities(&req)
+            .await
+            .map_err(|e| stygian_browser::error::BrowserError::ProxyUnavailable {
+                reason: e.to_string(),
+            })?;
+        let url = handle.proxy_url.clone();
+        Ok((url, Box::new(ProxyLeaseAdapter(handle))))
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -819,6 +819,7 @@ impl DnsTxtFetcher {
     }
 
     /// Attach extra tags to every proxy discovered via this fetcher.
+    #[must_use]
     pub fn with_tags(mut self, tags: Vec<String>) -> Self {
         self.tags.extend(tags);
         self
@@ -852,7 +853,7 @@ impl DnsTxtFetcher {
             return None;
         }
         let parts: Vec<&str> = remainder.splitn(3, ':').collect();
-        let type_str = parts.first().map(|s| s.trim()).unwrap_or("http");
+        let type_str = parts.first().map_or("http", |s| s.trim());
         match type_str.to_ascii_lowercase().as_str() {
             "cdn_edge" | "cdn" => {
                 let provider = parts

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -998,6 +998,7 @@ mod tests {
     // ── DnsTxtFetcher::parse_record ───────────────────────────────────────────
 
     #[cfg(feature = "dns-fetcher")]
+    #[expect(clippy::unwrap_used, reason = "test assertions on Option")]
     mod dns_txt {
         use super::*;
 

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -357,6 +357,7 @@ impl FreeListFetcher {
                     ProxyType::Socks4 => "socks4",
                     #[cfg(feature = "socks")]
                     ProxyType::Socks5 => "socks5",
+                    ProxyType::CdnEdge => "https",
                 };
                 Some(Proxy {
                     url: format!("{scheme}://{host}:{port}"),
@@ -594,6 +595,7 @@ impl FreeApiProxiesFetcher {
         match normalized.as_deref() {
             None | Some("" | "http") => Some(ProxyType::Http),
             Some("https") => Some(ProxyType::Https),
+            Some("cdn" | "cdn_edge") => Some(ProxyType::CdnEdge),
             #[cfg(feature = "socks")]
             Some("socks" | "socks5") => Some(ProxyType::Socks5),
             #[cfg(feature = "socks")]
@@ -634,6 +636,7 @@ impl FreeApiProxiesFetcher {
             ProxyType::Socks4 => "socks4",
             #[cfg(feature = "socks")]
             ProxyType::Socks5 => "socks5",
+            ProxyType::CdnEdge => "https",
         };
 
         let mut tags = self.tags.clone();
@@ -763,6 +766,208 @@ pub async fn load_from_fetcher(
 
     debug!(total, loaded, "Proxy list loaded into manager");
     Ok(loaded)
+}
+
+// ─── DnsTxtFetcher ───────────────────────────────────────────────────────────
+
+/// Fetches proxy endpoints from DNS TXT records.
+///
+/// Each TXT record at the configured zone should encode one proxy entry using
+/// the following colon-delimited format:
+///
+/// ```text
+/// host:port                        HTTP proxy, no auth
+/// host:port:https                  HTTPS proxy, no auth
+/// host:port:socks5                 SOCKS5 proxy (requires socks feature)
+/// host:port:socks5:user:pass       SOCKS5 proxy with auth
+/// host:port:http:user:pass         HTTP proxy with auth
+/// host:port:cdn_edge               CDN edge proxy
+/// host:port:cdn_edge:cloudflare    CDN edge proxy with provider metadata
+/// [::1]:port:http                  IPv6 host in bracket notation
+/// ```
+///
+/// Records that do not match the format are silently skipped.
+///
+/// # Example
+///
+/// ```no_run
+/// use stygian_proxy::fetcher::{DnsTxtFetcher, ProxyFetcher};
+///
+/// # async fn run() -> stygian_proxy::error::ProxyResult<()> {
+/// let fetcher = DnsTxtFetcher::new("proxies.internal.example.com");
+/// let proxies = fetcher.fetch().await?;
+/// println!("Discovered {} proxies via DNS", proxies.len());
+/// # Ok(())
+/// # }
+/// ```
+#[cfg(feature = "dns-fetcher")]
+pub struct DnsTxtFetcher {
+    zone: String,
+    tags: Vec<String>,
+}
+
+#[cfg(feature = "dns-fetcher")]
+impl DnsTxtFetcher {
+    /// Create a fetcher that queries TXT records for `zone`.
+    ///
+    /// `zone` is a DNS name such as `"proxies.internal.example.com"`.
+    pub fn new(zone: impl Into<String>) -> Self {
+        Self {
+            zone: zone.into(),
+            tags: vec!["dns-txt".into()],
+        }
+    }
+
+    /// Attach extra tags to every proxy discovered via this fetcher.
+    pub fn with_tags(mut self, tags: Vec<String>) -> Self {
+        self.tags.extend(tags);
+        self
+    }
+
+    /// Parse a single TXT record string into a [`Proxy`].
+    fn parse_record(&self, record: &str) -> Option<Proxy> {
+        let record = record.trim();
+        if record.is_empty() || record.starts_with('#') {
+            return None;
+        }
+        // Extract host and port, supporting bracketed IPv6 addresses.
+        let (host, port, remainder) = if let Some(rest) = record.strip_prefix('[') {
+            let end = rest.find(']')?;
+            let host = format!("[{}]", rest.get(..end)?);
+            let after = rest.get(end + 1..).unwrap_or("").trim_start_matches(':');
+            let colon = after.find(':').unwrap_or(after.len());
+            let port: u16 = after.get(..colon)?.trim().parse().ok()?;
+            let rem = after.get(colon + 1..).unwrap_or("");
+            (host, port, rem)
+        } else {
+            let first = record.find(':')?;
+            let host = record.get(..first)?.trim().to_string();
+            let rest = record.get(first + 1..)?;
+            let second = rest.find(':').unwrap_or(rest.len());
+            let port: u16 = rest.get(..second)?.trim().parse().ok()?;
+            let rem = rest.get(second + 1..).unwrap_or("");
+            (host, port, rem)
+        };
+        if host.is_empty() || port == 0 {
+            return None;
+        }
+        let parts: Vec<&str> = remainder.splitn(3, ':').collect();
+        let type_str = parts.first().map(|s| s.trim()).unwrap_or("http");
+        match type_str.to_ascii_lowercase().as_str() {
+            "cdn_edge" | "cdn" => {
+                let provider = parts
+                    .get(1)
+                    .copied()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                Some(Proxy {
+                    url: format!("https://{host}:{port}"),
+                    proxy_type: ProxyType::CdnEdge,
+                    username: None,
+                    password: None,
+                    weight: 1,
+                    tags: self.tags.clone(),
+                    capabilities: crate::types::ProxyCapabilities {
+                        is_cdn_edge: true,
+                        cdn_provider: provider,
+                        ..Default::default()
+                    },
+                })
+            }
+            type_str => {
+                let proxy_type = match type_str {
+                    "https" => ProxyType::Https,
+                    #[cfg(feature = "socks")]
+                    "socks5" | "socks" => ProxyType::Socks5,
+                    #[cfg(feature = "socks")]
+                    "socks4" => ProxyType::Socks4,
+                    _ => ProxyType::Http,
+                };
+                let scheme = match proxy_type {
+                    ProxyType::Http => "http",
+                    ProxyType::Https => "https",
+                    #[cfg(feature = "socks")]
+                    ProxyType::Socks4 => "socks4",
+                    #[cfg(feature = "socks")]
+                    ProxyType::Socks5 => "socks5",
+                    ProxyType::CdnEdge => "https",
+                };
+                let username = parts
+                    .get(1)
+                    .copied()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                let password = parts
+                    .get(2)
+                    .copied()
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string);
+                Some(Proxy {
+                    url: format!("{scheme}://{host}:{port}"),
+                    proxy_type,
+                    username,
+                    password,
+                    weight: 1,
+                    tags: self.tags.clone(),
+                    capabilities: crate::types::ProxyCapabilities::default(),
+                })
+            }
+        }
+    }
+}
+
+#[cfg(feature = "dns-fetcher")]
+#[async_trait]
+impl ProxyFetcher for DnsTxtFetcher {
+    async fn fetch(&self) -> ProxyResult<Vec<Proxy>> {
+        use hickory_resolver::TokioAsyncResolver;
+        use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+
+        let resolver =
+            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
+
+        let lookup =
+            resolver
+                .txt_lookup(self.zone.as_str())
+                .await
+                .map_err(|e| ProxyError::FetchFailed {
+                    origin: self.zone.clone(),
+                    message: format!("DNS TXT lookup failed for '{}': {e}", self.zone),
+                })?;
+
+        let mut proxies: Vec<Proxy> = Vec::new();
+        for txt in lookup.iter() {
+            // Each TXT record may contain multiple character-strings; join them.
+            let record_str: String = txt
+                .iter()
+                .filter_map(|bytes| std::str::from_utf8(bytes).ok())
+                .collect::<Vec<_>>()
+                .join("");
+            if let Some(proxy) = self.parse_record(&record_str) {
+                proxies.push(proxy);
+            }
+        }
+
+        if proxies.is_empty() {
+            return Err(ProxyError::FetchFailed {
+                origin: self.zone.clone(),
+                message: format!(
+                    "no valid proxy records found in DNS TXT for '{}'",
+                    self.zone
+                ),
+            });
+        }
+
+        debug!(
+            zone = %self.zone,
+            count = proxies.len(),
+            "fetched proxy list from DNS TXT",
+        );
+        Ok(proxies)
+    }
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/crates/stygian-proxy/src/fetcher.rs
+++ b/crates/stygian-proxy/src/fetcher.rs
@@ -366,7 +366,10 @@ impl FreeListFetcher {
                     password: None,
                     weight: 1,
                     tags: self.tags.clone(),
-                    capabilities: crate::types::ProxyCapabilities::default(),
+                    capabilities: crate::types::ProxyCapabilities {
+                        is_cdn_edge: matches!(proxy_type, ProxyType::CdnEdge),
+                        ..Default::default()
+                    },
                 })
             })
             .collect();
@@ -656,7 +659,10 @@ impl FreeApiProxiesFetcher {
             password: record.password.filter(|v| !v.trim().is_empty()),
             weight: 1,
             tags,
-            capabilities: crate::types::ProxyCapabilities::default(),
+            capabilities: crate::types::ProxyCapabilities {
+                is_cdn_edge: matches!(proxy_type, ProxyType::CdnEdge),
+                ..Default::default()
+            },
         })
     }
 
@@ -924,11 +930,19 @@ impl DnsTxtFetcher {
 #[async_trait]
 impl ProxyFetcher for DnsTxtFetcher {
     async fn fetch(&self) -> ProxyResult<Vec<Proxy>> {
-        use hickory_resolver::TokioAsyncResolver;
-        use hickory_resolver::config::{ResolverConfig, ResolverOpts};
+        use hickory_resolver::Resolver;
+        use hickory_resolver::config::ResolverConfig;
+        use hickory_resolver::net::runtime::TokioRuntimeProvider;
 
-        let resolver =
-            TokioAsyncResolver::tokio(ResolverConfig::default(), ResolverOpts::default());
+        let resolver = Resolver::builder_with_config(
+            ResolverConfig::default(),
+            TokioRuntimeProvider::default(),
+        )
+        .build()
+        .map_err(|e| ProxyError::FetchFailed {
+            origin: self.zone.clone(),
+            message: format!("failed to build DNS resolver: {e}"),
+        })?;
 
         let lookup =
             resolver
@@ -940,15 +954,19 @@ impl ProxyFetcher for DnsTxtFetcher {
                 })?;
 
         let mut proxies: Vec<Proxy> = Vec::new();
-        for txt in lookup.iter() {
+        for record in lookup.answers() {
+            use hickory_resolver::proto::rr::RData;
             // Each TXT record may contain multiple character-strings; join them.
-            let record_str: String = txt
-                .iter()
-                .filter_map(|bytes| std::str::from_utf8(bytes).ok())
-                .collect::<Vec<_>>()
-                .join("");
-            if let Some(proxy) = self.parse_record(&record_str) {
-                proxies.push(proxy);
+            if let RData::TXT(ref txt) = record.data {
+                let record_str: String = txt
+                    .txt_data
+                    .iter()
+                    .filter_map(|bytes| std::str::from_utf8(bytes).ok())
+                    .collect::<Vec<_>>()
+                    .join("");
+                if let Some(proxy) = self.parse_record(&record_str) {
+                    proxies.push(proxy);
+                }
             }
         }
 
@@ -976,6 +994,87 @@ impl ProxyFetcher for DnsTxtFetcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── DnsTxtFetcher::parse_record ───────────────────────────────────────────
+
+    #[cfg(feature = "dns-fetcher")]
+    mod dns_txt {
+        use super::*;
+
+        fn fetcher() -> DnsTxtFetcher {
+            DnsTxtFetcher::new("proxies.example.com")
+        }
+
+        #[test]
+        fn parse_http_host_port() {
+            let proxy = fetcher().parse_record("10.0.1.5:8080").unwrap();
+            assert_eq!(proxy.url, "http://10.0.1.5:8080");
+            assert_eq!(proxy.proxy_type, ProxyType::Http);
+            assert!(proxy.username.is_none());
+            assert!(proxy.password.is_none());
+        }
+
+        #[test]
+        fn parse_https_record() {
+            let proxy = fetcher().parse_record("10.0.1.5:443:https").unwrap();
+            assert_eq!(proxy.url, "https://10.0.1.5:443");
+            assert_eq!(proxy.proxy_type, ProxyType::Https);
+        }
+
+        #[test]
+        fn parse_cdn_edge_with_provider() {
+            let proxy = fetcher()
+                .parse_record("edge.cdn.example.com:443:cdn_edge:cloudflare")
+                .unwrap();
+            assert_eq!(proxy.url, "https://edge.cdn.example.com:443");
+            assert_eq!(proxy.proxy_type, ProxyType::CdnEdge);
+            assert!(proxy.capabilities.is_cdn_edge);
+            assert_eq!(
+                proxy.capabilities.cdn_provider.as_deref(),
+                Some("cloudflare")
+            );
+        }
+
+        #[test]
+        fn parse_cdn_edge_without_provider() {
+            let proxy = fetcher()
+                .parse_record("cdn.example.com:443:cdn_edge")
+                .unwrap();
+            assert!(proxy.capabilities.is_cdn_edge);
+            assert!(proxy.capabilities.cdn_provider.is_none());
+        }
+
+        #[test]
+        fn parse_auth_fields() {
+            let proxy = fetcher()
+                .parse_record("10.0.0.1:3128:http:alice:secret")
+                .unwrap();
+            assert_eq!(proxy.username.as_deref(), Some("alice"));
+            assert_eq!(proxy.password.as_deref(), Some("secret"));
+        }
+
+        #[test]
+        fn parse_ipv6_bracketed() {
+            let proxy = fetcher().parse_record("[::1]:8080").unwrap();
+            assert_eq!(proxy.url, "http://[::1]:8080");
+        }
+
+        #[test]
+        fn parse_empty_record_returns_none() {
+            assert!(fetcher().parse_record("").is_none());
+            assert!(fetcher().parse_record("   ").is_none());
+        }
+
+        #[test]
+        fn parse_comment_record_returns_none() {
+            assert!(fetcher().parse_record("# comment line").is_none());
+        }
+
+        #[test]
+        fn parse_invalid_port_returns_none() {
+            assert!(fetcher().parse_record("10.0.0.1:notaport").is_none());
+        }
+    }
 
     #[test]
     fn free_api_proxies_fetcher_request_url_no_params() {

--- a/crates/stygian-proxy/src/health.rs
+++ b/crates/stygian-proxy/src/health.rs
@@ -2,7 +2,9 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+
+use rand::RngExt;
 
 use tokio::sync::RwLock;
 use tokio::task::{JoinHandle, JoinSet};
@@ -122,15 +124,17 @@ impl HealthChecker {
     /// Cancel `token` to stop the task gracefully.  Missed ticks are skipped.
     pub fn spawn(self, token: CancellationToken) -> JoinHandle<()> {
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(self.config.health_check_interval);
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
+                let sleep_dur = jitter_duration(
+                    self.config.health_check_interval,
+                    self.config.health_check_jitter_pct,
+                );
                 tokio::select! {
                     () = token.cancelled() => {
                         tracing::info!("health checker: shutdown requested");
                         break;
                     }
-                    _ = interval.tick() => {
+                    () = tokio::time::sleep(sleep_dur) => {
                         self.check_all().await;
                     }
                 }
@@ -243,6 +247,20 @@ impl HealthChecker {
             "health check cycle complete"
         );
     }
+}
+
+/// Apply a random jitter factor to `base`.
+///
+/// `jitter_pct` is clamped to `[0.0, 0.99]`.  A value of `0.20` produces a
+/// sleep window uniformly distributed in `[base × 0.80, base × 1.20)`.
+fn jitter_duration(base: Duration, jitter_pct: f32) -> Duration {
+    if jitter_pct <= 0.0 {
+        return base;
+    }
+    let pct = jitter_pct.clamp(0.0, 0.99);
+    // gen::<f32>() ∈ [0.0, 1.0) → factor ∈ [1 − pct, 1 + pct)
+    let factor = 1.0_f32 + (rand::rng().random::<f32>() * 2.0_f32 - 1.0_f32) * pct;
+    base.mul_f32(factor.max(0.01))
 }
 
 #[cfg(any(test, feature = "tls-profiled"))]

--- a/crates/stygian-proxy/src/health.rs
+++ b/crates/stygian-proxy/src/health.rs
@@ -118,10 +118,11 @@ impl HealthChecker {
         Ok(self.with_profiled_client(requester))
     }
 
-    /// Spawn an infinite background task that checks proxies on every
-    /// `config.health_check_interval` tick.
+    /// Spawn an infinite background task that checks proxies on a jittered
+    /// sleep-based schedule derived from `config.health_check_interval`.
     ///
-    /// Cancel `token` to stop the task gracefully.  Missed ticks are skipped.
+    /// Each cycle sleeps for `jitter_duration(interval, jitter_pct)` before
+    /// running a probe pass.  Cancel `token` to stop the task gracefully.
     pub fn spawn(self, token: CancellationToken) -> JoinHandle<()> {
         tokio::spawn(async move {
             loop {
@@ -259,7 +260,10 @@ fn jitter_duration(base: Duration, jitter_pct: f32) -> Duration {
     }
     let pct = jitter_pct.clamp(0.0, 0.99);
     // random::<f32>() ∈ [0.0, 1.0) → factor ∈ [1 − pct, 1 + pct)
-    let factor = (rand::rng().random::<f32>() * 2.0_f32 - 1.0_f32).mul_add(pct, 1.0_f32);
+    let factor = rand::rng()
+        .random::<f32>()
+        .mul_add(2.0_f32, -1.0_f32)
+        .mul_add(pct, 1.0_f32);
     base.mul_f32(factor.max(0.01))
 }
 

--- a/crates/stygian-proxy/src/health.rs
+++ b/crates/stygian-proxy/src/health.rs
@@ -258,8 +258,8 @@ fn jitter_duration(base: Duration, jitter_pct: f32) -> Duration {
         return base;
     }
     let pct = jitter_pct.clamp(0.0, 0.99);
-    // gen::<f32>() ∈ [0.0, 1.0) → factor ∈ [1 − pct, 1 + pct)
-    let factor = 1.0_f32 + (rand::rng().random::<f32>() * 2.0_f32 - 1.0_f32) * pct;
+    // random::<f32>() ∈ [0.0, 1.0) → factor ∈ [1 − pct, 1 + pct)
+    let factor = (rand::rng().random::<f32>() * 2.0_f32 - 1.0_f32).mul_add(pct, 1.0_f32);
     base.mul_f32(factor.max(0.01))
 }
 

--- a/crates/stygian-proxy/src/lib.rs
+++ b/crates/stygian-proxy/src/lib.rs
@@ -52,6 +52,8 @@ pub mod mcp;
 // Top-level re-exports
 pub use circuit_breaker::{CircuitBreaker, STATE_CLOSED, STATE_HALF_OPEN, STATE_OPEN};
 pub use error::{ProxyError, ProxyResult};
+#[cfg(feature = "dns-fetcher")]
+pub use fetcher::DnsTxtFetcher;
 pub use fetcher::{
     FreeApiProxiesFetcher, FreeListFetcher, FreeListSource, ProxyFetcher, load_from_fetcher,
 };

--- a/crates/stygian-proxy/src/mcp.rs
+++ b/crates/stygian-proxy/src/mcp.rs
@@ -34,7 +34,7 @@
 //! | `proxy_acquire` | – | `handle_token`, `proxy_url` |
 //! | `proxy_acquire_for_domain` | `domain` | `handle_token`, `proxy_url` |
 //! | `proxy_release` | `handle_token`, `success?` | success |
-//! | `proxy_acquire_with_capabilities` | `require_https_connect?`, `require_socks5_udp?`, `require_http3_tunnel?`, `require_geo_country?` | `handle_token`, `proxy_url` |
+//! | `proxy_acquire_with_capabilities` | `require_https_connect?`, `require_socks5_udp?`, `require_http3_tunnel?`, `require_geo_country?`, `require_cdn_edge?`, `require_tls_profile?` | `handle_token`, `proxy_url` |
 //! | `proxy_fetch_freelist` | `sources`, `tags?` | `loaded` |
 //! | `proxy_fetch_freeapiproxies` | `endpoint?`, `tags?` | `loaded` |
 
@@ -403,7 +403,9 @@ impl McpProxyServer {
                     "require_https_connect": { "type": "boolean", "description": "Require the proxy to support HTTPS CONNECT tunnelling (default: false)" },
                     "require_socks5_udp":    { "type": "boolean", "description": "Require SOCKS5 UDP relay support (default: false)" },
                     "require_http3_tunnel":  { "type": "boolean", "description": "Require HTTP/3 QUIC tunnel support (default: false)" },
-                    "require_geo_country":   { "type": "string",  "description": "ISO-3166-1 alpha-2 country code the egress IP must match (e.g. \"US\")" }
+                    "require_geo_country":   { "type": "string",  "description": "ISO-3166-1 alpha-2 country code the egress IP must match (e.g. \"US\")" },
+                    "require_cdn_edge":      { "type": "boolean", "description": "Require a CDN-edge proxy (default: false)" },
+                    "require_tls_profile":   { "type": "string",  "description": "Require a specific TLS fingerprint profile (e.g. \"chrome-131\", \"firefox-120\")" }
                 }
             }
         })
@@ -550,6 +552,7 @@ impl McpProxyServer {
                 "socks4" | "socks4a" => ProxyType::Socks4,
                 #[cfg(feature = "socks")]
                 "socks5" | "socks" => ProxyType::Socks5,
+                "cdn" | "cdn_edge" => ProxyType::CdnEdge,
                 "http" => ProxyType::Http,
                 other => {
                     return error_response(
@@ -801,6 +804,14 @@ impl McpProxyServer {
                 .unwrap_or(false),
             require_geo_country: args
                 .get("require_geo_country")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            require_cdn_edge: args
+                .get("require_cdn_edge")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            require_tls_profile: args
+                .get("require_tls_profile")
                 .and_then(Value::as_str)
                 .map(str::to_string),
         };

--- a/crates/stygian-proxy/src/routing.rs
+++ b/crates/stygian-proxy/src/routing.rs
@@ -20,6 +20,14 @@ pub enum TransportPreference {
     PreferH3,
     /// Always use HTTP/1.1 or HTTP/2 over a TCP CONNECT tunnel.
     ForceTcp,
+    /// Prefer a persistent TCP connection that spans multiple logical requests.
+    ///
+    /// Forces a TCP CONNECT tunnel and signals the HTTP client layer to keep
+    /// the underlying connection open between requests.  Connection lifetime
+    /// and per-connection request limits are governed by
+    /// [`crate::types::ProxyConfig::max_requests_per_connection`] and
+    /// [`crate::types::ProxyConfig::connection_max_age_secs`].
+    PersistentTcp,
 }
 
 /// Resolve the [`RoutingPath`] for a request given proxy capabilities and the
@@ -27,11 +35,12 @@ pub enum TransportPreference {
 ///
 /// # Decision logic
 ///
-/// | Preference   | `supports_http3_tunnel` | Result          |
-/// |--------------|------------------------|-----------------|
-/// | `PreferH3`   | `true`                 | `H3OverUdp`    |
-/// | `PreferH3`   | `false`                | `H1H2OverTcp`  |
-/// | `ForceTcp`   | any                    | `H1H2OverTcp`  |
+/// | Preference       | `supports_http3_tunnel` | Result           |
+/// |------------------|------------------------|------------------|
+/// | `PreferH3`       | `true`                 | `H3OverUdp`      |
+/// | `PreferH3`       | `false`                | `H1H2OverTcp`    |
+/// | `ForceTcp`       | any                    | `H1H2OverTcp`    |
+/// | `PersistentTcp`  | any                    | `PersistentTcp`  |
 ///
 /// # Example
 /// ```
@@ -59,6 +68,7 @@ pub const fn resolve_routing_path(
 ) -> RoutingPath {
     match preference {
         TransportPreference::ForceTcp => RoutingPath::H1H2OverTcp,
+        TransportPreference::PersistentTcp => RoutingPath::PersistentTcp,
         TransportPreference::PreferH3 => {
             if capabilities.supports_http3_tunnel {
                 RoutingPath::H3OverUdp
@@ -104,6 +114,18 @@ mod tests {
         assert_eq!(
             resolve_routing_path(&caps, TransportPreference::ForceTcp),
             RoutingPath::H1H2OverTcp,
+        );
+    }
+
+    #[test]
+    fn persistent_tcp_returns_persistent_tcp() {
+        let caps = ProxyCapabilities {
+            supports_http3_tunnel: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_routing_path(&caps, TransportPreference::PersistentTcp),
+            RoutingPath::PersistentTcp,
         );
     }
 }

--- a/crates/stygian-proxy/src/types.rs
+++ b/crates/stygian-proxy/src/types.rs
@@ -26,7 +26,7 @@ pub enum ProxyType {
     #[cfg(feature = "socks")]
     /// SOCKS5 proxy (requires the `socks` feature).
     Socks5,
-    /// CDN edge relay (Cloudflare, CloudFront, Azure Front Door, etc.).
+    /// CDN edge relay (`Cloudflare`, `CloudFront`, `Azure Front Door`, etc.).
     ///
     /// Traffic egresses through a CDN PoP rather than a traditional proxy
     /// server.  Provider metadata is carried in
@@ -447,7 +447,7 @@ pub struct ProxyConfig {
     pub connection_max_age_secs: Option<u64>,
 }
 
-fn default_health_check_jitter_pct() -> f32 {
+const fn default_health_check_jitter_pct() -> f32 {
     0.20
 }
 

--- a/crates/stygian-proxy/src/types.rs
+++ b/crates/stygian-proxy/src/types.rs
@@ -26,6 +26,12 @@ pub enum ProxyType {
     #[cfg(feature = "socks")]
     /// SOCKS5 proxy (requires the `socks` feature).
     Socks5,
+    /// CDN edge relay (Cloudflare, CloudFront, Azure Front Door, etc.).
+    ///
+    /// Traffic egresses through a CDN PoP rather than a traditional proxy
+    /// server.  Provider metadata is carried in
+    /// [`ProxyCapabilities::cdn_provider`].
+    CdnEdge,
 }
 
 /// TLS-profiled request mode for proxy-side HTTP operations.
@@ -78,6 +84,23 @@ pub struct ProxyCapabilities {
     /// `None` means the provider did not supply confidence metadata.
     #[serde(default)]
     pub geo_confidence: Option<f32>,
+    /// `true` when this proxy routes through a CDN edge node rather than a
+    /// traditional SOCKS/HTTP proxy server.
+    #[serde(default)]
+    pub is_cdn_edge: bool,
+    /// CDN provider name when `is_cdn_edge` is `true`.
+    ///
+    /// Advisory — used for monitoring and routing hints.
+    /// Examples: `"cloudflare"`, `"cloudfront"`, `"azure-front-door"`.
+    #[serde(default)]
+    pub cdn_provider: Option<String>,
+    /// TLS fingerprint profile this proxy presents toward the upstream target.
+    ///
+    /// Advisory identifier such as `"chrome-131"`, `"firefox-120"`, or
+    /// `"curl"`.  Use with [`CapabilityRequirement::require_tls_profile`] to
+    /// select proxies by their TLS stack identity.  `None` means unknown.
+    #[serde(default)]
+    pub tls_profile: Option<String>,
 }
 
 impl ProxyCapabilities {
@@ -104,6 +127,14 @@ impl ProxyCapabilities {
         }
         if let Some(ref required_country) = req.require_geo_country
             && self.geo_country.as_deref() != Some(required_country.as_str())
+        {
+            return false;
+        }
+        if req.require_cdn_edge && !self.is_cdn_edge {
+            return false;
+        }
+        if let Some(ref required_profile) = req.require_tls_profile
+            && self.tls_profile.as_deref() != Some(required_profile.as_str())
         {
             return false;
         }
@@ -137,6 +168,16 @@ pub struct CapabilityRequirement {
     /// Require a specific egress country (ISO-3166-1 alpha-2).
     #[serde(default)]
     pub require_geo_country: Option<String>,
+    /// Require a CDN-edge proxy (`is_cdn_edge` must be `true`).
+    #[serde(default)]
+    pub require_cdn_edge: bool,
+    /// Require a specific TLS fingerprint profile.
+    ///
+    /// When `Some`, only proxies whose [`ProxyCapabilities::tls_profile`]
+    /// matches this value exactly are eligible.  Examples: `"chrome-131"`,
+    /// `"firefox-120"`, `"curl"`.
+    #[serde(default)]
+    pub require_tls_profile: Option<String>,
 }
 
 /// The protocol routing path resolved for an outbound request.
@@ -157,6 +198,10 @@ pub enum RoutingPath {
     H1H2OverTcp,
     /// HTTP/3 (QUIC) over a UDP relay — requires `supports_http3_tunnel`.
     H3OverUdp,
+    /// Persistent TCP CONNECT tunnel — connection is kept alive between requests.
+    ///
+    /// Selected when [`crate::routing::TransportPreference::PersistentTcp`] is used.
+    PersistentTcp,
 }
 
 /// A proxy endpoint with optional authentication credentials.
@@ -350,6 +395,9 @@ mod serde_duration_secs {
 /// assert_eq!(cfg.circuit_open_threshold, 5);
 /// assert_eq!(cfg.circuit_half_open_after, Duration::from_secs(30));
 /// assert!(cfg.profiled_request_mode.is_none());
+/// assert_eq!(cfg.health_check_jitter_pct, 0.20_f32);
+/// assert!(cfg.max_requests_per_connection.is_none());
+/// assert!(cfg.connection_max_age_secs.is_none());
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -362,6 +410,16 @@ pub struct ProxyConfig {
     /// Per-probe HTTP timeout (seconds).
     #[serde(with = "serde_duration_secs")]
     pub health_check_timeout: Duration,
+    /// Jitter factor applied to the health-check sleep window.
+    ///
+    /// `0.20` distributes each check window uniformly over
+    /// `interval × [0.80, 1.20)`, preventing synchronised fleet-wide check
+    /// storms.  Set to `0.0` to disable jitter.  Clamped to `[0.0, 0.99]`
+    /// at runtime.
+    ///
+    /// Default: `0.20` (±20 %).
+    #[serde(default = "default_health_check_jitter_pct")]
+    pub health_check_jitter_pct: f32,
     /// Consecutive failures before the circuit trips to OPEN.
     pub circuit_open_threshold: u32,
     /// How long to wait in OPEN before transitioning to HALF-OPEN (seconds).
@@ -378,6 +436,19 @@ pub struct ProxyConfig {
     /// Ignored when `tls-profiled` is disabled.
     #[serde(default)]
     pub profiled_request_mode: Option<ProfiledRequestMode>,
+    /// Maximum requests routed through one persistent TCP connection before it
+    /// is recycled.  `None` means no limit.  Only consulted when
+    /// [`crate::routing::TransportPreference::PersistentTcp`] is active.
+    #[serde(default)]
+    pub max_requests_per_connection: Option<u32>,
+    /// Maximum age of a persistent TCP connection in seconds before it is
+    /// replaced.  `None` means no age limit.
+    #[serde(default)]
+    pub connection_max_age_secs: Option<u64>,
+}
+
+fn default_health_check_jitter_pct() -> f32 {
+    0.20
 }
 
 impl Default for ProxyConfig {
@@ -386,10 +457,13 @@ impl Default for ProxyConfig {
             health_check_url: "https://httpbin.org/ip".into(),
             health_check_interval: Duration::from_mins(1),
             health_check_timeout: Duration::from_secs(5),
+            health_check_jitter_pct: 0.20,
             circuit_open_threshold: 5,
             circuit_half_open_after: Duration::from_secs(30),
             sticky_policy: crate::session::StickyPolicy::default(),
             profiled_request_mode: None,
+            max_requests_per_connection: None,
+            connection_max_age_secs: None,
         }
     }
 }

--- a/crates/stygian-proxy/src/types.rs
+++ b/crates/stygian-proxy/src/types.rs
@@ -28,7 +28,7 @@ pub enum ProxyType {
     Socks5,
     /// CDN edge relay (`Cloudflare`, `CloudFront`, `Azure Front Door`, etc.).
     ///
-    /// Traffic egresses through a CDN PoP rather than a traditional proxy
+    /// Traffic egresses through a CDN point-of-presence rather than a traditional proxy
     /// server.  Provider metadata is carried in
     /// [`ProxyCapabilities::cdn_provider`].
     CdnEdge,


### PR DESCRIPTION
## Summary

Five new proxy capabilities plus a rand 0.10 compatibility fix.

### Changes

#### `stygian-proxy`

- **Health jitter** — `ProxyConfig::health_check_jitter_pct` spreads health-check wake intervals by ±N% via CSPRNG, preventing thundering-herd probes against shared targets
- **CDN edge proxy type** — `ProxyType::CdnEdge` for CDN-fronted egress nodes; paired with `ProxyCapabilities::is_cdn_edge`, `cdn_provider`, and `CapabilityRequirement::require_cdn_edge`
- **Persistent connections** — `TransportPreference::PersistentTcp` routing path with `ProxyConfig::max_requests_per_connection` and `connection_max_age_secs` lifetime bounds
- **DNS TXT discovery** — `DnsTxtFetcher` (feature `dns-fetcher`) resolves proxy lists from DNS TXT records via `hickory-resolver`
- **TLS fingerprint capability** — `ProxyCapabilities::tls_profile`, `CapabilityRequirement::require_tls_profile`, and `ProxyManagerBridge::bind_proxy_with_tls_profile()` (feature `browser`)
- **rand 0.10 fix** — `health.rs` migrated from removed `thread_rng()`/`.gen()` to `rand::rng().random::<f32>()`

#### `stygian-browser`

- `ProxySource` trait gains `bind_proxy_with_tls_profile()` default method

#### Documentation

- `book/src/proxy/overview.md` — feature table and architecture diagram updated
- `book/src/proxy/health-circuit-breaker.md` — jitter section + persistent-connection config section
- `book/src/proxy/strategies.md` — new capability filtering section
- `book/src/proxy/integrations.md` — DNS TXT discovery and TLS-profile browser binding sections

#### CHANGELOG

- All 5 features logged under `[Unreleased] ### Added`

### Testing

All 439 unit tests pass (`cargo test --workspace --all-features`).