### PR TITLE
feat(proxy,mcp): migrate stygian-proxy to MCP 2026-07-28 RC spec

### DIFF
--- a/crates/stygian-proxy/src/mcp.rs
+++ b/crates/stygian-proxy/src/mcp.rs
@@ -14,15 +14,27 @@
 //!
 //! ## Protocol
 //!
-//! Implements MCP 2025-11-25 over JSON-RPC 2.0 on stdin/stdout.
+//! Implements MCP 2026-07-28 over JSON-RPC 2.0 on stdin/stdout.
 //!
 //! | MCP Method | Description |
 //! | ----------- | ------------- |
-//! | `initialize` | Handshake, return server capabilities |
+//! | `server/discover` | Advertise protocol versions, identity, capabilities |
 //! | `tools/list` | List available proxy tools |
 //! | `tools/call` | Execute a proxy tool |
 //! | `resources/list` | List available resources (currently `proxy://pool/stats`) |
 //! | `resources/read` | Read a resource (e.g. pool statistics from `proxy://pool/stats`) |
+//!
+//! ## Migrating from MCP 2025-11-25
+//!
+//! The `initialize` / `notifications/initialized` handshake was removed. Clients
+//! must advertise their protocol version, identity, and capabilities in the
+//! `_meta` block of every request under the `io.modelcontextprotocol/*` keys.
+//! See the `extract_client_protocol_version` and `extract_meta` helpers for
+//! the reader-side extraction (used by future PRs in the [MCP-001] migration
+//! sequence; PR 2 only adds them as helpers — enforcement lands in PR 4
+//! alongside the aggregator).
+//!
+//! [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
 //!
 //! ## Tools
 //!
@@ -68,11 +80,71 @@ fn error_response(id: &Value, code: i64, message: &str) -> Value {
 
 fn ok_response(id: &Value, result: impl Into<Value>) -> Value {
     let result = result.into();
+    // MCP 2026-07-28 §8: every result carries a `resultType` field. `"complete"`
+    // for ordinary responses; `"input_required"` for MRTR interim responses.
+    // We only emit `"complete"` here — MRTR lands in a later migration PR.
+    let result = match result {
+        Value::Object(mut obj) => {
+            obj.insert("resultType".to_owned(), json!("complete"));
+            Value::Object(obj)
+        }
+        other => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("resultType".to_owned(), json!("complete"));
+            obj.insert("value".to_owned(), other);
+            Value::Object(obj)
+        }
+    };
     json!({
         "jsonrpc": "2.0",
         "id": id,
         "result": result
     })
+}
+
+// ─── MCP 2026-07-28 _meta helpers ──────────────────────────────────────────────
+
+/// Read the `io.modelcontextprotocol/<key>` entry from a request's
+/// `params._meta` block. Returns `None` when the request omits `_meta` or
+/// the requested key is absent.
+///
+/// MCP 2026-07-28 §2: every request now carries its protocol version, client
+/// identity, and client capabilities under the `io.modelcontextprotocol/*`
+/// namespace within `params._meta`.
+#[allow(dead_code)] // Used by PR 4 (aggregator) and future per-request gates.
+fn extract_meta<'a>(req: &'a Value, key: &str) -> Option<&'a Value> {
+    let meta = req.get("params")?.get("_meta")?.as_object()?;
+    meta.get(&format!("io.modelcontextprotocol/{key}"))
+}
+
+/// Extract the client's advertised protocol version from a request's `_meta`.
+///
+/// Returns `None` when the field is absent. Spec mandates this be present on
+/// every 2026-07-28 request; enforcement is the aggregator's responsibility
+/// (lands in PR 4 of [MCP-001]).
+///
+/// [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
+#[allow(dead_code)] // Used by PR 4 (aggregator) and future per-request gates.
+fn extract_client_protocol_version(req: &Value) -> Option<String> {
+    extract_meta(req, "protocolVersion")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+/// Compare a client-advertised protocol version against a list of versions the
+/// server supports. Returns `Ok(())` when the version is in the supported
+/// list, `Err(unsupported)` with the offending value otherwise.
+///
+/// MCP 2026-07-28 §2: version mismatch on any request returns
+/// `UnsupportedProtocolVersionError` (code `-32022`). PR 2 exposes the
+/// helper; PR 4 wires it into the aggregator's per-request gate.
+#[cfg(test)]
+fn is_supported_protocol_version(client: &str, supported: &[&str]) -> Result<(), String> {
+    if supported.contains(&client) {
+        Ok(())
+    } else {
+        Err(format!("Unsupported protocol version: {client}"))
+    }
 }
 
 // ─── Active handle store ──────────────────────────────────────────────────────
@@ -218,9 +290,9 @@ impl McpProxyServer {
     ///
     /// # tokio_test::block_on(async {
     /// let server = McpProxyServer::new().unwrap();
-    /// let req = json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}});
+    /// let req = json!({"jsonrpc":"2.0","id":1,"method":"server/discover"});
     /// let resp = server.handle_request(&req).await;
-    /// assert_eq!(resp["result"]["protocolVersion"], "2025-11-25");
+    /// assert_eq!(resp["result"]["protocolVersion"], "2026-07-28");
     /// # });
     /// ```
     pub async fn handle_request(&self, req: &Value) -> Value {
@@ -263,10 +335,10 @@ impl McpProxyServer {
         let method = req.get("method").and_then(Value::as_str).unwrap_or("");
 
         match method {
-            "initialize" => Self::handle_initialize(id),
-            "initialized" | "notifications/initialized" | "ping" => {
-                json!({"jsonrpc":"2.0","id":id,"result":{}})
-            }
+            // MCP 2026-07-28 §3: `server/discover` replaces the `initialize`
+            // handshake. The handshake (`initialize` + `notifications/initialized`)
+            // and the unrelated `ping` RPC are removed.
+            "server/discover" => Self::handle_discover(id),
             "tools/list" => Self::handle_tools_list(id),
             "tools/call" => self.handle_tools_call(id, req).await,
             "resources/list" => Self::handle_resources_list(id),
@@ -275,19 +347,30 @@ impl McpProxyServer {
         }
     }
 
-    fn handle_initialize(id: &Value) -> Value {
+    /// Advertise the server's identity, supported protocol versions, and
+    /// capabilities. Replaces the `initialize` handshake removed in
+    /// MCP 2026-07-28.
+    ///
+    /// Note: the prior version advertised `resources.subscribe: false`. That
+    /// field is removed in 2026-07-28 since `resources/subscribe` /
+    /// `resources/unsubscribe` are replaced by the server-pushed
+    /// `subscriptions/listen` stream (lands in PR 3 for the browser server;
+    /// proxy has no subscriptions today).
+    fn handle_discover(id: &Value) -> Value {
         ok_response(
             id,
             json!({
-                "protocolVersion": "2025-11-25",
+                "protocolVersion": "2026-07-28",
+                "supportedProtocolVersions": ["2026-07-28"],
                 "capabilities": {
                     "tools":     { "listChanged": false },
-                    "resources": { "listChanged": false, "subscribe": false }
+                    "resources": { "listChanged": false }
                 },
                 "serverInfo": {
                     "name": "stygian-proxy",
                     "version": env!("CARGO_PKG_VERSION")
-                }
+                },
+                "extensions": []
             }),
         )
     }
@@ -987,15 +1070,24 @@ mod tests {
     }
 
     #[test]
-    fn initialize_response_has_version() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn discover_response_advertises_protocol_version()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let server = McpProxyServer::new()?;
         let id = json!(1);
-        let resp = McpProxyServer::handle_initialize(&id);
+        let resp = McpProxyServer::handle_discover(&id);
         assert_eq!(
             resp.get("result")
                 .and_then(|r| r.get("protocolVersion"))
                 .and_then(Value::as_str),
-            Some("2025-11-25")
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            resp.get("result")
+                .and_then(|r| r.get("supportedProtocolVersions"))
+                .and_then(Value::as_array)
+                .and_then(|v| v.first())
+                .and_then(Value::as_str),
+            Some("2026-07-28")
         );
         assert_eq!(
             resp.get("result")
@@ -1004,8 +1096,149 @@ mod tests {
                 .and_then(Value::as_str),
             Some("stygian-proxy")
         );
+        assert_eq!(
+            resp.get("result")
+                .and_then(|r| r.get("resultType"))
+                .and_then(Value::as_str),
+            Some("complete")
+        );
+        // MCP 2026-07-28 §8: extensions array present even when empty.
+        assert!(
+            resp.get("result")
+                .and_then(|r| r.get("extensions"))
+                .and_then(Value::as_array)
+                .is_some()
+        );
+        // The deprecated `resources.subscribe: false` capability is gone —
+        // `subscriptions/listen` replaces `resources/subscribe` (lands in PR 3).
+        assert!(
+            resp.get("result")
+                .and_then(|r| r.get("capabilities"))
+                .and_then(|c| c.get("resources"))
+                .and_then(|r| r.get("subscribe"))
+                .is_none()
+        );
         let _ = server; // keep test parity with prior server construction
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn initialize_method_is_no_longer_recognized()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let server = McpProxyServer::new()?;
+        let resp = server
+            .handle_request(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            }))
+            .await;
+        assert_eq!(
+            resp.pointer("/error/code").and_then(Value::as_i64),
+            Some(-32601)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ping_method_is_no_longer_recognized()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let server = McpProxyServer::new()?;
+        let resp = server
+            .handle_request(&json!({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "ping"
+            }))
+            .await;
+        assert_eq!(
+            resp.pointer("/error/code").and_then(Value::as_i64),
+            Some(-32601)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ok_response_threads_result_type_complete() {
+        // MCP 2026-07-28 §8: every `ok_response` envelope carries a
+        // `resultType: "complete"` field, even when the result is not an
+        // object. The non-object branch is defensive — the spec only defines
+        // object results, but a bug in a caller should not produce an invalid
+        // envelope.
+        let id = json!(42);
+        let obj = McpProxyServer::handle_tools_list(&id);
+        assert_eq!(
+            obj.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
+        assert!(obj.pointer("/result/tools").is_some());
+
+        let scalar = ok_response(&id, json!("plain-string"));
+        assert_eq!(
+            scalar.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
+        assert_eq!(
+            scalar.pointer("/result/value").and_then(Value::as_str),
+            Some("plain-string")
+        );
+    }
+
+    #[test]
+    fn extract_meta_reads_namespaced_keys() {
+        // The `_meta` reader must look under `params._meta.io.modelcontextprotocol/*`.
+        // `protocolVersion`, `clientInfo`, `clientCapabilities` are the three
+        // carriers defined by MCP 2026-07-28 §2.
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "test-client",
+                        "version": "0.0.1"
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "tools": {}
+                    },
+                    "unrelated": "ignored"
+                }
+            }
+        });
+        assert_eq!(
+            extract_client_protocol_version(&req).as_deref(),
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            extract_meta(&req, "clientInfo")
+                .and_then(|v| v.get("name"))
+                .and_then(Value::as_str),
+            Some("test-client")
+        );
+        assert!(extract_meta(&req, "clientCapabilities").is_some());
+        assert!(extract_meta(&req, "not-a-key").is_none());
+
+        // `_meta` absent → all helpers return None.
+        let bare = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        assert!(extract_client_protocol_version(&bare).is_none());
+        assert!(extract_meta(&bare, "protocolVersion").is_none());
+    }
+
+    #[test]
+    fn is_supported_protocol_version_accepts_listed_and_rejects_others() {
+        // MCP 2026-07-28 §2: clients advertise their protocol version on every
+        // request. Servers reject unknown versions with
+        // `UnsupportedProtocolVersionError` (code `-32022`). The aggregator
+        // (PR 4 of MCP-001) wires this check into the per-request gate; the
+        // proxy server itself stays permissive at this layer because it is
+        // also called directly via `tools/list` / `tools/call` and the
+        // dispatcher doesn't enforce `_meta` yet.
+        assert!(is_supported_protocol_version("2026-07-28", &["2026-07-28"]).is_ok());
+        assert!(is_supported_protocol_version("2026-07-28", &["2025-11-25"]).is_err());
+        assert!(is_supported_protocol_version("2025-11-25", &["2026-07-28", "2025-11-25"]).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Second PR in the [MCP-001 migration sequence](#95). Mirrors PR 1's migration patterns against the proxy server. PR 3 (browser) and PR 4 (aggregator) follow.

## Behavioural changes (MCP 2026-07-28 RC)

- **Remove `initialize` / `notifications/initialized` handshake.** Clients now advertise protocol version, identity, and capabilities per-request in `_meta` under the `io.modelcontextprotocol/*` keys (spec §2). The dispatcher returns `Method not found` for `initialize`.
- **Remove `ping`.**
- **Add `server/discover` RPC** (spec §3).
- **Drop the deprecated `resources.subscribe: false` capability.** The 2026-07-28 spec replaces `resources/subscribe` with the server-pushed `subscriptions/listen` stream (lands in PR 3 for the browser server). Proxy has no subscriptions today, so the capability is just gone from the discover payload.
- **Add `resultType: "complete"` to every result envelope** (spec §8). Threaded through `ok_response`.
- **Bump `protocolVersion` to "2026-07-28".**

## New helpers (used by future PRs in MCP-001)

- `extract_meta(req, key)` — reads `params._meta.io.modelcontextprotocol/<key>`.
- `extract_client_protocol_version(req)` — typed wrapper.
- `is_supported_protocol_version(client, supported)` — `#[cfg(test)]` for now; PR 4 wires it into the aggregator's per-request gate.

## Tests

16 mcp tests pass (10 existing + 6 new):

- `discover_response_advertises_protocol_version` (replaces `initialize_response_has_version`, also asserts the deprecated `resources.subscribe` capability is absent)
- `initialize_method_is_no_longer_recognized`
- `ping_method_is_no_longer_recognized`
- `ok_response_threads_result_type_complete`
- `extract_meta_reads_namespaced_keys`
- `is_supported_protocol_version_accepts_listed_and_rejects_others`

## Verification

- `cargo build --workspace --all-features` ✅
- `cargo test -p stygian-proxy --all-features` ✅ (116 tests)
- `cargo doc -p stygian-proxy --no-deps --features mcp` ✅ (12 pre-existing warnings, unrelated)
- `cargo clippy -p stygian-proxy --features mcp -- -D warnings` — 3 pre-existing `missing_errors_doc` errors in `types.rs` are not in scope (present on main, unrelated to MCP migration)

## Out of scope (deferred to PRs 3–4)

- `subscriptions/listen` migration (PR 3, browser).
- `_meta` enforcement at the dispatcher (server still accepts `tools/list` without `_meta`; aggregator gates this in PR 4).
- Tasks extension (`tasks/get` + `tasks/update`).
- `Mcp-Method` / `Mcp-Name` headers, OpenTelemetry trace context, `ttlMs` / `cacheScope` cache hints.
- Error-code renumbering (-32002 → -32602, etc).
- `resultType: "input_required"` for MRTR (no servers emit it yet).

Tracking issue: https://github.com/greysquirr3l/stygian/issues/95