### PR TITLE
build(deps): upgrade indexmap + openapiv3 ecosystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -2807,11 +2806,11 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openapiv3"
-version = "1.0.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b83630305ecc3355e998ddd2f926f98aae8e105eb42652174a58757851ba47"
+checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4475,7 +4475,7 @@ dependencies = [
  "flate2",
  "futures",
  "hmac 0.13.0",
- "indexmap 1.9.3",
+ "indexmap 2.14.0",
  "indicatif",
  "lru",
  "mockall",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "stable_deref_trait",
 ]
 
@@ -1777,7 +1777,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1794,12 +1794,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2231,16 +2225,6 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2778,7 +2762,7 @@ checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "memchr",
 ]
 
@@ -2810,7 +2794,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_json",
 ]
@@ -2916,7 +2900,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
 ]
 
@@ -4003,7 +3987,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -4196,7 +4180,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -4474,7 +4458,7 @@ dependencies = [
  "flate2",
  "futures",
  "hmac 0.13.0",
- "indexmap 2.14.0",
+ "indexmap",
  "indicatif",
  "lru",
  "mockall",
@@ -4916,7 +4900,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -4949,7 +4933,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -5466,7 +5450,7 @@ checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
  "serde",
 ]
@@ -5536,7 +5520,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "object",
  "postcard",
@@ -5699,7 +5683,7 @@ dependencies = [
  "anyhow",
  "bitflags",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "wit-parser",
 ]
 
@@ -6271,7 +6255,7 @@ dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ quick-xml = { version = "0.38", features = ["serialize"] }
 flate2 = "1.1"
 
 # OpenAPI spec parsing
-openapiv3 = "1"
+openapiv3 = "2"
 serde_yaml = "0.9"
 indexmap = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ flate2 = "1.1"
 # OpenAPI spec parsing
 openapiv3 = "1"
 serde_yaml = "0.9"
-indexmap = "1"
+indexmap = "2"
 
 # Proc-macro support
 syn         = { version = "2", features = ["full"] }

--- a/crates/stygian-graph/src/adapters/openapi_gen.rs
+++ b/crates/stygian-graph/src/adapters/openapi_gen.rs
@@ -220,7 +220,7 @@ impl OpenApiGenerator {
             },
             JsonType::Bool => Schema {
                 schema_data: SchemaData::default(),
-                schema_kind: SchemaKind::Type(OaType::Boolean {}),
+                schema_kind: SchemaKind::Type(OaType::Boolean(openapiv3::BooleanType::default())),
             },
             JsonType::Integer => Schema {
                 schema_data: SchemaData::default(),


### PR DESCRIPTION
Combined upgrade of coupled dependencies indexmap and openapiv3.

## Changes
- `indexmap` 1.9.3 → 2.14.0
- `openapiv3` 1.0.4 → 2.2.0

## Why combined?
openapiv3 2.0.0-rc.0 bumped its indexmap dependency to 2.0, making these upgrades interdependent. Upgrading indexmap alone causes type mismatches because openapiv3 1.x uses indexmap 1.x types.

## Breaking API changes fixed
- **openapiv3 2.x**: `OaType::Boolean` changed from struct variant `Boolean {}` to tuple variant `Boolean(BooleanType)` in openapi_gen.rs:223

## Supersedes
- #72 (indexmap upgrade)
- #78 (openapiv3 upgrade)

## Testing
- All tests pass locally
- Pre-push checks passed