### PR TITLE
style(tests): use assert_eq!/assert_ne! instead of assert! with comparisons

### DIFF
--- a/crates/stygian-browser/src/transport_realism/observations.rs
+++ b/crates/stygian-browser/src/transport_realism/observations.rs
@@ -425,6 +425,6 @@ mod tests {
     fn unused_constants_are_reachable() {
         // Reference capture constants must remain reachable so other
         // modules (diagnostic.rs, tls_validation.rs) can keep using them.
-        assert!(CHROME_131_JA3.len() == 32);
+        assert_eq!(CHROME_131_JA3.len(), 32);
     }
 }

--- a/crates/stygian-plugin/tests/comprehensive_tests.rs
+++ b/crates/stygian-plugin/tests/comprehensive_tests.rs
@@ -228,7 +228,7 @@ mod tests {
         let template_id = template.id;
 
         store.save(&template).await?;
-        assert!(store.get(&template_id).await?.id == template_id);
+        assert_eq!(store.get(&template_id).await?.id, template_id);
 
         store.delete(&template_id).await?;
         assert!(store.get(&template_id).await.is_err());
@@ -406,7 +406,10 @@ mod tests {
             .await;
 
         assert!(response.get("content").is_some());
-        assert!(response.get("isError").and_then(serde_json::Value::as_bool) != Some(true));
+        assert_ne!(
+            response.get("isError").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
         Ok(())
     }
 


### PR DESCRIPTION
Fixes 3 instances flagged by `clippy::manual_assert_eq` (a pedantic lint enabled in this workspace's `.vscode/settings.json` rust-analyzer config, though not by CI's plain `cargo clippy -- -D warnings`):

- `crates/stygian-browser/src/transport_realism/observations.rs:428`
- `crates/stygian-plugin/tests/comprehensive_tests.rs:231`
- `crates/stygian-plugin/tests/comprehensive_tests.rs:409` (assert_ne! case)

`assert_eq!`/`assert_ne!` print both operands on failure instead of just "assertion failed", which is strictly better for debugging test failures.

## Verification
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo test --workspace --all-features` — all pass, 0 failures
- `cargo fmt --all -- --check` — clean