### PR TITLE
chore(release): prep 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.15.0] - 2026-08-17
+
+### Changed
+
+- **BREAKING**: `stygian-graph`, `stygian-browser`, `stygian-proxy`,
+  `stygian-mcp`: migrated all four MCP JSON-RPC servers from the
+  `2025-11-25` protocol to the now-final `2026-07-28` spec. Removes
+  the `initialize`/`initialized` handshake and `ping` /
+  `logging/setLevel` / `notifications/roots/list_changed`; adds a
+  `server/discover` RPC (exempt from the per-request version gate so
+  clients can call it before negotiating); every other request must
+  now carry `_meta.io.modelcontextprotocol/protocolVersion`; all
+  success responses carry `resultType: "complete"`. `stygian-mcp`'s
+  aggregator enforces the version gate for every method except
+  `server/discover`. Closes #95, #96, #98, #99, #100.
+- `workspace`: refreshed dependencies — `mockall` 0.14.0 → 0.15.0,
+  `wasmtime` 45.0.2 → 46.0.2, `quick-xml` 0.40 → 0.41 (workspace
+  constraint) and `feed-rs` 2.3 → 2.4 (needed to reach a patched
+  `quick-xml` on both the direct and transitive paths),
+  `crossbeam-epoch` 0.9.18 → 0.9.20, `anyhow` 1.0.102 → 1.0.103,
+  `lru` 0.18.0 → 0.18.2, `quinn-proto` 0.11.15 → 0.11.16.
+- `stygian-graph`: brought back to zero-warning clippy after a newer
+  toolchain surfaced 3 pre-existing `useless_borrows_in_formatting`
+  warnings (redundant `&` in `format!` arguments), unrelated to any
+  dependency change.
+- test style: replaced `assert!(a == b)` / `assert!(a != b)` with
+  `assert_eq!` / `assert_ne!` in `stygian-browser` and
+  `stygian-plugin` test code for clearer failure output (flagged by
+  `clippy::manual_assert_eq`, a pedantic lint enabled in the
+  workspace's local rust-analyzer config but not by CI).
+
+### Fixed
+
+- **stygian-plugin (extension, CodeQL `js/incomplete-sanitization`)**:
+  `selector-utils.ts` CSS attribute-selector escaping only escaped
+  `"` but not `\`, so an attribute value containing a backslash
+  could escape the quoted context. Backslashes are now escaped
+  before double-quotes. Resolves #91.
+- **tools/stealth-canary (CodeQL `py/implicit-string-concatenation-in-list`)**:
+  `trend_cli.py` had two adjacent string literals in a list with no
+  separating comma — an accidental-omission bug that happened to
+  still produce the intended single header string. Joined into one
+  literal to remove the ambiguity. Resolves #90.
+
+### Security
+
+- **RUSTSEC-2026-0204** (`crossbeam-epoch`, invalid pointer
+  dereference in the `Atomic`/`Shared` `fmt::Pointer` impl),
+  **RUSTSEC-2026-0190** (`anyhow`, undefined behavior in
+  `Error::downcast_mut()`), **RUSTSEC-2026-0253** (`lru`,
+  use-after-free on a panicking `Drop` during `pop()`),
+  **RUSTSEC-2026-0194** / **RUSTSEC-2026-0195** (`quick-xml`,
+  quadratic attribute-name check and unbounded namespace allocation,
+  both denial-of-service) — all fixed via in-range dependency bumps,
+  except the `rust-s3` → `aws-creds` path, which hard-pins
+  `quick-xml = "0.38"` with no newer `aws-creds` release available
+  yet; that path is acknowledged in `deny.toml` and the
+  `cargo-audit` ignore list pending an upstream fix.
+
 ## [0.14.2] - 2026-06-23
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,7 +4408,7 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "stygian-browser"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-charon"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "lru",
  "redis",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-extract-derive"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4458,7 +4458,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-graph"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4514,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-mcp"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "serde_json",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-plugin"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4557,7 +4557,7 @@ dependencies = [
 
 [[package]]
 name = "stygian-proxy"
-version = "0.14.2"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 exclude = ["crates/stygian-charon/fuzz"]
 
 [workspace.package]
-version = "0.14.2"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.94.0"
 authors = ["Nick Campbell <s0ma@protonmail.com>"]

--- a/crates/stygian-browser/Cargo.toml
+++ b/crates/stygian-browser/Cargo.toml
@@ -68,14 +68,14 @@ base64 = { workspace = true, optional = true }
 prometheus-client = { workspace = true, optional = true }
 
 # Extract feature: proc-macro for #[derive(Extract)]
-stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.14.2", optional = true }
+stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.15.0", optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
 toml = { workspace = true }
 tracing-subscriber = { workspace = true }
 trybuild = "1"
-stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.14.2" }
+stygian-extract-derive = { path = "../stygian-extract-derive", version = "0.15.0" }
 
 [lints]
 workspace = true

--- a/crates/stygian-graph/Cargo.toml
+++ b/crates/stygian-graph/Cargo.toml
@@ -87,8 +87,8 @@ serde_yaml.workspace = true
 indexmap.workspace = true
 
 # Browser automation (optional)
-stygian-browser = { path = "../stygian-browser", version = "0.14.2", optional = true }
-stygian-charon = { path = "../stygian-charon", version = "0.14.2", optional = true }
+stygian-browser = { path = "../stygian-browser", version = "0.15.0", optional = true }
+stygian-charon = { path = "../stygian-charon", version = "0.15.0", optional = true }
 
 # WASM plugins (optional)
 wasmtime = { workspace = true, optional = true }

--- a/crates/stygian-mcp/Cargo.toml
+++ b/crates/stygian-mcp/Cargo.toml
@@ -19,10 +19,10 @@ tracing     = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 anyhow      = { workspace = true }
 
-stygian-graph   = { path = "../stygian-graph",   version = "0.14.2", default-features = false, features = ["mcp", "browser", "charon"] }
-stygian-browser = { path = "../stygian-browser",  version = "0.14.2", default-features = false, features = ["mcp", "stealth"] }
-stygian-proxy   = { path = "../stygian-proxy",    version = "0.14.2", features = ["mcp", "browser", "tls-profiled"] }
-stygian-plugin  = { path = "../stygian-plugin",   version = "0.14.2", features = ["graph-integration"] }
+stygian-graph   = { path = "../stygian-graph",   version = "0.15.0", default-features = false, features = ["mcp", "browser", "charon"] }
+stygian-browser = { path = "../stygian-browser",  version = "0.15.0", default-features = false, features = ["mcp", "stealth"] }
+stygian-proxy   = { path = "../stygian-proxy",    version = "0.15.0", features = ["mcp", "browser", "tls-profiled"] }
+stygian-plugin  = { path = "../stygian-plugin",   version = "0.15.0", features = ["graph-integration"] }
 
 [features]
 # Structured data extraction via derive macros

--- a/crates/stygian-plugin/Cargo.toml
+++ b/crates/stygian-plugin/Cargo.toml
@@ -31,7 +31,7 @@ tower-http = { version = "0.7", features = ["cors", "trace"], optional = true }
 tower = { version = "0.5", optional = true }
 
 # Stygian crates
-stygian-graph = { path = "../stygian-graph", version = "0.14.2", optional = true }
+stygian-graph = { path = "../stygian-graph", version = "0.15.0", optional = true }
 
 # Parsing
 scraper = "0.27"

--- a/crates/stygian-proxy/Cargo.toml
+++ b/crates/stygian-proxy/Cargo.toml
@@ -71,7 +71,7 @@ futures = { workspace = true }
 rand = { workspace = true }
 
 # Browser integration (optional)
-stygian-browser = { path = "../stygian-browser", version = "0.14.2", optional = true }
+stygian-browser = { path = "../stygian-browser", version = "0.15.0", optional = true }
 
 # DNS TXT proxy discovery (optional)
 hickory-resolver = { version = "0.26.1", features = ["tokio"], optional = true }


### PR DESCRIPTION
Prepares the 0.15.0 release: MCP 2026-07-28 spec migration (breaking), CodeQL fixes, RUSTSEC advisory remediation, and routine dependency bumps merged since 0.14.2.

## Changes
- Bumps `[workspace.package] version` and all 10 internal cross-crate path-dependency version pins from `0.14.2` → `0.15.0`.
- Finalizes the `CHANGELOG.md` `[Unreleased]` section into `[0.15.0] - 2026-08-17` (Changed / Fixed / Security), covering everything merged since 0.14.2: the MCP protocol migration (#102), CodeQL fixes (#103), RUSTSEC remediation (#115), and the mockall/wasmtime dependency bumps (#107, #106).
- Regenerates `Cargo.lock` (internal crate version bumps only — no external dependency drift).

The browser extension's `manifest.json`/`package.json` version is intentionally left untouched — the release workflow overwrites it to match the release tag at bundle-time.

Once merged, `auto-tag.yml` will tag `v0.15.0` on `main`, which triggers the `Release` workflow: CI verification, `cargo publish` for all 7 crates in dependency order, and a GitHub Release with the extension bundle attached.

## Verification
- `cargo check --workspace --all-features` — clean, all crates report `0.15.0`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo deny check` — advisories/bans/licenses/sources all ok
- `cargo test --workspace --all-features` — all pass, 0 failures