### PR TITLE
chore(git): untrack ORCHESTRATOR.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ reference_projects/
 stygian-technical-assessment.md
 docs/stygian-local-refactor-plan.md
 docs/technical-assessment.md
+ORCHESTRATOR.md


### PR DESCRIPTION
Marks `ORCHESTRATOR.md` as a local-only file per the project's gitignore policy (PROGRESS.md is already gitignored at `.gitignore:92`).

Both files are operator-only artifacts that should not be tracked in version control:

- `PROGRESS.md` — accumulated learnings + task tracker; regenerated by subagents during a dev cycle.
- `ORCHESTRATOR.md` — opencode orchestrator prompt; lives at the repo root for the operator's personal use during a Ralph Wiggum loop, not as a public artifact.

The file may still exist in the working tree for local use. If you need to edit it without it appearing in future commits, use `git update-index --skip-worktree ORCHESTRATOR.md`.