### PR TITLE
chore(release): prep 0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.14.2] - 2026-06-23
+
+### Fixed
+
+- **stygian-browser (outer HTML on SPAs)**: `outer_html_recursive` and
+  `outer_html_via_rust_walk` previously identified target nodes via the
+  ephemeral CDP `NodeId`. On JavaScript-heavy SPAs (e.g. Wix / React),
+  any DOM mutation after the element was resolved invalidates the
+  `NodeId`, causing `DOM.getOuterHTML` to silently return an empty string
+  for a node that still exists. Both call sites now use the stable V8
+  `RemoteObjectId` (tied to the heap object reference), which survives
+  DOM mutations. Fixes silent empty-string extraction on live SPAs.
+
+### Security
+
+- **quinn-proto**: bumped `quinn-proto` 0.11.14 → 0.11.15
+  (RUSTSEC-2026-0185, high — remote memory exhaustion via unbounded
+  out-of-order stream reassembly).
+
 ## [0.14.1] - 2026-06-20
 
 ### Fixed
@@ -1464,14 +1483,15 @@ Both crates are functional and well-tested, but APIs may evolve based on communi
 
 ---
 
-[Unreleased]: https://github.com/greysquirr3l/stygian/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/greysquirr3l/stygian/compare/v0.14.2...HEAD
+[0.14.2]: https://github.com/greysquirr3l/stygian/compare/v0.14.1...v0.14.2
+[0.14.1]: https://github.com/greysquirr3l/stygian/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/greysquirr3l/stygian/compare/v0.13.5...v0.14.0
 [0.13.5]: https://github.com/greysquirr3l/stygian/compare/v0.13.4...v0.13.5
 [0.13.4]: https://github.com/greysquirr3l/stygian/compare/v0.13.3...v0.13.4
 [0.13.3]: https://github.com/greysquirr3l/stygian/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/greysquirr3l/stygian/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/greysquirr3l/stygian/compare/v0.13.0...v0.13.1
-[0.13.0]: https://github.com/greysquirr3l/stygian/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/greysquirr3l/stygian/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/greysquirr3l/stygian/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/greysquirr3l/stygian/compare/v0.10.0...v0.11.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,9 +3276,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4414,7 +4414,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stygian-browser"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-charon"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "lru",
  "redis",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-extract-derive"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4464,7 +4464,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-graph"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4520,7 +4520,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-mcp"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -4536,7 +4536,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-plugin"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-proxy"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["crates/stygian-charon/fuzz"]
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.2"
 edition = "2024"
 rust-version = "1.94.0"
 authors = ["Nick Campbell <s0ma@protonmail.com>"]

--- a/crates/stygian-browser/Cargo.toml
+++ b/crates/stygian-browser/Cargo.toml
@@ -68,14 +68,14 @@ base64 = { workspace = true, optional = true }
 prometheus-client = { workspace = true, optional = true }
 
 # Extract feature: proc-macro for #[derive(Extract)]
-stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.14.0", optional = true }
+stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.14.2", optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 trybuild = "1"
-stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.14.0" }
+stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.14.2" }
 
 [lints]
 workspace = true

--- a/crates/stygian-browser/src/page.rs
+++ b/crates/stygian-browser/src/page.rs
@@ -528,8 +528,8 @@ impl NodeHandle {
     /// Strategy body for [`OuterHtmlStrategy::Recursive`].
     ///
     /// Primary: `DOM.getOuterHTML` (single round-trip, browser-side
-    /// serialisation). Fallback: `DOM.describeNode(nodeId, depth=-1)` +
-    /// Rust-side `Node` → HTML serializer.
+    /// serialisation via stable `objectId`). Fallback: `DOM.describeNode`
+    /// with `objectId` + `depth=-1`, Rust-side `Node` → HTML serializer.
     async fn outer_html_recursive(&self) -> Result<OuterHtmlResult> {
         use chromiumoxide::cdp::browser_protocol::dom::{GetOuterHtmlParams, GetOuterHtmlReturns};
         use chromiumoxide::types::CommandResponse;
@@ -540,7 +540,14 @@ impl NodeHandle {
             self.cdp_timeout,
             self.page.execute(
                 GetOuterHtmlParams::builder()
-                    .node_id(self.element.node_id)
+                    // Use the stable V8 RemoteObjectId instead of the
+                    // ephemeral CDP NodeId. NodeIds are invalidated whenever
+                    // the page's JavaScript mutates the DOM (e.g. React
+                    // re-renders on SPAs like Wix), causing DOM.getOuterHTML
+                    // to silently return an empty string for a valid node.
+                    // RemoteObjectId is tied to the V8 heap object reference
+                    // and survives DOM mutations.
+                    .object_id(self.element.remote_object_id.clone())
                     .build(),
             ),
         )
@@ -609,9 +616,9 @@ impl NodeHandle {
         }
     }
 
-    /// Rust-side fallback: `DOM.describeNode` with `depth = -1` returns the
-    /// entire subtree rooted at the target node; we walk it locally and emit
-    /// HTML using [`serialize_node_tree`].
+    /// Rust-side fallback: `DOM.describeNode` with `depth = -1` and
+    /// `objectId` returns the entire subtree rooted at the target node;
+    /// we walk it locally and emit HTML using [`serialize_node_tree`].
     async fn outer_html_via_rust_walk(&self) -> Result<String> {
         use chromiumoxide::cdp::browser_protocol::dom::DescribeNodeParams;
         use chromiumoxide::types::CommandResponse;
@@ -622,7 +629,10 @@ impl NodeHandle {
             self.cdp_timeout,
             self.page.execute(
                 DescribeNodeParams::builder()
-                    .node_id(self.element.node_id)
+                    // Use stable RemoteObjectId rather than ephemeral NodeId
+                    // for the same reason as outer_html_recursive — NodeIds
+                    // become stale after SPA DOM mutations.
+                    .object_id(self.element.remote_object_id.clone())
                     .depth(-1)
                     .build(),
             ),

--- a/crates/stygian-graph/Cargo.toml
+++ b/crates/stygian-graph/Cargo.toml
@@ -87,8 +87,8 @@ serde_yaml.workspace = true
 indexmap.workspace = true
 
 # Browser automation (optional)
-stygian-browser = { path = "../stygian-browser", version = "0.14.0", optional = true }
-stygian-charon = { path = "../stygian-charon", version = "0.14.0", optional = true }
+stygian-browser = { path = "../stygian-browser", version = "0.14.2", optional = true }
+stygian-charon = { path = "../stygian-charon", version = "0.14.2", optional = true }
 
 # WASM plugins (optional)
 wasmtime = { workspace = true, optional = true }

--- a/crates/stygian-mcp/Cargo.toml
+++ b/crates/stygian-mcp/Cargo.toml
@@ -19,10 +19,10 @@ tracing     = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow      = { workspace = true }
 
-stygian-graph   = { path = "../stygian-graph",   version = "0.14.0", default-features = false, features = ["mcp", "browser", "charon"] }
-stygian-browser = { path = "../stygian-browser",  version = "0.14.0", default-features = false, features = ["mcp", "stealth"] }
-stygian-proxy   = { path = "../stygian-proxy",    version = "0.14.0", features = ["mcp", "browser", "tls-profiled"] }
-stygian-plugin  = { path = "../stygian-plugin",   version = "0.14.0", features = ["graph-integration"] }
+stygian-graph   = { path = "../stygian-graph",   version = "0.14.2", default-features = false, features = ["mcp", "browser", "charon"] }
+stygian-browser = { path = "../stygian-browser",  version = "0.14.2", default-features = false, features = ["mcp", "stealth"] }
+stygian-proxy   = { path = "../stygian-proxy",    version = "0.14.2", features = ["mcp", "browser", "tls-profiled"] }
+stygian-plugin  = { path = "../stygian-plugin",   version = "0.14.2", features = ["graph-integration"] }
 
 [features]
 # Structured data extraction via derive macros

--- a/crates/stygian-plugin/Cargo.toml
+++ b/crates/stygian-plugin/Cargo.toml
@@ -31,7 +31,7 @@ tower-http = { version = "0.7", features = ["cors", "trace"], optional = true }
 tower = { version = "0.5", optional = true }
 
 # Stygian crates
-stygian-graph = { path = "../stygian-graph", version = "0.14.0", optional = true }
+stygian-graph = { path = "../stygian-graph", version = "0.14.2", optional = true }
 
 # Parsing
 scraper = "0.27"

--- a/crates/stygian-proxy/Cargo.toml
+++ b/crates/stygian-proxy/Cargo.toml
@@ -71,7 +71,7 @@ futures = { workspace = true }
 rand = { workspace = true }
 
 # Browser integration (optional)
-stygian-browser = { path = "../stygian-browser", version = "0.14.0", optional = true }
+stygian-browser = { path = "../stygian-browser", version = "0.14.2", optional = true }
 
 # DNS TXT proxy discovery (optional)
 hickory-resolver = { version = "0.26.1", features = ["tokio"], optional = true }


### PR DESCRIPTION
## 0.14.2

### Fixed

- **stygian-browser**: `outer_html_recursive` and `outer_html_via_rust_walk` now use stable V8 `RemoteObjectId` instead of ephemeral CDP `NodeId`. NodeIds are invalidated by JavaScript DOM mutations (React/SPA re-renders), causing `DOM.getOuterHTML` to silently return empty. Fixes extraction on Wix and other live SPAs.

### Security

- **quinn-proto** 0.11.14 → 0.11.15 (RUSTSEC-2026-0185, high — remote memory exhaustion via unbounded out-of-order stream reassembly). Resolves the Security Audit CI failure on main.

---

Merging this PR will trigger `auto-tag.yml` → `v0.14.2` tag → `release.yml` via `workflow_run`.