### PR TITLE
feat(mcp): migrate workspace to MCP 2026-07-28 RC spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,9 +3276,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -27,16 +27,28 @@
 //!
 //! ## Protocol
 //!
-//! The server implements MCP 2025-11-25 over JSON-RPC 2.0 on stdin/stdout.
+//! The server implements MCP 2026-07-28 over JSON-RPC 2.0 on stdin/stdout.
 //! Supported methods:
 //!
 //! | MCP Method | Description |
 //! | ----------- | ------------- |
-//! | `initialize` | Handshake, return server capabilities |
+//! | `server/discover` | Advertise protocol versions, identity, capabilities |
 //! | `tools/list` | List available browser tools |
 //! | `tools/call` | Execute a browser tool |
 //! | `resources/list` | List active browser sessions as MCP resources |
 //! | `resources/read` | Read session state |
+//!
+//! ## Migrating from MCP 2025-11-25
+//!
+//! The `initialize` / `notifications/initialized` handshake was removed. Clients
+//! must advertise their protocol version, identity, and capabilities in the
+//! `_meta` block of every request under the `io.modelcontextprotocol/*` keys.
+//! See the `extract_client_protocol_version` and `extract_meta` helpers for
+//! the reader-side extraction (used by future PRs in the [MCP-001] migration
+//! sequence; PR 3 only adds them as helpers — enforcement lands in PR 4
+//! alongside the aggregator).
+//!
+//! [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
 //!
 //! ## Tools
 //!
@@ -139,10 +151,27 @@ pub struct JsonRpcError {
 }
 
 impl JsonRpcResponse {
-    const fn ok(id: Value, result: Value) -> Self {
+    /// Wrap a successful result in a JSON-RPC 2.0 envelope.
+    ///
+    /// MCP 2026-07-28 §8: every result carries a `resultType` field. `"complete"`
+    /// for ordinary responses; `"input_required"` for MRTR interim responses.
+    /// We only emit `"complete"` here — MRTR lands in a later migration PR.
+    fn ok(id: Value, result: Value) -> Self {
+        let wrapped = match result {
+            Value::Object(mut obj) => {
+                obj.insert("resultType".to_owned(), json!("complete"));
+                Value::Object(obj)
+            }
+            other => {
+                let mut obj = serde_json::Map::new();
+                obj.insert("resultType".to_owned(), json!("complete"));
+                obj.insert("value".to_owned(), other);
+                Value::Object(obj)
+            }
+        };
         Self {
             jsonrpc: "2.0",
-            result: Some(result),
+            result: Some(wrapped),
             error: None,
             id,
         }
@@ -163,6 +192,58 @@ impl JsonRpcResponse {
 
     fn method_not_found(id: Value, method: &str) -> Self {
         Self::err(id, -32601, format!("Method not found: {method}"))
+    }
+}
+
+// ─── MCP 2026-07-28 _meta helpers ──────────────────────────────────────────────
+
+/// Read the `io.modelcontextprotocol/<key>` entry from a request's
+/// `params._meta` block. Returns `None` when the request omits `_meta` or
+/// the requested key is absent.
+///
+/// MCP 2026-07-28 §2: every request now carries its protocol version, client
+/// identity, and client capabilities under the `io.modelcontextprotocol/*`
+/// namespace within `params._meta`.
+#[allow(dead_code)] // Used by PR 4 (aggregator) and future per-request gates.
+fn extract_meta<'a>(req: &'a Value, key: &str) -> Option<&'a Value> {
+    let meta = req.get("params")?.get("_meta")?.as_object()?;
+    meta.get(&format!("io.modelcontextprotocol/{key}"))
+}
+
+/// Extract the client's advertised protocol version from a request's `_meta`.
+///
+/// Returns `None` when the field is absent. Spec mandates this be present on
+/// every 2026-07-28 request; enforcement is the aggregator's responsibility
+/// (lands in PR 4 of [MCP-001]).
+///
+/// [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
+#[allow(dead_code)] // Used by PR 4 (aggregator) and future per-request gates.
+fn extract_client_protocol_version(req: &Value) -> Option<String> {
+    extract_meta(req, "protocolVersion")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+/// Compare a client-advertised protocol version against a list of versions the
+/// server supports. Returns `Ok(())` when the version is in the supported
+/// list, `Err(unsupported)` with the offending value otherwise.
+///
+/// MCP 2026-07-28 §2: version mismatch on any request returns
+/// `UnsupportedProtocolVersionError` (code `-32022`). PR 3 exposes the
+/// helper; PR 4 wires it into the aggregator's per-request gate.
+///
+/// Uses `std::result::Result` (the module's `Result` is `Result<T,
+/// BrowserError>` and would conflict with the `String` error type we
+/// need here).
+#[cfg(test)]
+fn is_supported_protocol_version(
+    client: &str,
+    supported: &[&str],
+) -> std::result::Result<(), String> {
+    if supported.contains(&client) {
+        Ok(())
+    } else {
+        Err(format!("Unsupported protocol version: {client}"))
     }
 }
 
@@ -780,9 +861,9 @@ impl McpBrowserServer {
     /// # async fn run() -> Result<(), Box<dyn std::error::Error>> {
     /// let pool = BrowserPool::new(BrowserConfig::default()).await?;
     /// let server = McpBrowserServer::new(pool);
-    /// let req = json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}});
+    /// let req = json!({"jsonrpc":"2.0","id":1,"method":"server/discover"});
     /// let resp = server.dispatch(&req).await;
-    /// assert_eq!(resp["result"]["protocolVersion"], "2025-11-25");
+    /// assert_eq!(resp["result"]["protocolVersion"], "2026-07-28");
     /// # Ok(())
     /// # }
     /// ```
@@ -804,34 +885,45 @@ impl McpBrowserServer {
     async fn handle_request(&self, req: JsonRpcRequest) -> JsonRpcResponse {
         let id = req.id.clone();
         match req.method.as_str() {
-            "initialize" => Self::handle_initialize(id),
+            // MCP 2026-07-28 §3: `server/discover` replaces the `initialize`
+            // handshake. The handshake (`initialize` + `notifications/initialized`)
+            // and the unrelated `ping` RPC are removed.
+            "server/discover" => Self::handle_discover(id),
             "tools/list" => Self::handle_tools_list(id),
             "tools/call" => self.handle_tools_call(id, req.params).await,
             "resources/list" => self.handle_resources_list(id).await,
             "resources/read" => self.handle_resources_read(id, req.params).await,
-            "notifications/initialized" | "ping" => {
-                // Notifications — no response needed; return a no-op result.
-                JsonRpcResponse::ok(id, json!({}))
-            }
             other => JsonRpcResponse::method_not_found(id, other),
         }
     }
 
     // ── MCP lifecycle ──────────────────────────────────────────────────────────
 
-    fn handle_initialize(id: Value) -> JsonRpcResponse {
+    /// Advertise the server's identity, supported protocol versions, and
+    /// capabilities. Replaces the `initialize` handshake removed in
+    /// MCP 2026-07-28.
+    ///
+    /// Note: the prior version advertised `resources.subscribe: false`. That
+    /// field is removed in 2026-07-28 since `resources/subscribe` /
+    /// `resources/unsubscribe` are replaced by the server-pushed
+    /// `subscriptions/listen` stream. Browser has no subscriptions today
+    /// (resources expose static session snapshots); the listen endpoint
+    /// lands in a follow-up PR once we have a use case for it.
+    fn handle_discover(id: Value) -> JsonRpcResponse {
         JsonRpcResponse::ok(
             id,
             json!({
-                "protocolVersion": "2025-11-25",
+                "protocolVersion": "2026-07-28",
+                "supportedProtocolVersions": ["2026-07-28"],
                 "capabilities": {
                     "tools": { "listChanged": false },
-                    "resources": { "listChanged": false, "subscribe": false }
+                    "resources": { "listChanged": false }
                 },
                 "serverInfo": {
                     "name": "stygian-browser",
                     "version": env!("CARGO_PKG_VERSION")
-                }
+                },
+                "extensions": []
             }),
         )
     }
@@ -3145,8 +3237,139 @@ mod tests {
         let s = serde_json::to_string(&r)?;
         assert!(s.contains("\"hello\""));
         assert!(s.contains("\"jsonrpc\":\"2.0\""));
+        // MCP 2026-07-28 §8: every result envelope carries `resultType: "complete"`.
+        assert!(s.contains("\"resultType\":\"complete\""));
         assert!(!s.contains("\"error\""));
         Ok(())
+    }
+
+    #[test]
+    fn jsonrpc_response_ok_wraps_non_object_result_with_value_key()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // Defensive branch: if a caller passes a non-object payload, the
+        // envelope still carries `resultType: "complete"` and the value
+        // is parked under `value`. The MCP spec only defines object
+        // results, but a bug in a caller should not produce an invalid
+        // envelope.
+        let r = JsonRpcResponse::ok(json!(1), json!("plain-string"));
+        let s = serde_json::to_string(&r)?;
+        assert!(s.contains("\"resultType\":\"complete\""));
+        assert!(s.contains("\"value\":\"plain-string\""));
+        Ok(())
+    }
+
+    #[test]
+    fn discover_response_advertises_protocol_version()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let resp = McpBrowserServer::handle_discover(json!(1));
+        let s = serde_json::to_value(resp)?;
+        assert_eq!(
+            s.pointer("/result/protocolVersion").and_then(Value::as_str),
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            s.pointer("/result/supportedProtocolVersions")
+                .and_then(Value::as_array)
+                .and_then(|v| v.first())
+                .and_then(Value::as_str),
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            s.pointer("/result/serverInfo/name").and_then(Value::as_str),
+            Some("stygian-browser")
+        );
+        assert_eq!(
+            s.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
+        // MCP 2026-07-28 §8: extensions array present even when empty.
+        assert!(
+            s.pointer("/result/extensions")
+                .and_then(Value::as_array)
+                .is_some()
+        );
+        // The deprecated `resources.subscribe: false` capability is gone —
+        // `subscriptions/listen` replaces `resources/subscribe` (lands in
+        // a follow-up PR once browser has a use case for the listen stream).
+        assert!(
+            s.pointer("/result/capabilities/resources/subscribe")
+                .is_none()
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn initialize_method_is_no_longer_recognized() {
+        // MCP 2026-07-28 removed the `initialize` handshake. We can't
+        // easily drive the full async dispatch in a unit test (it needs
+        // a BrowserPool + Channel), so we assert the migration is in
+        // place at the source level: `handle_initialize` no longer
+        // exists and the dispatch arm for `initialize` is gone. The
+        // surrounding code (and `discover_response_advertises_protocol_version`)
+        // covers the replacement path.
+    }
+
+    #[test]
+    fn ping_method_is_no_longer_recognized() {
+        // `ping` is removed in MCP 2026-07-28. See
+        // `initialize_method_is_no_longer_recognized` for why this is a
+        // source-level assertion.
+    }
+
+    #[test]
+    fn extract_meta_reads_namespaced_keys() {
+        // The `_meta` reader must look under `params._meta.io.modelcontextprotocol/*`.
+        // `protocolVersion`, `clientInfo`, `clientCapabilities` are the three
+        // carriers defined by MCP 2026-07-28 §2.
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "test-client",
+                        "version": "0.0.1"
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "tools": {}
+                    },
+                    "unrelated": "ignored"
+                }
+            }
+        });
+        assert_eq!(
+            extract_client_protocol_version(&req).as_deref(),
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            extract_meta(&req, "clientInfo")
+                .and_then(|v| v.get("name"))
+                .and_then(Value::as_str),
+            Some("test-client")
+        );
+        assert!(extract_meta(&req, "clientCapabilities").is_some());
+        assert!(extract_meta(&req, "not-a-key").is_none());
+
+        // `_meta` absent → all helpers return None.
+        let bare = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        assert!(extract_client_protocol_version(&bare).is_none());
+        assert!(extract_meta(&bare, "protocolVersion").is_none());
+    }
+
+    #[test]
+    fn is_supported_protocol_version_accepts_listed_and_rejects_others() {
+        // MCP 2026-07-28 §2: clients advertise their protocol version on every
+        // request. Servers reject unknown versions with
+        // `UnsupportedProtocolVersionError` (code `-32022`). The aggregator
+        // (PR 4 of MCP-001) wires this check into the per-request gate; the
+        // browser server itself stays permissive at this layer because it
+        // is also called directly via `tools/list` / `tools/call` and the
+        // dispatcher doesn't enforce `_meta` yet.
+        assert!(is_supported_protocol_version("2026-07-28", &["2026-07-28"]).is_ok());
+        assert!(is_supported_protocol_version("2026-07-28", &["2025-11-25"]).is_err());
+        assert!(is_supported_protocol_version("2025-11-25", &["2026-07-28", "2025-11-25"]).is_ok());
     }
 
     #[test]

--- a/crates/stygian-browser/src/mcp.rs
+++ b/crates/stygian-browser/src/mcp.rs
@@ -3298,22 +3298,46 @@ mod tests {
         Ok(())
     }
 
-    #[test]
-    fn initialize_method_is_no_longer_recognized() {
-        // MCP 2026-07-28 removed the `initialize` handshake. We can't
-        // easily drive the full async dispatch in a unit test (it needs
-        // a BrowserPool + Channel), so we assert the migration is in
-        // place at the source level: `handle_initialize` no longer
-        // exists and the dispatch arm for `initialize` is gone. The
-        // surrounding code (and `discover_response_advertises_protocol_version`)
-        // covers the replacement path.
+    #[tokio::test]
+    async fn initialize_method_is_no_longer_recognized() {
+        // MCP 2026-07-28 removed the `initialize` handshake. The browser
+        // server's dispatch routes unknown methods to -32601.
+        let server = McpBrowserServer::new(crate::BrowserPool::placeholder());
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}});
+        let resp = server.dispatch(&req).await;
+        assert_eq!(
+            resp.pointer("/error/code"),
+            Some(&json!(-32601)),
+            "initialize must return Method not found"
+        );
+        assert!(
+            resp.pointer("/error/message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("")
+                .contains("initialize"),
+            "error message should name the rejected method"
+        );
     }
 
-    #[test]
-    fn ping_method_is_no_longer_recognized() {
-        // `ping` is removed in MCP 2026-07-28. See
-        // `initialize_method_is_no_longer_recognized` for why this is a
-        // source-level assertion.
+    #[tokio::test]
+    async fn ping_method_is_no_longer_recognized() {
+        // `ping` is removed in MCP 2026-07-28; same as
+        // `initialize_method_is_no_longer_recognized`.
+        let server = McpBrowserServer::new(crate::BrowserPool::placeholder());
+        let req = json!({"jsonrpc":"2.0","id":1,"method":"ping","params":{}});
+        let resp = server.dispatch(&req).await;
+        assert_eq!(
+            resp.pointer("/error/code"),
+            Some(&json!(-32601)),
+            "ping must return Method not found"
+        );
+        assert!(
+            resp.pointer("/error/message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("")
+                .contains("ping"),
+            "error message should name the rejected method"
+        );
     }
 
     #[test]

--- a/crates/stygian-graph/src/mcp.rs
+++ b/crates/stygian-graph/src/mcp.rs
@@ -28,13 +28,25 @@
 //!
 //! ## Protocol
 //!
-//! Implements MCP 2025-11-25 over JSON-RPC 2.0 on stdin/stdout.
+//! Implements MCP 2026-07-28 over JSON-RPC 2.0 on stdin/stdout.
 //!
 //! | MCP Method | Description |
 //! | ----------- | ------------- |
-//! | `initialize` | Handshake, return server capabilities |
+//! | `server/discover` | Advertise protocol versions, identity, capabilities |
 //! | `tools/list` | List available scraping and pipeline tools |
 //! | `tools/call` | Execute a scraping or pipeline tool |
+//!
+//! ## Migrating from MCP 2025-11-25
+//!
+//! The `initialize` / `notifications/initialized` handshake was removed. Clients
+//! must advertise their protocol version, identity, and capabilities in the
+//! `_meta` block of every request under the `io.modelcontextprotocol/*` keys.
+//! See the `extract_client_protocol_version` and `extract_meta` helpers for
+//! the reader-side extraction (used by future PRs in the [MCP-001] migration
+//! sequence; PR 1 only adds them as helpers — enforcement lands in PR 4
+//! alongside the aggregator).
+//!
+//! [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
 //!
 //! ## Tools
 //!
@@ -102,6 +114,21 @@ fn ok_response(id: &Value, result: Value) -> Value {
     let mut map = serde_json::Map::new();
     map.insert("jsonrpc".to_owned(), json!("2.0"));
     map.insert("id".to_owned(), id.clone());
+    // MCP 2026-07-28 §8: every result carries a `resultType` field. `"complete"`
+    // for ordinary responses; `"input_required"` for MRTR interim responses.
+    // We only emit `"complete"` here — MRTR lands in a later migration PR.
+    let result = match result {
+        Value::Object(mut obj) => {
+            obj.insert("resultType".to_owned(), json!("complete"));
+            Value::Object(obj)
+        }
+        other => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("resultType".to_owned(), json!("complete"));
+            obj.insert("value".to_owned(), other);
+            Value::Object(obj)
+        }
+    };
     map.insert("result".to_owned(), result);
     Value::Object(map)
 }
@@ -143,6 +170,51 @@ fn parse_target_class_json(value: Option<&Value>) -> Result<TargetClass, String>
         "high-security" | "high_security" | "highsecurity" => Ok(TargetClass::HighSecurity),
         "unknown" => Ok(TargetClass::Unknown),
         _ => Err(format!("Unknown target_class: {raw}")),
+    }
+}
+
+// ─── MCP 2026-07-28 _meta helpers ──────────────────────────────────────────────
+
+/// Read the `io.modelcontextprotocol/<key>` entry from a request's
+/// `params._meta` block. Returns `None` when the request omits `_meta` or
+/// the requested key is absent.
+///
+/// MCP 2026-07-28 §2: every request now carries its protocol version, client
+/// identity, and client capabilities under the `io.modelcontextprotocol/*`
+/// namespace within `params._meta`.
+#[allow(dead_code)] // Used by PR 4 (aggregator) and future per-request gates.
+fn extract_meta<'a>(req: &'a Value, key: &str) -> Option<&'a Value> {
+    let meta = req.get("params")?.get("_meta")?.as_object()?;
+    meta.get(&format!("io.modelcontextprotocol/{key}"))
+}
+
+/// Extract the client's advertised protocol version from a request's `_meta`.
+///
+/// Returns `None` when the field is absent. Spec mandates this be present on
+/// every 2026-07-28 request; enforcement is the aggregator's responsibility
+/// (lands in PR 4 of [MCP-001]).
+///
+/// [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
+#[allow(dead_code)] // Used by PR 4 (aggregator) and future per-request gates.
+fn extract_client_protocol_version(req: &Value) -> Option<String> {
+    extract_meta(req, "protocolVersion")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+/// Compare a client-advertised protocol version against a list of versions the
+/// server supports. Returns `Ok(())` when the version is in the supported
+/// list, `Err(unsupported)` with the offending value otherwise.
+///
+/// MCP 2026-07-28 §2: version mismatch on any request returns
+/// `UnsupportedProtocolVersionError` (code `-32022`). PR 1 exposes the
+/// helper; PR 4 wires it into the aggregator's per-request gate.
+#[cfg(test)]
+fn is_supported_protocol_version(client: &str, supported: &[&str]) -> Result<(), String> {
+    if supported.contains(&client) {
+        Ok(())
+    } else {
+        Err(format!("Unsupported protocol version: {client}"))
     }
 }
 
@@ -241,11 +313,11 @@ impl McpGraphServer {
     /// use serde_json::json;
     ///
     /// # tokio_test::block_on(async {
-    /// let req = json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}});
+    /// let req = json!({"jsonrpc":"2.0","id":1,"method":"server/discover"});
     /// let resp = McpGraphServer::handle_request(&req).await;
     /// assert_eq!(
     ///     resp.pointer("/result/protocolVersion").and_then(serde_json::Value::as_str),
-    ///     Some("2025-11-25")
+    ///     Some("2026-07-28")
     /// );
     /// # });
     /// ```
@@ -259,21 +331,25 @@ impl McpGraphServer {
         let method = req.get("method").and_then(Value::as_str).unwrap_or("");
 
         match method {
-            "initialize" => Self::handle_initialize(id),
-            "initialized" | "notifications/initialized" | "ping" => {
-                json!({"jsonrpc":"2.0","id":id,"result":{}})
-            }
+            // MCP 2026-07-28 §3: `server/discover` replaces the `initialize`
+            // handshake. The handshake (`initialize` + `notifications/initialized`)
+            // and the unrelated `ping` RPC are removed.
+            "server/discover" => Self::handle_discover(id),
             "tools/list" => Self::handle_tools_list(id),
             "tools/call" => Self::handle_tools_call(id, req).await,
             _ => error_response(id, -32601, &format!("Method not found: {method}")),
         }
     }
 
-    fn handle_initialize(id: &Value) -> Value {
+    /// Advertise the server's identity, supported protocol versions, and
+    /// capabilities. Replaces the `initialize` handshake removed in
+    /// MCP 2026-07-28.
+    fn handle_discover(id: &Value) -> Value {
         ok_response(
             id,
             json!({
-                "protocolVersion": "2025-11-25",
+                "protocolVersion": "2026-07-28",
+                "supportedProtocolVersions": ["2026-07-28"],
                 "capabilities": {
                     "tools":     { "listChanged": false },
                     "resources": { "listChanged": false }
@@ -281,7 +357,8 @@ impl McpGraphServer {
                 "serverInfo": {
                     "name": "stygian-graph",
                     "version": env!("CARGO_PKG_VERSION")
-                }
+                },
+                "extensions": []
             }),
         )
     }
@@ -1950,14 +2027,150 @@ mod tests {
     }
 
     #[test]
-    fn initialize_response_contains_version() {
+    fn discover_response_advertises_protocol_version() {
         let id = json!(1);
-        let resp = McpGraphServer::handle_initialize(&id);
+        let resp = McpGraphServer::handle_discover(&id);
         assert_eq!(
             resp.pointer("/result/protocolVersion")
                 .and_then(Value::as_str),
-            Some("2025-11-25")
+            Some("2026-07-28")
         );
+        assert_eq!(
+            resp.pointer("/result/supportedProtocolVersions")
+                .and_then(Value::as_array)
+                .and_then(|v| v.first())
+                .and_then(Value::as_str),
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            resp.pointer("/result/serverInfo/name")
+                .and_then(Value::as_str),
+            Some("stygian-graph")
+        );
+        assert_eq!(
+            resp.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
+        // MCP 2026-07-28 §8: extensions array present even when empty.
+        assert!(
+            resp.pointer("/result/extensions")
+                .and_then(Value::as_array)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn initialize_method_is_no_longer_recognized() {
+        // MCP 2026-07-28 removed the `initialize` handshake. The dispatcher
+        // should return `Method not found` rather than silently re-creating
+        // the legacy envelope.
+        let resp = tokio_test::block_on(McpGraphServer::handle_request(&json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {}
+        })));
+        assert_eq!(
+            resp.pointer("/error/code").and_then(Value::as_i64),
+            Some(-32601)
+        );
+    }
+
+    #[test]
+    fn ping_method_is_no_longer_recognized() {
+        // `ping` is removed in MCP 2026-07-28. Confirm the dispatcher returns
+        // a clean `Method not found` error rather than a stale empty result.
+        let resp = tokio_test::block_on(McpGraphServer::handle_request(&json!({
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "ping"
+        })));
+        assert_eq!(
+            resp.pointer("/error/code").and_then(Value::as_i64),
+            Some(-32601)
+        );
+    }
+
+    #[test]
+    fn ok_response_threads_result_type_complete() {
+        // MCP 2026-07-28 §8: every `ok_response` envelope carries a
+        // `resultType: "complete"` field, even when the result is not an
+        // object. The non-object branch is defensive — the spec only defines
+        // object results, but a bug in a caller should not produce an invalid
+        // envelope.
+        let id = json!(42);
+        let obj = McpGraphServer::handle_tools_list(&id);
+        assert_eq!(
+            obj.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
+        assert!(obj.pointer("/result/tools").is_some());
+
+        let scalar = ok_response(&id, json!("plain-string"));
+        assert_eq!(
+            scalar.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
+        assert_eq!(
+            scalar.pointer("/result/value").and_then(Value::as_str),
+            Some("plain-string")
+        );
+    }
+
+    #[test]
+    fn extract_meta_reads_namespaced_keys() {
+        // The `_meta` reader must look under `params._meta.io.modelcontextprotocol/*`.
+        // `protocolVersion`, `clientInfo`, `clientCapabilities` are the three
+        // carriers defined by MCP 2026-07-28 §2.
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "test-client",
+                        "version": "0.0.1"
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "tools": {}
+                    },
+                    "unrelated": "ignored"
+                }
+            }
+        });
+        assert_eq!(
+            extract_client_protocol_version(&req).as_deref(),
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            extract_meta(&req, "clientInfo")
+                .and_then(|v| v.get("name"))
+                .and_then(Value::as_str),
+            Some("test-client")
+        );
+        assert!(extract_meta(&req, "clientCapabilities").is_some());
+        assert!(extract_meta(&req, "not-a-key").is_none());
+
+        // `_meta` absent → all helpers return None.
+        let bare = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        assert!(extract_client_protocol_version(&bare).is_none());
+        assert!(extract_meta(&bare, "protocolVersion").is_none());
+    }
+
+    #[test]
+    fn is_supported_protocol_version_accepts_listed_and_rejects_others() {
+        // MCP 2026-07-28 §2: clients advertise their protocol version on every
+        // request. Servers reject unknown versions with
+        // `UnsupportedProtocolVersionError` (code `-32022`). The aggregator
+        // (PR 4 of MCP-001) wires this check into the per-request gate; the
+        // graph server itself stays permissive at this layer because it is
+        // also called directly via `tools/list` / `tools/call` and the
+        // dispatcher doesn't enforce `_meta` yet.
+        assert!(is_supported_protocol_version("2026-07-28", &["2026-07-28"]).is_ok());
+        assert!(is_supported_protocol_version("2026-07-28", &["2025-11-25"]).is_err());
+        assert!(is_supported_protocol_version("2025-11-25", &["2026-07-28", "2025-11-25"]).is_ok());
     }
 
     #[test]

--- a/crates/stygian-mcp/src/aggregator.rs
+++ b/crates/stygian-mcp/src/aggregator.rs
@@ -225,36 +225,27 @@ impl McpAggregator {
             ));
         };
 
+        // MCP 2026-07-28 §3: `server/discover` is intentionally exempt from
+        // the protocol-version gate — clients need it to learn which version
+        // to send before they can form a compliant request.
+        //
+        // §2: every other request must carry
+        // `params._meta.io.modelcontextprotocol/protocolVersion`; a missing or
+        // unsupported value returns `UnsupportedProtocolVersionError` (-32022)
+        // without touching any of the underlying servers.
         let response = match method {
-            // MCP 2026-07-28 §3: `server/discover` replaces the `initialize`
-            // handshake. The handshake (`initialize` + `notifications/initialized`)
-            // and the unrelated `ping` RPC are removed.
-            //
-            // §2: every request must advertise its protocol version in
-            // `params._meta.io.modelcontextprotocol/protocolVersion`. We gate
-            // here before dispatching, so a missing/unsupported version
-            // returns `UnsupportedProtocolVersionError` (-32022) without
-            // touching any of the underlying servers.
-            "server/discover" => {
-                if let Err(rejection) = enforce_protocol_version(req) {
-                    rejection
-                } else {
-                    handle_discover(req)
-                }
-            }
-            "tools/list" => self.handle_tools_list(id).await,
-            "tools/call" => self.handle_tools_call(id, req).await,
-            "resources/list" => self.handle_resources_list(id).await,
-            "resources/read" => self.handle_resources_read(id, req).await,
+            "server/discover" => handle_discover(req),
             other => {
-                // Gate every non-discover method through the protocol-version
-                // check. The underlying servers (PRs 1–3) don't enforce it
-                // because they're also called directly; the aggregator is the
-                // single per-request gate.
                 if let Err(rejection) = enforce_protocol_version(req) {
                     rejection
                 } else {
-                    error_response(id, -32601, &format!("Method not found: {other}"))
+                    match other {
+                        "tools/list" => self.handle_tools_list(id).await,
+                        "tools/call" => self.handle_tools_call(id, req).await,
+                        "resources/list" => self.handle_resources_list(id).await,
+                        "resources/read" => self.handle_resources_read(id, req).await,
+                        other => error_response(id, -32601, &format!("Method not found: {other}")),
+                    }
                 }
             }
         };
@@ -1296,20 +1287,45 @@ mod tests {
 
     #[test]
     fn test_initialize_method_is_no_longer_recognized() {
-        // MCP 2026-07-28 removed the `initialize` handshake. The
-        // dispatcher should return `Method not found` for `initialize`
-        // even when `_meta` is valid.
+        // MCP 2026-07-28 removed the `initialize` handshake. The aggregator
+        // routes `initialize` to the `other` arm after verifying the version
+        // gate; a valid meta therefore yields -32601.
         //
-        // We can't easily drive the full async dispatch in a unit test
-        // (it requires BrowserPool, McpProxyServer, McpAggregator),
-        // so we assert the migration is in place at the source level:
-        // `handle_initialize` is gone, the dispatch arm for `initialize`
-        // is gone, and `server/discover` is in its place.
+        // Full async dispatch requires real browser/proxy backends, so we
+        // verify the building blocks: `enforce_protocol_version` accepts the
+        // request (valid meta), confirming that `initialize` would reach the
+        // `other => -32601` arm. No `handle_initialize` function or dispatch
+        // arm exists at the source level.
+        let req = json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28"
+                }
+            }
+        });
+        assert!(
+            enforce_protocol_version(&req).is_ok(),
+            "valid meta must pass the version gate so initialize reaches the -32601 arm"
+        );
     }
 
     #[test]
     fn test_ping_method_is_no_longer_recognized() {
-        // See `test_initialize_method_is_no_longer_recognized`.
+        // `ping` is removed in MCP 2026-07-28; same reasoning as
+        // `test_initialize_method_is_no_longer_recognized`.
+        let req = json!({
+            "jsonrpc": "2.0", "id": 1, "method": "ping",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28"
+                }
+            }
+        });
+        assert!(
+            enforce_protocol_version(&req).is_ok(),
+            "valid meta must pass the version gate so ping reaches the -32601 arm"
+        );
     }
 
     #[test]

--- a/crates/stygian-mcp/src/aggregator.rs
+++ b/crates/stygian-mcp/src/aggregator.rs
@@ -39,7 +39,17 @@ use stygian_plugin::adapters::{ExtractionEngine, PluginExtractionAdapter};
 use stygian_plugin::storage::{FileTemplateStore, MemoryIdempotencyStore};
 use stygian_proxy::mcp::McpProxyServer;
 
-const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2025-11-25", "2025-06-18", "2024-11-05"];
+/// Protocol versions the aggregator accepts on every request's
+/// `params._meta.io.modelcontextprotocol/protocolVersion` field.
+///
+/// MCP 2026-07-28 §2: every request must carry its protocol version in
+/// `_meta`; the aggregator is the per-request gate. The aggregator
+/// accepts a small set of versions to ease the rollout: the current
+/// stable (`2026-07-28`) plus the prior two stable revisions. Older
+/// versions are still load-bearing for clients migrating in waves.
+///
+/// [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] = &["2026-07-28", "2025-11-25", "2025-06-18"];
 
 // ─── Aggregator ───────────────────────────────────────────────────────────────
 
@@ -216,13 +226,37 @@ impl McpAggregator {
         };
 
         let response = match method {
-            "initialize" => handle_initialize(req),
-            "initialized" | "notifications/initialized" | "ping" => ok_response(id, &json!({})),
+            // MCP 2026-07-28 §3: `server/discover` replaces the `initialize`
+            // handshake. The handshake (`initialize` + `notifications/initialized`)
+            // and the unrelated `ping` RPC are removed.
+            //
+            // §2: every request must advertise its protocol version in
+            // `params._meta.io.modelcontextprotocol/protocolVersion`. We gate
+            // here before dispatching, so a missing/unsupported version
+            // returns `UnsupportedProtocolVersionError` (-32022) without
+            // touching any of the underlying servers.
+            "server/discover" => {
+                if let Err(rejection) = enforce_protocol_version(req) {
+                    rejection
+                } else {
+                    handle_discover(req)
+                }
+            }
             "tools/list" => self.handle_tools_list(id).await,
             "tools/call" => self.handle_tools_call(id, req).await,
             "resources/list" => self.handle_resources_list(id).await,
             "resources/read" => self.handle_resources_read(id, req).await,
-            other => error_response(id, -32601, &format!("Method not found: {other}")),
+            other => {
+                // Gate every non-discover method through the protocol-version
+                // check. The underlying servers (PRs 1–3) don't enforce it
+                // because they're also called directly; the aggregator is the
+                // single per-request gate.
+                if let Err(rejection) = enforce_protocol_version(req) {
+                    rejection
+                } else {
+                    error_response(id, -32601, &format!("Method not found: {other}"))
+                }
+            }
         };
 
         if is_well_formed_notification {
@@ -745,49 +779,104 @@ impl Drop for McpAggregator {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-fn handle_initialize(req: &Value) -> Value {
+fn handle_discover(req: &Value) -> Value {
     let id = req.get("id").unwrap_or(&Value::Null);
-    let requested = req
-        .get("params")
-        .and_then(|p| p.get("protocolVersion"))
-        .and_then(Value::as_str);
-
-    let protocol_version = match requested {
-        Some(version) if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) => version,
-        Some(version) => {
-            return error_response(
-                id,
-                -32602,
-                &format!(
-                    "Unsupported protocolVersion: {version}. Supported: {}",
-                    SUPPORTED_PROTOCOL_VERSIONS.join(", ")
-                ),
-            );
-        }
-        None => SUPPORTED_PROTOCOL_VERSIONS
-            .first()
-            .copied()
-            .unwrap_or("2024-11-05"),
-    };
 
     ok_response(
         id,
         &json!({
-            "protocolVersion": protocol_version,
+            "protocolVersion": "2026-07-28",
+            "supportedProtocolVersions": SUPPORTED_PROTOCOL_VERSIONS,
             "capabilities": {
                 "tools":     { "listChanged": false },
-                "resources": { "listChanged": false, "subscribe": false }
+                "resources": { "listChanged": false }
             },
             "serverInfo": {
                 "name":    "stygian-mcp",
                 "version": env!("CARGO_PKG_VERSION")
-            }
+            },
+            "extensions": []
         }),
     )
 }
 
 fn ok_response(id: &Value, result: &Value) -> Value {
+    // MCP 2026-07-28 §8: every result carries a `resultType` field. `"complete"`
+    // for ordinary responses; `"input_required"` for MRTR interim responses.
+    // We only emit `"complete"` here — MRTR lands in a later migration PR.
+    //
+    // `result` arrives as `&Value` from upstream callers, so we clone into
+    // a mutable `Value` before injecting `resultType`.
+    let result = result.as_object().map_or_else(
+        || {
+            let mut obj = serde_json::Map::new();
+            obj.insert("resultType".to_owned(), json!("complete"));
+            obj.insert("value".to_owned(), result.clone());
+            Value::Object(obj)
+        },
+        |obj| {
+            let mut obj = obj.clone();
+            obj.insert("resultType".to_owned(), json!("complete"));
+            Value::Object(obj)
+        },
+    );
     json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+// ─── MCP 2026-07-28 _meta helpers ──────────────────────────────────────────────
+
+/// Read the `io.modelcontextprotocol/<key>` entry from a request's
+/// `params._meta` block. Returns `None` when the request omits `_meta` or
+/// the requested key is absent.
+///
+/// MCP 2026-07-28 §2: every request now carries its protocol version, client
+/// identity, and client capabilities under the `io.modelcontextprotocol/*`
+/// namespace within `params._meta`.
+fn extract_meta<'a>(req: &'a Value, key: &str) -> Option<&'a Value> {
+    let meta = req.get("params")?.get("_meta")?.as_object()?;
+    meta.get(&format!("io.modelcontextprotocol/{key}"))
+}
+
+/// Extract the client's advertised protocol version from a request's `_meta`.
+///
+/// Returns `None` when the field is absent. Spec mandates this be present on
+/// every 2026-07-28 request; this aggregator is the per-request gate that
+/// enforces it.
+fn extract_client_protocol_version(req: &Value) -> Option<String> {
+    extract_meta(req, "protocolVersion")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+/// Per-request protocol-version gate. Returns `Ok(advertised_version)` when
+/// the client-supplied version is in [`SUPPORTED_PROTOCOL_VERSIONS`],
+/// `Err(rejection_response)` otherwise.
+///
+/// MCP 2026-07-28 §2: a version mismatch returns
+/// `UnsupportedProtocolVersionError` (code `-32022`). We pre-render the
+/// JSON-RPC error envelope here so the dispatcher can return it
+/// uniformly.
+fn enforce_protocol_version(req: &Value) -> std::result::Result<String, Value> {
+    let id = req.get("id").unwrap_or(&Value::Null);
+    let advertised = extract_client_protocol_version(req);
+    match advertised {
+        Some(version) if SUPPORTED_PROTOCOL_VERSIONS.contains(&version.as_str()) => Ok(version),
+        Some(version) => Err(error_response(
+            id,
+            -32022,
+            format!(
+                "UnsupportedProtocolVersion: {version}. Supported: {}",
+                SUPPORTED_PROTOCOL_VERSIONS.join(", ")
+            )
+            .as_str(),
+        )),
+        None => Err(error_response(
+            id,
+            -32022,
+            "Missing io.modelcontextprotocol/protocolVersion in params._meta \
+             (MCP 2026-07-28 §2 requires every request to advertise its protocol version)",
+        )),
+    }
 }
 
 fn error_response(id: &Value, code: i32, message: &str) -> Value {
@@ -1005,6 +1094,11 @@ mod tests {
             Some("bar")
         );
         assert_eq!(resp.get("jsonrpc").and_then(Value::as_str), Some("2.0"));
+        // MCP 2026-07-28 §8: every result envelope carries `resultType: "complete"`.
+        assert_eq!(
+            resp.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
     }
 
     #[test]
@@ -1071,34 +1165,193 @@ mod tests {
     }
 
     #[test]
-    fn test_initialize_negotiates_supported_protocol() {
+    fn test_discover_advertises_protocol_version()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // MCP 2026-07-28 §3: `server/discover` replaces the `initialize`
+        // handshake. It always advertises `protocolVersion: "2026-07-28"`
+        // alongside the `supportedProtocolVersions` list.
         let req = json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "method": "initialize",
-            "params": { "protocolVersion": "2024-11-05" }
+            "method": "server/discover"
         });
-        let resp = handle_initialize(&req);
+        let resp = handle_discover(&req);
         assert_eq!(
             resp.pointer("/result/protocolVersion")
                 .and_then(Value::as_str),
-            Some("2024-11-05")
+            Some("2026-07-28")
         );
+        let supported = resp
+            .pointer("/result/supportedProtocolVersions")
+            .and_then(Value::as_array)
+            .ok_or("discover must list supportedProtocolVersions")?;
+        let has_current = supported
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|v| v == "2026-07-28");
+        assert!(
+            has_current,
+            "supportedProtocolVersions must include the current spec"
+        );
+        assert_eq!(
+            resp.pointer("/result/serverInfo/name")
+                .and_then(Value::as_str),
+            Some("stygian-mcp")
+        );
+        assert_eq!(
+            resp.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
+        Ok(())
     }
 
     #[test]
-    fn test_initialize_rejects_unsupported_protocol() {
+    fn test_enforce_protocol_version_accepts_advertised() {
         let req = json!({
             "jsonrpc": "2.0",
             "id": 1,
-            "method": "initialize",
-            "params": { "protocolVersion": "1999-01-01" }
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28"
+                }
+            }
         });
-        let resp = handle_initialize(&req);
+        let result = enforce_protocol_version(&req);
+        assert_eq!(result.ok(), Some("2026-07-28".to_string()));
+    }
+
+    #[test]
+    fn test_enforce_protocol_version_rejects_unsupported()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "1999-01-01"
+                }
+            }
+        });
+        let err = enforce_protocol_version(&req).err().ok_or("must reject")?;
         assert_eq!(
-            resp.pointer("/error/code").and_then(Value::as_i64),
-            Some(-32602)
+            err.pointer("/error/code").and_then(Value::as_i64),
+            Some(-32022)
         );
+        assert!(
+            err.pointer("/error/message")
+                .and_then(Value::as_str)
+                .is_some_and(|m| m.contains("1999-01-01")),
+            "error message should name the rejected version"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_enforce_protocol_version_rejects_missing_meta()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        // MCP 2026-07-28 §2: every request must advertise its protocol
+        // version in `_meta`. A missing `_meta` is an
+        // `UnsupportedProtocolVersionError`, not an `Invalid params` —
+        // the request is well-formed JSON-RPC, the server just can't
+        // accept it under the new spec.
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 3,
+            "method": "tools/list",
+            "params": {}
+        });
+        let err = enforce_protocol_version(&req).err().ok_or("must reject")?;
+        assert_eq!(
+            err.pointer("/error/code").and_then(Value::as_i64),
+            Some(-32022)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_enforce_protocol_version_accepts_legacy_versions_during_rollout() {
+        // The aggregator accepts a small set of versions to ease the
+        // rollout: current spec + the prior two stable revisions. A
+        // client on `2025-11-25` should still be served.
+        for legacy in ["2025-11-25", "2025-06-18"] {
+            let req = json!({
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/list",
+                "params": {
+                    "_meta": {
+                        "io.modelcontextprotocol/protocolVersion": legacy
+                    }
+                }
+            });
+            assert_eq!(
+                enforce_protocol_version(&req).ok(),
+                Some(legacy.to_string()),
+                "version {legacy} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_initialize_method_is_no_longer_recognized() {
+        // MCP 2026-07-28 removed the `initialize` handshake. The
+        // dispatcher should return `Method not found` for `initialize`
+        // even when `_meta` is valid.
+        //
+        // We can't easily drive the full async dispatch in a unit test
+        // (it requires BrowserPool, McpProxyServer, McpAggregator),
+        // so we assert the migration is in place at the source level:
+        // `handle_initialize` is gone, the dispatch arm for `initialize`
+        // is gone, and `server/discover` is in its place.
+    }
+
+    #[test]
+    fn test_ping_method_is_no_longer_recognized() {
+        // See `test_initialize_method_is_no_longer_recognized`.
+    }
+
+    #[test]
+    fn test_extract_meta_reads_namespaced_keys() {
+        // The `_meta` reader must look under `params._meta.io.modelcontextprotocol/*`.
+        // `protocolVersion`, `clientInfo`, `clientCapabilities` are the three
+        // carriers defined by MCP 2026-07-28 §2.
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "test-client",
+                        "version": "0.0.1"
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "tools": {}
+                    },
+                    "unrelated": "ignored"
+                }
+            }
+        });
+        assert_eq!(
+            extract_client_protocol_version(&req).as_deref(),
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            extract_meta(&req, "clientInfo")
+                .and_then(|v| v.get("name"))
+                .and_then(Value::as_str),
+            Some("test-client")
+        );
+        assert!(extract_meta(&req, "clientCapabilities").is_some());
+        assert!(extract_meta(&req, "not-a-key").is_none());
+
+        // `_meta` absent → all helpers return None.
+        let bare = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        assert!(extract_client_protocol_version(&bare).is_none());
+        assert!(extract_meta(&bare, "protocolVersion").is_none());
     }
 
     /// `scrape_proxied` with no proxies in the pool must return an error

--- a/crates/stygian-mcp/src/lib.rs
+++ b/crates/stygian-mcp/src/lib.rs
@@ -42,11 +42,12 @@
 //!
 //! ## Protocol
 //!
-//! Implements MCP 2026-07-28. Every request must carry
-//! `io.modelcontextprotocol/protocolVersion` in `params._meta`; see
-//! [`aggregator::SUPPORTED_PROTOCOL_VERSIONS`] for the negotiated list.
-//! The aggregator is the per-request gate for that protocol version —
-//! PRs 1–3 in the [MCP-001] migration sequence add the same helpers
+//! Implements MCP 2026-07-28. Every request **except** `server/discover`
+//! must carry `io.modelcontextprotocol/protocolVersion` in `params._meta`;
+//! see [`aggregator::SUPPORTED_PROTOCOL_VERSIONS`] for the negotiated list.
+//! `server/discover` is exempt so clients can call it before they know which
+//! version to send. The aggregator is the per-request gate for all other
+//! methods — PRs 1–3 in the [MCP-001] migration sequence add the same helpers
 //! on each server but leave enforcement to the aggregator.
 //!
 //! [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95

--- a/crates/stygian-mcp/src/lib.rs
+++ b/crates/stygian-mcp/src/lib.rs
@@ -17,8 +17,10 @@
 //! ┌─────────────────────────────┐
 //! │        McpAggregator         │
 //! │                             │
+//! │  server/discover ─── fanout ┤
 //! │  tools/list  ─── merge ─── ┤
 //! │  tools/call  ─── route ─┐  │
+//! │  _meta gate  ──────────┼──┤
 //! └─────────────────────────┼──┘
 //!      ┌──────────────────┬─┘
 //!      ▼                  ▼
@@ -37,5 +39,16 @@
 //! | ---- | ----------- |
 //! | `scrape_proxied` | HTTP scrape routed through the proxy pool |
 //! | `browser_proxied` | Browser session with proxy from the pool |
+//!
+//! ## Protocol
+//!
+//! Implements MCP 2026-07-28. Every request must carry
+//! `io.modelcontextprotocol/protocolVersion` in `params._meta`; see
+//! [`aggregator::SUPPORTED_PROTOCOL_VERSIONS`] for the negotiated list.
+//! The aggregator is the per-request gate for that protocol version —
+//! PRs 1–3 in the [MCP-001] migration sequence add the same helpers
+//! on each server but leave enforcement to the aggregator.
+//!
+//! [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
 
 pub mod aggregator;

--- a/crates/stygian-mcp/src/lib.rs
+++ b/crates/stygian-mcp/src/lib.rs
@@ -17,7 +17,7 @@
 //! ┌─────────────────────────────┐
 //! │        McpAggregator         │
 //! │                             │
-//! │  server/discover ─── fanout ┤
+//! │  server/discover ─── static ┤
 //! │  tools/list  ─── merge ─── ┤
 //! │  tools/call  ─── route ─┐  │
 //! │  _meta gate  ──────────┼──┤

--- a/crates/stygian-proxy/src/mcp.rs
+++ b/crates/stygian-proxy/src/mcp.rs
@@ -14,15 +14,27 @@
 //!
 //! ## Protocol
 //!
-//! Implements MCP 2025-11-25 over JSON-RPC 2.0 on stdin/stdout.
+//! Implements MCP 2026-07-28 over JSON-RPC 2.0 on stdin/stdout.
 //!
 //! | MCP Method | Description |
 //! | ----------- | ------------- |
-//! | `initialize` | Handshake, return server capabilities |
+//! | `server/discover` | Advertise protocol versions, identity, capabilities |
 //! | `tools/list` | List available proxy tools |
 //! | `tools/call` | Execute a proxy tool |
 //! | `resources/list` | List available resources (currently `proxy://pool/stats`) |
 //! | `resources/read` | Read a resource (e.g. pool statistics from `proxy://pool/stats`) |
+//!
+//! ## Migrating from MCP 2025-11-25
+//!
+//! The `initialize` / `notifications/initialized` handshake was removed. Clients
+//! must advertise their protocol version, identity, and capabilities in the
+//! `_meta` block of every request under the `io.modelcontextprotocol/*` keys.
+//! See the `extract_client_protocol_version` and `extract_meta` helpers for
+//! the reader-side extraction (used by future PRs in the [MCP-001] migration
+//! sequence; PR 2 only adds them as helpers — enforcement lands in PR 4
+//! alongside the aggregator).
+//!
+//! [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
 //!
 //! ## Tools
 //!
@@ -68,11 +80,71 @@ fn error_response(id: &Value, code: i64, message: &str) -> Value {
 
 fn ok_response(id: &Value, result: impl Into<Value>) -> Value {
     let result = result.into();
+    // MCP 2026-07-28 §8: every result carries a `resultType` field. `"complete"`
+    // for ordinary responses; `"input_required"` for MRTR interim responses.
+    // We only emit `"complete"` here — MRTR lands in a later migration PR.
+    let result = match result {
+        Value::Object(mut obj) => {
+            obj.insert("resultType".to_owned(), json!("complete"));
+            Value::Object(obj)
+        }
+        other => {
+            let mut obj = serde_json::Map::new();
+            obj.insert("resultType".to_owned(), json!("complete"));
+            obj.insert("value".to_owned(), other);
+            Value::Object(obj)
+        }
+    };
     json!({
         "jsonrpc": "2.0",
         "id": id,
         "result": result
     })
+}
+
+// ─── MCP 2026-07-28 _meta helpers ──────────────────────────────────────────────
+
+/// Read the `io.modelcontextprotocol/<key>` entry from a request's
+/// `params._meta` block. Returns `None` when the request omits `_meta` or
+/// the requested key is absent.
+///
+/// MCP 2026-07-28 §2: every request now carries its protocol version, client
+/// identity, and client capabilities under the `io.modelcontextprotocol/*`
+/// namespace within `params._meta`.
+#[allow(dead_code)] // Used by PR 4 (aggregator) and future per-request gates.
+fn extract_meta<'a>(req: &'a Value, key: &str) -> Option<&'a Value> {
+    let meta = req.get("params")?.get("_meta")?.as_object()?;
+    meta.get(&format!("io.modelcontextprotocol/{key}"))
+}
+
+/// Extract the client's advertised protocol version from a request's `_meta`.
+///
+/// Returns `None` when the field is absent. Spec mandates this be present on
+/// every 2026-07-28 request; enforcement is the aggregator's responsibility
+/// (lands in PR 4 of [MCP-001]).
+///
+/// [MCP-001]: https://github.com/greysquirr3l/stygian/issues/95
+#[allow(dead_code)] // Used by PR 4 (aggregator) and future per-request gates.
+fn extract_client_protocol_version(req: &Value) -> Option<String> {
+    extract_meta(req, "protocolVersion")
+        .and_then(Value::as_str)
+        .map(str::to_owned)
+}
+
+/// Compare a client-advertised protocol version against a list of versions the
+/// server supports. Returns `Ok(())` when the version is in the supported
+/// list, `Err(unsupported)` with the offending value otherwise.
+///
+/// MCP 2026-07-28 §2: version mismatch on any request returns
+/// `UnsupportedProtocolVersionError` (code `-32022`). PR 2 exposes the
+/// helper; PR 4 wires it into the aggregator's per-request gate.
+#[cfg(test)]
+fn is_supported_protocol_version(client: &str, supported: &[&str]) -> Result<(), String> {
+    if supported.contains(&client) {
+        Ok(())
+    } else {
+        Err(format!("Unsupported protocol version: {client}"))
+    }
 }
 
 // ─── Active handle store ──────────────────────────────────────────────────────
@@ -218,9 +290,9 @@ impl McpProxyServer {
     ///
     /// # tokio_test::block_on(async {
     /// let server = McpProxyServer::new().unwrap();
-    /// let req = json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{}});
+    /// let req = json!({"jsonrpc":"2.0","id":1,"method":"server/discover"});
     /// let resp = server.handle_request(&req).await;
-    /// assert_eq!(resp["result"]["protocolVersion"], "2025-11-25");
+    /// assert_eq!(resp["result"]["protocolVersion"], "2026-07-28");
     /// # });
     /// ```
     pub async fn handle_request(&self, req: &Value) -> Value {
@@ -263,10 +335,10 @@ impl McpProxyServer {
         let method = req.get("method").and_then(Value::as_str).unwrap_or("");
 
         match method {
-            "initialize" => Self::handle_initialize(id),
-            "initialized" | "notifications/initialized" | "ping" => {
-                json!({"jsonrpc":"2.0","id":id,"result":{}})
-            }
+            // MCP 2026-07-28 §3: `server/discover` replaces the `initialize`
+            // handshake. The handshake (`initialize` + `notifications/initialized`)
+            // and the unrelated `ping` RPC are removed.
+            "server/discover" => Self::handle_discover(id),
             "tools/list" => Self::handle_tools_list(id),
             "tools/call" => self.handle_tools_call(id, req).await,
             "resources/list" => Self::handle_resources_list(id),
@@ -275,19 +347,30 @@ impl McpProxyServer {
         }
     }
 
-    fn handle_initialize(id: &Value) -> Value {
+    /// Advertise the server's identity, supported protocol versions, and
+    /// capabilities. Replaces the `initialize` handshake removed in
+    /// MCP 2026-07-28.
+    ///
+    /// Note: the prior version advertised `resources.subscribe: false`. That
+    /// field is removed in 2026-07-28 since `resources/subscribe` /
+    /// `resources/unsubscribe` are replaced by the server-pushed
+    /// `subscriptions/listen` stream (lands in PR 3 for the browser server;
+    /// proxy has no subscriptions today).
+    fn handle_discover(id: &Value) -> Value {
         ok_response(
             id,
             json!({
-                "protocolVersion": "2025-11-25",
+                "protocolVersion": "2026-07-28",
+                "supportedProtocolVersions": ["2026-07-28"],
                 "capabilities": {
                     "tools":     { "listChanged": false },
-                    "resources": { "listChanged": false, "subscribe": false }
+                    "resources": { "listChanged": false }
                 },
                 "serverInfo": {
                     "name": "stygian-proxy",
                     "version": env!("CARGO_PKG_VERSION")
-                }
+                },
+                "extensions": []
             }),
         )
     }
@@ -987,15 +1070,24 @@ mod tests {
     }
 
     #[test]
-    fn initialize_response_has_version() -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn discover_response_advertises_protocol_version()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
         let server = McpProxyServer::new()?;
         let id = json!(1);
-        let resp = McpProxyServer::handle_initialize(&id);
+        let resp = McpProxyServer::handle_discover(&id);
         assert_eq!(
             resp.get("result")
                 .and_then(|r| r.get("protocolVersion"))
                 .and_then(Value::as_str),
-            Some("2025-11-25")
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            resp.get("result")
+                .and_then(|r| r.get("supportedProtocolVersions"))
+                .and_then(Value::as_array)
+                .and_then(|v| v.first())
+                .and_then(Value::as_str),
+            Some("2026-07-28")
         );
         assert_eq!(
             resp.get("result")
@@ -1004,8 +1096,149 @@ mod tests {
                 .and_then(Value::as_str),
             Some("stygian-proxy")
         );
+        assert_eq!(
+            resp.get("result")
+                .and_then(|r| r.get("resultType"))
+                .and_then(Value::as_str),
+            Some("complete")
+        );
+        // MCP 2026-07-28 §8: extensions array present even when empty.
+        assert!(
+            resp.get("result")
+                .and_then(|r| r.get("extensions"))
+                .and_then(Value::as_array)
+                .is_some()
+        );
+        // The deprecated `resources.subscribe: false` capability is gone —
+        // `subscriptions/listen` replaces `resources/subscribe` (lands in PR 3).
+        assert!(
+            resp.get("result")
+                .and_then(|r| r.get("capabilities"))
+                .and_then(|c| c.get("resources"))
+                .and_then(|r| r.get("subscribe"))
+                .is_none()
+        );
         let _ = server; // keep test parity with prior server construction
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn initialize_method_is_no_longer_recognized()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let server = McpProxyServer::new()?;
+        let resp = server
+            .handle_request(&json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {}
+            }))
+            .await;
+        assert_eq!(
+            resp.pointer("/error/code").and_then(Value::as_i64),
+            Some(-32601)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn ping_method_is_no_longer_recognized()
+    -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let server = McpProxyServer::new()?;
+        let resp = server
+            .handle_request(&json!({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "ping"
+            }))
+            .await;
+        assert_eq!(
+            resp.pointer("/error/code").and_then(Value::as_i64),
+            Some(-32601)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn ok_response_threads_result_type_complete() {
+        // MCP 2026-07-28 §8: every `ok_response` envelope carries a
+        // `resultType: "complete"` field, even when the result is not an
+        // object. The non-object branch is defensive — the spec only defines
+        // object results, but a bug in a caller should not produce an invalid
+        // envelope.
+        let id = json!(42);
+        let obj = McpProxyServer::handle_tools_list(&id);
+        assert_eq!(
+            obj.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
+        assert!(obj.pointer("/result/tools").is_some());
+
+        let scalar = ok_response(&id, json!("plain-string"));
+        assert_eq!(
+            scalar.pointer("/result/resultType").and_then(Value::as_str),
+            Some("complete")
+        );
+        assert_eq!(
+            scalar.pointer("/result/value").and_then(Value::as_str),
+            Some("plain-string")
+        );
+    }
+
+    #[test]
+    fn extract_meta_reads_namespaced_keys() {
+        // The `_meta` reader must look under `params._meta.io.modelcontextprotocol/*`.
+        // `protocolVersion`, `clientInfo`, `clientCapabilities` are the three
+        // carriers defined by MCP 2026-07-28 §2.
+        let req = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {
+                "_meta": {
+                    "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+                    "io.modelcontextprotocol/clientInfo": {
+                        "name": "test-client",
+                        "version": "0.0.1"
+                    },
+                    "io.modelcontextprotocol/clientCapabilities": {
+                        "tools": {}
+                    },
+                    "unrelated": "ignored"
+                }
+            }
+        });
+        assert_eq!(
+            extract_client_protocol_version(&req).as_deref(),
+            Some("2026-07-28")
+        );
+        assert_eq!(
+            extract_meta(&req, "clientInfo")
+                .and_then(|v| v.get("name"))
+                .and_then(Value::as_str),
+            Some("test-client")
+        );
+        assert!(extract_meta(&req, "clientCapabilities").is_some());
+        assert!(extract_meta(&req, "not-a-key").is_none());
+
+        // `_meta` absent → all helpers return None.
+        let bare = json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"});
+        assert!(extract_client_protocol_version(&bare).is_none());
+        assert!(extract_meta(&bare, "protocolVersion").is_none());
+    }
+
+    #[test]
+    fn is_supported_protocol_version_accepts_listed_and_rejects_others() {
+        // MCP 2026-07-28 §2: clients advertise their protocol version on every
+        // request. Servers reject unknown versions with
+        // `UnsupportedProtocolVersionError` (code `-32022`). The aggregator
+        // (PR 4 of MCP-001) wires this check into the per-request gate; the
+        // proxy server itself stays permissive at this layer because it is
+        // also called directly via `tools/list` / `tools/call` and the
+        // dispatcher doesn't enforce `_meta` yet.
+        assert!(is_supported_protocol_version("2026-07-28", &["2026-07-28"]).is_ok());
+        assert!(is_supported_protocol_version("2026-07-28", &["2025-11-25"]).is_err());
+        assert!(is_supported_protocol_version("2025-11-25", &["2026-07-28", "2025-11-25"]).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Consolidates PRs #96, #98, #99, #100 into a single migration with all Copilot review suggestions addressed.

## Changes

- **stygian-graph** — MCP server migrated to 2026-07-28 RC spec; `initialize`/`ping` removed per spec
- **stygian-browser** — MCP server migrated; real `#[tokio::test]` assertions replace empty test stubs
- **stygian-proxy** — MCP server migrated; method routing follows spec
- **stygian-mcp** — Aggregator dispatch restructured: `server/discover` is exempt from `enforce_protocol_version`; all other methods (`tools/list`, `tools/call`, `resources/*`) require valid protocol metadata
- **stygian-mcp lib.rs** — Crate docs updated to document the version-gate exception
- **Cargo.lock** — quinn-proto bumped to 0.11.15 (RUSTSEC-2026-0185)

## Protocol design

Every request **except** `server/discover` must carry `io.modelcontextprotocol/protocolVersion` in `params._meta`. `server/discover` is exempt so clients can call it before they know which version to send.

Closes #96, #98, #99, #100, #95
