### PR TITLE
fix(docs): resolve feature-gated rustdoc broken-intra-doc-links

### DIFF
--- a/crates/stygian-charon/src/change_feed/mod.rs
+++ b/crates/stygian-charon/src/change_feed/mod.rs
@@ -65,7 +65,8 @@
 //! ## Metrics surface
 //!
 //! When the `metrics` feature is enabled, the
-//! [`MetricsCollector`][crate::metrics::MetricsCollector]
+//! `MetricsCollector` (see `crate::metrics::MetricsCollector`; only compiled
+//! with `--features metrics`)
 //! implements [`ChangeEventSink`] so the detector
 //! records events directly into the existing
 //! Prometheus exporter. The `change_feed_*` series

--- a/crates/stygian-graph/src/adapters/storage.rs
+++ b/crates/stygian-graph/src/adapters/storage.rs
@@ -6,7 +6,7 @@
 //! | --------- | -------------- | --------------- |
 //! | [`NullStorage`](storage::NullStorage) | always | no-op (tests / dry-run) |
 //! | [`FileStorage`](storage::FileStorage) | always | `.jsonl` files on local disk |
-//! | [`PostgresStorage`](storage::PostgresStorage) | `feature = "postgres"` | PostgreSQL via sqlx |
+//! | `PostgresStorage` (`storage::postgres::PostgresStorage`) | `feature = "postgres"` | PostgreSQL via sqlx |
 
 use crate::domain::error::{Result, ServiceError, StygianError};
 use crate::ports::storage::{StoragePort, StorageRecord};

--- a/crates/stygian-proxy/src/lib.rs
+++ b/crates/stygian-proxy/src/lib.rs
@@ -10,7 +10,8 @@
 //! - Async health checker with configurable intervals
 //! - Per-proxy circuit breaker (`Closed -> Open -> HalfOpen`)
 //! - In-memory proxy pool (no external DB required)
-//! - `graph` feature: [`ProxyManagerPort`] trait for stygian-graph HTTP adapters
+//! - `graph` feature: `ProxyManagerPort` trait for stygian-graph HTTP adapters
+//!   (see `crate::graph`; only compiled with `--features graph`)
 //! - `browser` feature: per-context proxy binding for stygian-browser
 //!
 //! ## Quick start


### PR DESCRIPTION
Fixes the **Documentation** job failure in https://github.com/greysquirr3l/stygian/actions/runs/27760837431/job/82134500982.

## What failed

`cargo doc --workspace --no-deps` (with `RUSTDOCFLAGS="-Dwarnings"` and `--all-features`) was emitting three `unresolved link` errors for intra-doc links that point to feature-gated items:

| File | Link | Gated behind |
|---|---|---|
| `crates/stygian-charon/src/change_feed/mod.rs:68` | `crate::metrics::MetricsCollector` | `metrics` |
| `crates/stygian-proxy/src/lib.rs:13` | `ProxyManagerPort` | `graph` |
| `crates/stygian-graph/src/adapters/storage.rs:9` | `storage::PostgresStorage` | `postgres` |

Each link resolved to an item that is only compiled under its respective cargo feature, so rustdoc couldn't resolve them.

## Fix

Replace each `[`Name`][path]` link with a backtick-quoted text + parenthesised pointer that names the path + feature. The doc still reads naturally and the path is recoverable.

```rust
// before
//! - `graph` feature: [`ProxyManagerPort`] trait for stygian-graph HTTP adapters

// after
//! - `graph` feature: `ProxyManagerPort` trait for stygian-graph HTTP adapters
//!   (see `crate::graph`; only compiled with `--features graph`)
```

## Verified

```bash
RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --no-deps                    # → clean
RUSTDOCFLAGS="-Dwarnings" cargo doc --workspace --no-deps --all-features    # → clean
```

3 files changed, 5 insertions(+), 3 deletions(-).