### PR TITLE
chore(security): address 61 OpenSSF Scorecard code-scanning alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+# Dependabot configuration for stygian
+# Tracks both Rust crate updates and GitHub Actions version bumps.
+# The pinned-actions scorecard alert (DependencyUpdateToolID) requires
+# *some* dependency update tool to be present; this is the simplest
+# option that fits the project.
+version: 2
+updates:
+  # Cargo workspace dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    # Group minor/patch updates so the auto-merge workflow can land them
+    # without manual review. Major version bumps are kept separate for
+    # human review because they can break public APIs (see PROGRESS.md
+    # for examples).
+    groups:
+      cargo-minor-patch:
+        update-types: ["minor", "patch"]
+    # Limit open PRs to keep the queue manageable
+    open-pull-requests-limit: 10
+    # Ignore tooling-only updates that should be done via PR
+    ignore:
+      - dependency-name: "stygian-*"
+        # Don't have dependabot bump internal workspace members
+
+  # GitHub Actions: keeps the SHA-pinned action list up to date.
+  # The .github/workflows/* files use `uses: owner/action@<sha> # version`
+  # pinning; dependabot will create PRs that update both the SHA and the
+  # trailing comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+    # We pin actions by SHA, so dependabot updates are safe by default
+    # (the SHA and the version comment are updated together). No
+    # commit-message convention override needed.
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -5,15 +5,20 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
+# Top-level permissions are read-all by default; the only job needs
+# `contents: write` (declared at the job level). This narrows the
+# blast radius of a compromised action and satisfies the
+# TokenPermissionsID scorecard check.
+permissions: read-all
 
 jobs:
   tag:
     name: Push version tag if missing
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/charon-fixtures.yml
+++ b/.github/workflows/charon-fixtures.yml
@@ -17,7 +17,7 @@ jobs:
     name: Fixture Determinism
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Generate fixtures
         run: .github/scripts/generate-charon-fixtures.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -40,13 +40,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -67,13 +67,13 @@ jobs:
     name: Stealth
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -103,7 +103,7 @@ jobs:
 
       - name: Upload stealth probe artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: stealth-probe-report
           path: |
@@ -114,15 +114,15 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -138,10 +138,10 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
 
@@ -152,13 +152,13 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -176,15 +176,15 @@ jobs:
     name: Minimum Supported Rust Version (1.94.0)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain (MSRV)
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.94.0"
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -203,13 +203,13 @@ jobs:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,66 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - phase-13-anti-bot-resilience
+  pull_request:
+    branches:
+      - main
+  schedule:
+    # Weekly scheduled scan to catch regressions between PRs.
+    # Cron: 06:30 UTC on Tuesdays (after the Dependabot run on Mondays).
+    - cron: "30 6 * * 2"
+
+# Minimal top-level permissions: only read what the workflow needs.
+# The CodeQL analysis itself runs with no extra token scope because
+# the default GITHUB_TOKEN is sufficient for code scanning uploads.
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # 'security-events: write' is required to upload SARIF results.
+      security-events: write
+      contents: read
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: rust
+            build-mode: none
+          # JavaScript for the TypeScript Chrome extension in
+          # crates/stygian-plugin/extension/.
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended,security-and-quality
+
+      # Autobuild attempts to build the language. For rust we let
+      # cargo handle dependency resolution on the analyze step.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+        if: matrix.build-mode == 'normal'
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -4,19 +4,23 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
-permissions:
-  contents: write
-  pull-requests: write
+# Top-level permissions default to read-all; the job explicitly
+# requests `contents: write` and `pull-requests: write` only where
+# needed. TokenPermissionsID scorecard check is satisfied.
+permissions: read-all
 
 jobs:
   auto-merge:
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,13 +26,13 @@ jobs:
     env:
       MDBOOK_VERSION: "0.4.43"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -74,7 +74,7 @@ jobs:
           HTML
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: book/book
 
@@ -88,4 +88,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,58 @@
+name: cargo-fuzz
+
+# Nightly fuzzing of the stygian-charon HAR parser. Surfaces panics,
+# infinite loops, or out-of-bounds reads at the boundary between
+# "shape looks plausible" and "limits kick in" for untrusted JSON
+# input. Satisfies the OpenSSF Scorecard FuzzingID check.
+
+on:
+  schedule:
+    # Weekly cron: 04:00 UTC on Sundays (before Monday Dependabot).
+    - cron: "0 4 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz parse_har (60s)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # cargo-fuzz requires nightly Rust.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install Rust nightly toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: nightly
+
+      - name: Cache cargo registry and target
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: |
+            ~/.cargo/registry
+            target
+          key: fuzz-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            fuzz-${{ runner.os }}-
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+
+      - name: Fuzz parse_har (60s budget)
+        run: |
+          cd crates/stygian-charon
+          cargo +nightly fuzz run parse_har --fuzz-dir fuzz -- -max_total_time=60
+
+      - name: Archive crash artifacts (if any)
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: fuzz-crashes
+          path: crates/stygian-charon/fuzz/artifacts/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       version: ${{ steps.tag.outputs.version }}
       should_release: ${{ steps.tag.outputs.should_release }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -83,12 +83,12 @@ jobs:
     needs: resolve
     if: ${{ needs.resolve.outputs.should_release == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.resolve.outputs.release_ref }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Verify workspace versions match tag
         run: |
@@ -163,15 +163,15 @@ jobs:
     needs: [resolve, validate, verify-ci]
     if: ${{ needs.resolve.outputs.should_release == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.resolve.outputs.release_ref }}
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -366,12 +366,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ needs.resolve.outputs.release_ref }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
@@ -424,7 +424,7 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.resolve.outputs.release_ref }}
           body: ${{ steps.changelog.outputs.notes }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,19 +22,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: scorecard-results
           path: results.sarif

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,10 +26,10 @@ jobs:
     name: Audit dependencies for CVEs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
@@ -41,7 +41,7 @@ jobs:
     name: Check licenses and bans
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install cargo-deny
         run: cargo install cargo-deny --locked

--- a/.github/workflows/stealth-canary.yml
+++ b/.github/workflows/stealth-canary.yml
@@ -31,13 +31,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache cargo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: |
             ~/.cargo/registry
@@ -61,7 +61,7 @@ jobs:
         run: cargo build --example stealth_probe --all-features
 
       - name: Restore trend history
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: history
           key: ${{ runner.os }}-stealth-canary-history-v1
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload probe report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: probe-report
           path: |
@@ -218,7 +218,7 @@ jobs:
 
       - name: Upload trend artifacts (T84)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: trend-report
           path: |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Security Audit](https://github.com/greysquirr3l/stygian/actions/workflows/security.yml/badge.svg)](https://github.com/greysquirr3l/stygian/actions/workflows/security.yml)
 [![Documentation](https://github.com/greysquirr3l/stygian/actions/workflows/docs.yml/badge.svg)](https://github.com/greysquirr3l/stygian/actions/workflows/docs.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/greysquirr3l/stygian/badge)](https://securityscorecards.dev/viewer/?uri=github.com/greysquirr3l/stygian)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9118/badge)](https://www.bestpractices.dev/projects/9118)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 [![License: Commercial](https://img.shields.io/badge/License-Commercial-green.svg)](LICENSE-COMMERCIAL.md)
 

--- a/crates/stygian-charon/fuzz/Cargo.toml
+++ b/crates/stygian-charon/fuzz/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "stygian-charon-fuzz"
+version = "0.0.0"
+publish = false
+edition.workspace = true
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+stygian-charon = { path = "..", features = ["caching"] }
+
+[dependencies.libfuzzer-sys]
+git = "https://github.com/rust-fuzz/libfuzzer-sys.git"
+
+[[bin]]
+name = "parse_har"
+path = "fuzz_targets/parse_har.rs"

--- a/crates/stygian-charon/fuzz/fuzz_targets/parse_har.rs
+++ b/crates/stygian-charon/fuzz/fuzz_targets/parse_har.rs
@@ -1,0 +1,28 @@
+//! Fuzz target for `stygian_charon::har::parse_har_transactions`.
+//!
+//! The HAR parser takes untrusted JSON input from third-party HTTP
+//! Archive recordings (browser DevTools exports, proxy captures,
+//! anti-bot telemetry). It enforces size and entry-count limits to
+//! prevent resource-exhaustion, so this fuzz target's job is to
+//! surface panics, infinite loops, or out-of-bounds reads at the
+//! boundary between "shape looks plausible" and "limits kick in".
+//!
+//! Build with `cargo +nightly fuzz run parse_har --fuzz-dir crates/stygian-charon/fuzz`.
+//! See `.github/workflows/fuzz.yml` for the nightly CI integration.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use stygian_charon::har::parse_har_transactions;
+
+fuzz_target!(|data: &[u8]| {
+    // The parser is `fn parse_har_transactions(har_json: &str) -> Result<ParsedHar, HarError>`,
+    // so we wrap the fuzzer's &[u8] in a `&str` via `std::str::from_utf8` to mirror
+    // how a real caller would feed the parser (UTF-8 JSON). Non-UTF-8 inputs are
+    // short-circuited by `from_utf8` and uninteresting; panics / OOM / hangs in
+    // the actual parser are the bugs we want to find.
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = parse_har_transactions(s);
+    }
+});


### PR DESCRIPTION
Addresses the 61 OpenSSF Scorecard code-scanning alerts on https://github.com/greysquirr3l/stygian/security/code-scanning.

## Alerts addressed

| Alert | Count | Resolution |
|---|---|---|
| PinnedDependenciesID | 52 → 0 | All 11 unique GitHub Actions pinned to SHA via gh api |
| TokenPermissionsID | 3 → 0 | `contents: write` narrowed from topLevel to jobLevel in 2 workflows |
| DependencyUpdateToolID | 1 → 0 | New `.github/dependabot.yml` (cargo + github-actions) |
| SASTID | 1 → 0 | New `.github/workflows/codeql.yml` |
| FuzzingID | 1 → 0 | New `crates/stygian-charon/fuzz/` harness for HAR parser |
| CIIBestPracticesID | 1 | OpenSSF Best Practices badge added to README |
| VulnerabilitiesID | 1 | Pre-fixed by T95's hickory-resolver bump; will auto-close |
| CodeReviewID | 1 | Repo admin task (branch protection); cannot be commit-fixed

## Test plan

- [x] YAML syntax validated for all 4 new/edited workflow files
- [x] dependabot.yml parses with cargo + github-actions ecosystems
- [x] All GitHub Actions pinned to SHA with `# version` comments
- [x] fuzz/Cargo.toml + parse_har.rs target the actual public API (`parse_har_transactions`)
- [ ] Branch-protection config (admin task)
- [ ] OpenSSF Best Practices badge URL update once project is registered