### PR TITLE
fix(security): address CodeQL warnings (#91, #90)

### DIFF
--- a/crates/stygian-plugin/extension/src/shared/selector-utils.ts
+++ b/crates/stygian-plugin/extension/src/shared/selector-utils.ts
@@ -73,7 +73,7 @@
     for (const attr of STABLE_ATTRIBUTE_NAMES) {
       const value = element.getAttribute(attr);
       if (value && value.trim().length > 0) {
-        const escaped = value.replace(/"/g, '\\"');
+        const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
         selectors.push(`[${attr}="${escaped}"]`);
         selectors.push(`${tagName}[${attr}="${escaped}"]`);
       }

--- a/tools/stealth-canary/trend_cli.py
+++ b/tools/stealth-canary/trend_cli.py
@@ -204,8 +204,12 @@ def _observation_severity_for(
 def _verdict_table(verdicts: list[trend.TrendVerdict]) -> str:
     """Render the per-target verdict table."""
 
+    header = (
+        "| label | status | current | rolling_mean | delta |"
+        " consecutive_drops | baseline | observation |"
+    )
     lines = [
-        "| label | status | current | rolling_mean | delta | consecutive_drops | baseline | observation |",
+        header,
         "|---|---|---:|---:|---:|---:|---|---|",
     ]
     for v in verdicts:

--- a/tools/stealth-canary/trend_cli.py
+++ b/tools/stealth-canary/trend_cli.py
@@ -205,8 +205,7 @@ def _verdict_table(verdicts: list[trend.TrendVerdict]) -> str:
     """Render the per-target verdict table."""
 
     lines = [
-        "| label | status | current | rolling_mean | delta | "
-        "consecutive_drops | baseline | observation |",
+        "| label | status | current | rolling_mean | delta | consecutive_drops | baseline | observation |",
         "|---|---|---:|---:|---:|---:|---|---|",
     ]
     for v in verdicts:


### PR DESCRIPTION
Fixes two open CodeQL code scanning alerts.

**#91 — `js/incomplete-sanitization` (warning)**
`crates/stygian-plugin/extension/src/shared/selector-utils.ts` L76
CSS attribute selector values were only escaping `"` but not `\`. An attribute value containing a backslash would produce a malformed selector; a crafted value could escape the quoted context. Fix: escape backslashes first, then double-quotes.

**#90 — `py/implicit-string-concatenation-in-list` (warning)**
`tools/stealth-canary/trend_cli.py` L208
Two adjacent string literals in a list with no comma between them — a common accidental-omission bug. Intent was a single long header string. Fix: joined into one string literal.